### PR TITLE
Improve region number patch

### DIFF
--- a/PulsarEngine/Network/Region.cpp
+++ b/PulsarEngine/Network/Region.cpp
@@ -11,10 +11,10 @@ namespace Network {
 static u32 region = 0x0A;
 
 static void PatchRegionNumber() {
-    bool is200 = System::sInstance->IsContext(PULSAR_200_WW) ? WWMODE_200 : WWMODE_DEFAULT;
-    if (System::sInstance->IsContext(PULSAR_MODE_OTT) == true) {
+    WWMode mode = System::sInstance->IsContext(PULSAR_200_WW) ? WWMODE_200 : WWMODE_DEFAULT;
+    if (System::sInstance->IsContext(PULSAR_MODE_OTT)) {
         region = 0x0B;
-    } else if (is200 == WWMODE_200) {
+    } else if (mode == WWMODE_200) {
         region = 0x0C;
     } else {
         region = 0x0A;


### PR DESCRIPTION
In the following ternary operation:

https://github.com/Retro-Rewind-Team/Pulsar/blob/4482297f5458b67fc47315f03bed8533a1344191/PulsarEngine/Network/Region.cpp#L14

A ``WWMode`` enum value is casted to a boolean variable, ``WWMODE_200`` having value 2, it's probably better to do it like this:

https://github.com/Retro-Rewind-Team/Pulsar/blob/a3a0c05402f7cdf737dda2550267c7cb55689f8d/PulsarEngine/Network/Region.cpp#L14

I've also removed the redundant `== true` check for OTT

