### PR TITLE
Fix casing of some includes

### DIFF
--- a/GameSource/MarioKartWii/3D/Model/Awards.hpp
+++ b/GameSource/MarioKartWii/3D/Model/Awards.hpp
@@ -7,70 +7,72 @@
 #include <MarioKartWii/3D/Model/ModelDirector.hpp>
 #include <MarioKartWii/3D/Model/ShadowModelDirector.hpp>
 #include <MarioKartWii/Mii/MiiHeadsModel.hpp>
-#include <MarioKartWii/Race/Racedata.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
 
 using namespace nw4r;
 
-class AwardCupModel {
+class AwardCupModel
+{
 public:
-    AwardCupModel* sInstance; //809c2c48
-    static AwardCupModel* CreateInstance(); //8074c5b0
-    static void DestroyInstance(); //8074c680
-    AwardCupModel(); //8074c73c inlined
-    ~AwardCupModel(); //8074c7e0
-    EGG::TDisposer<AwardCupModel> disposer; //8074c4a8 vtable 808cbd10
-    virtual void Load(u32 modelId, u8 trophyMetal); //0x8 8074c8a8 modelId = cupId, + 8 for default cup (vs)
-    virtual void Prepare(); //0xc 8074cd20
-    virtual void Update(); //0x10 8074cf00
-    virtual void Activate(); //8074ce50 0x14
-    ModelDirector* mode; //0x14 
-    u8 trophyMetal; //0x18 1 = gold
+    AwardCupModel *sInstance;                       // 809c2c48
+    static AwardCupModel *CreateInstance();         // 8074c5b0
+    static void DestroyInstance();                  // 8074c680
+    AwardCupModel();                                // 8074c73c inlined
+    ~AwardCupModel();                               // 8074c7e0
+    EGG::TDisposer<AwardCupModel> disposer;         // 8074c4a8 vtable 808cbd10
+    virtual void Load(u32 modelId, u8 trophyMetal); // 0x8 8074c8a8 modelId = cupId, + 8 for default cup (vs)
+    virtual void Prepare();                         // 0xc 8074cd20
+    virtual void Update();                          // 0x10 8074cf00
+    virtual void Activate();                        // 8074ce50 0x14
+    ModelDirector *mode;                            // 0x14
+    u8 trophyMetal;                                 // 0x18 1 = gold
     u8 padding[3];
     u8 unknown_0x1c[0x20 - 0x1c];
-    float unknown_0x20[9]; //0x20
-    u8 unknown_0x44[0x4c - 0x44]; //0x44
-    EGG::Effect* rk_trophyMetal; //0x4c rk_trophy_gold if metal == gold
-    EGG::Effect* rk_trophyGold; //0x50
-    EGG::Effect* rk_trophyGold; //0x54
-    EGG::Effect* rk_trophyCopper; //0x58
-    EGG::EffectResource* effRes; //0x5c rk_trophy breff/breft
-    u8 unknown_0x60[0x68 - 0x60]; //0x60
+    float unknown_0x20[9];        // 0x20
+    u8 unknown_0x44[0x4c - 0x44]; // 0x44
+    EGG::Effect *rk_trophyMetal;  // 0x4c rk_trophy_gold if metal == gold
+    EGG::Effect *rk_trophyGold;   // 0x50
+    EGG::Effect *rk_trophyGold;   // 0x54
+    EGG::Effect *rk_trophyCopper; // 0x58
+    EGG::EffectResource *effRes;  // 0x5c rk_trophy breff/breft
+    u8 unknown_0x60[0x68 - 0x60]; // 0x60
 
-}; //0x68
+}; // 0x68
 
-class AwardsMgr {
+class AwardsMgr
+{
 public:
-    static AwardsMgr* sInstance; //809c2f00
-    static AwardsMgr* CreateInstance(); //80787eb0
-    static void DestroyInstance(); //80787fe0
+    static AwardsMgr *sInstance;        // 809c2f00
+    static AwardsMgr *CreateInstance(); // 80787eb0
+    static void DestroyInstance();      // 80787fe0
 
-    AwardsMgr(); //80788094
-    ~AwardsMgr(); //80788198
-    void Init(); //8078823c
-    void LoadStand(); //80789008 inlined
-    void LoadPlayers(const RacedataScenario* scenario, CharacterId* characters); //80789340
-    void SetParams(u32 r4, u32 r5, u32 r6, u32 r7); //8078a1d8
+    AwardsMgr();                                                                 // 80788094
+    ~AwardsMgr();                                                                // 80788198
+    void Init();                                                                 // 8078823c
+    void LoadStand();                                                            // 80789008 inlined
+    void LoadPlayers(const RacedataScenario *scenario, CharacterId *characters); // 80789340
+    void SetParams(u32 r4, u32 r5, u32 r6, u32 r7);                              // 8078a1d8
 
-    EGG::TDisposer<AwardsMgr> disposer; //80787d84 vtable 808d1808
+    EGG::TDisposer<AwardsMgr> disposer; // 80787d84 vtable 808d1808
 
-    g3d::ResFile v_stand1Brres; //0x10
-    g3d::ResFile v_stand1Brres2; //0x14
-    g3d::ResFile v_stand1Brres3; //0x18
-    g3d::ResFile v_stand1Brres4; //0x1c
-    ModelDirector* v_Stand1; //0x20
-    ModelDirector* v_Stand4; //0x24
-    ModelDirector* v_Stand3; //0x28
-    ModelDirector* v_Stand2; //0x2c
+    g3d::ResFile v_stand1Brres;  // 0x10
+    g3d::ResFile v_stand1Brres2; // 0x14
+    g3d::ResFile v_stand1Brres3; // 0x18
+    g3d::ResFile v_stand1Brres4; // 0x1c
+    ModelDirector *v_Stand1;     // 0x20
+    ModelDirector *v_Stand4;     // 0x24
+    ModelDirector *v_Stand3;     // 0x28
+    ModelDirector *v_Stand2;     // 0x2c
 
     u8 unknown_0x30[0x84 - 0x30];
-    ModelDirector* characterModels[42][2]; //0x84 unsure how this gets filled
-    ShadowModelDirector* shadowCharModels[42][2]; //0x1d4
-    MiiHeadsModel* miiHeadModels[42][2]; //0x324
+    ModelDirector *characterModels[42][2];        // 0x84 unsure how this gets filled
+    ShadowModelDirector *shadowCharModels[42][2]; // 0x1d4
+    MiiHeadsModel *miiHeadModels[42][2];          // 0x324
     u8 unknown_0x474[0x534 - 0x474];
 
-    u32 configr5; //0x534
-    u32 configr6; //0x538
-    u32 configr7; //0x53c
-}; //0x540
+    u32 configr5; // 0x534
+    u32 configr6; // 0x538
+    u32 configr7; // 0x53c
+}; // 0x540
 
 #endif

--- a/GameSource/MarioKartWii/Archive/ArchiveHolder.hpp
+++ b/GameSource/MarioKartWii/Archive/ArchiveHolder.hpp
@@ -5,72 +5,78 @@
 #include <core/egg/mem/ExpHeap.hpp>
 #include <core/egg/mem/Disposer.hpp>
 #include <core/egg/Thread.hpp>
-#include <MarioKartWii/System/identifiers.hpp>
+#include <MarioKartWii/System/Identifiers.hpp>
 #include <MarioKartWii/Archive/ArchiveFile.hpp>
 
 class LayoutResources;
 
-enum ArchiveSource {
-    ARCHIVE_HOLDER_COMMON = 0x0, //common.szs and Kart/kartSzs.szs
-    ARCHIVE_HOLDER_COURSE = 0x1, //beginner_course
-    ARCHIVE_HOLDER_UI = 0x2, //title.szs
-    ARCHIVE_HOLDER_FONT = 0x3, //font.szs
-    ARCHIVE_HOLDER_EARTH = 0x4, //earth.szs
-    ARCHIVE_HOLDER_MIIBODY = 0x5, //MiiBody.szs
-    ARCHIVE_HOLDER_DRIVER = 0x6, //Driver.szs
+enum ArchiveSource
+{
+    ARCHIVE_HOLDER_COMMON = 0x0,  // common.szs and Kart/kartSzs.szs
+    ARCHIVE_HOLDER_COURSE = 0x1,  // beginner_course
+    ARCHIVE_HOLDER_UI = 0x2,      // title.szs
+    ARCHIVE_HOLDER_FONT = 0x3,    // font.szs
+    ARCHIVE_HOLDER_EARTH = 0x4,   // earth.szs
+    ARCHIVE_HOLDER_MIIBODY = 0x5, // MiiBody.szs
+    ARCHIVE_HOLDER_DRIVER = 0x6,  // Driver.szs
     ARCHIVE_HOLDER_AWARD = 0x7,
     ARCHIVE_HOLDER_BACKMODEL = 0x8,
     ARCHIVE_HOLDER_KART = 0x9
 };
 
-enum SourceType { //conditions what "suffixes" contains
-    SOURCE_TYPE_SUFFIX, //means functions are called with a name to which the suffix (.szs _E.szs) is appended
-    SOURCE_TYPE_FULLNAME, //means the name functions are called with is unused and instead the "suffixes" contain the names
-    SOURCE_TYPE_FULLNAME_PRELOADED //same as above but the archives are already preloaded and just need a mount
+enum SourceType
+{                                  // conditions what "suffixes" contains
+    SOURCE_TYPE_SUFFIX,            // means functions are called with a name to which the suffix (.szs _E.szs) is appended
+    SOURCE_TYPE_FULLNAME,          // means the name functions are called with is unused and instead the "suffixes" contain the names
+    SOURCE_TYPE_FULLNAME_PRELOADED // same as above but the archives are already preloaded and just need a mount
 };
 
-class ArchivesHolder {
+class ArchivesHolder
+{
 public:
-    explicit ArchivesHolder(u16 archiveCount); //8052a538 vtable 
-    static ArchivesHolder* CreateByType(ArchiveSource type); //8052a098
-    virtual ~ArchivesHolder(); //8052a6dc vtable 808b31d8
-    virtual void Reset(); //8052a648 sets extensions to .szs
-    void* GetFile(const char* fileName, u32* size) const; //8052a760 gets subfile from archive
-    bool HasArchives() const; //8052a800
-    bool FileExists(const char* fileName) const; //8052a864
-    void LoadArchives(const char* fileName, EGG::Heap* mountHeap, EGG::Heap* dumpHeap, u32* size = nullptr); //8052a954 decompresses
-    void UnmountArchives(); //8052aa88 also frees buffers
-    void LoadFromOther(const ArchivesHolder& other, EGG::Heap* heap); //8052aae8
-    void DumpArchives(char* fileName, EGG::Heap* dumpHeap); //8052ab6c just dumps without 
-    void ClearArchives(); //8052ac40
-    int GetTotalMountedArchivesSize() const; //8052aca0
-    void* GetFirstMountedArchive() const; //8052ad08 1st in terms of memory address which is very weird
-    void* GetFirstMountedArchiveEnd() const; //8052ad80 same but returns the end of the block holding the archive
-    int GetLoadedArchivesCount() const; //8052ae08
+    explicit ArchivesHolder(u16 archiveCount);                                                               // 8052a538 vtable
+    static ArchivesHolder *CreateByType(ArchiveSource type);                                                 // 8052a098
+    virtual ~ArchivesHolder();                                                                               // 8052a6dc vtable 808b31d8
+    virtual void Reset();                                                                                    // 8052a648 sets extensions to .szs
+    void *GetFile(const char *fileName, u32 *size) const;                                                    // 8052a760 gets subfile from archive
+    bool HasArchives() const;                                                                                // 8052a800
+    bool FileExists(const char *fileName) const;                                                             // 8052a864
+    void LoadArchives(const char *fileName, EGG::Heap *mountHeap, EGG::Heap *dumpHeap, u32 *size = nullptr); // 8052a954 decompresses
+    void UnmountArchives();                                                                                  // 8052aa88 also frees buffers
+    void LoadFromOther(const ArchivesHolder &other, EGG::Heap *heap);                                        // 8052aae8
+    void DumpArchives(char *fileName, EGG::Heap *dumpHeap);                                                  // 8052ab6c just dumps without
+    void ClearArchives();                                                                                    // 8052ac40
+    int GetTotalMountedArchivesSize() const;                                                                 // 8052aca0
+    void *GetFirstMountedArchive() const;                                                                    // 8052ad08 1st in terms of memory address which is very weird
+    void *GetFirstMountedArchiveEnd() const;                                                                 // 8052ad80 same but returns the end of the block holding the archive
+    int GetLoadedArchivesCount() const;                                                                      // 8052ae08
 
-    ArchiveFile* archives; //0x4 size archive count
-    u16 archiveCount; //0x8
+    ArchiveFile *archives; // 0x4 size archive count
+    u16 archiveCount;      // 0x8
     u8 padding[2];
-    void* filePtr; //only used for sourceType 2 (sets the matching Archive ptr)
-    char** archiveSuffixes; //0x10 appended to the name .szs, _E.szs, _Dif.szs etc...
-    u32* fileSizes; //only used for sourceType 2
-    SourceType* sourceType; //0x18 name => 0 = fileName.suffix 1 = suffix 2 = idk
-};//total size 0x1c
+    void *filePtr;          // only used for sourceType 2 (sets the matching Archive ptr)
+    char **archiveSuffixes; // 0x10 appended to the name .szs, _E.szs, _Dif.szs etc...
+    u32 *fileSizes;         // only used for sourceType 2
+    SourceType *sourceType; // 0x18 name => 0 = fileName.suffix 1 = suffix 2 = idk
+}; // total size 0x1c
 size_assert(ArchivesHolder, 0x1C);
 
-class CommonArchivesLoader : public ArchivesHolder {
-    ~CommonArchivesLoader() override; //8052a4e0 vtable 808b31a8
-    void Reset() override; //8052a3c0
+class CommonArchivesLoader : public ArchivesHolder
+{
+    ~CommonArchivesLoader() override; // 8052a4e0 vtable 808b31a8
+    void Reset() override;            // 8052a3c0
 };
 
-class CourseArchivesHolder : public ArchivesHolder {
-    CourseArchivesHolder(); //8052a1c8
-    ~CourseArchivesHolder() override; //8052a430 vtable 808b31c8
-    void Reset() override; //8052a21c
+class CourseArchivesHolder : public ArchivesHolder
+{
+    CourseArchivesHolder();           // 8052a1c8
+    ~CourseArchivesHolder() override; // 8052a430 vtable 808b31c8
+    void Reset() override;            // 8052a21c
 };
-class UIArchivesHolder : public ArchivesHolder {
-    ~UIArchivesHolder() override; //8052a488 vtable 808b31b8
-    void Reset() override; //8052a2fc
+class UIArchivesHolder : public ArchivesHolder
+{
+    ~UIArchivesHolder() override; // 8052a488 vtable 808b31b8
+    void Reset() override;        // 8052a2fc
 };
 
 #endif

--- a/GameSource/MarioKartWii/Audio/Actors/CharacterActor.hpp
+++ b/GameSource/MarioKartWii/Audio/Actors/CharacterActor.hpp
@@ -1,92 +1,96 @@
 #ifndef _CHARACTERACTOR_
 #define _CHARACTERACTOR_
 #include <kamek.hpp>
-#include <MarioKartWii/Race/Racedata.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
 #include <MarioKartWii/Audio/Other/RandomAudioMgr.hpp>
 #include <MarioKartWii/Audio/Actors/RaceActor.hpp>
 
-namespace Audio {
-using namespace nw4r;
-class DriverController;
-enum CharacterSourceType {
-    CHARACTER_SOURCE_USE_ITEM = 0x0,
-    CHARACTER_SOURCE_THROW_ITEM = 0x1,
-    CHARACTER_SOURCE_USE_STAR_MEGA = 0x2,
-    CHARACTER_SOURCE_HIT_ITEM = 0x3,
-    CHARACTER_SOURCE_BOOST = 0x6,
-    CHARACTER_SOURCE_NO_STUNTTRICK = 0x8, //when you don't trick on a trickable surface
-    CHARACTER_SOURCE_NO_FLIPTRICK = 0xA, //when you don't trick off a boost ramp
-    CHARACTER_SOURCE_STUNT_1FLIP = 0xB,
-    CHARACTER_SOURCE_2FLIPS = 0xC,
-    CHARACTER_SOURCE_NO_FLIP_LANDING = 0xD, //from landing without tricking
-    CHARACTER_SOURCE_WHEELIE = 0xf,
-    CHARACTER_SOURCE_WHEELIE_LOW_SPEED = 0x10,
-    CHARACTER_SOURCE_HIT_WALL = 0x11,
-    CHARACTER_SOURCE_HITBY_OBJECT = 0x12,
-    CHARACTER_SOURCE_HITBY_EXPLOSION = 0x13,
-    CHARACTER_SOURCE_HITBY_FIRE = 0x14,
-    CHARACTER_SOURCE_HITBY_BANANA = 0x15,
-    CHARACTER_SOURCE_RESPAWN = 0x1A,
-    CHARACTER_SOURCE_DRAFT = 0x1C
-};
+namespace Audio
+{
+    using namespace nw4r;
+    class DriverController;
+    enum CharacterSourceType
+    {
+        CHARACTER_SOURCE_USE_ITEM = 0x0,
+        CHARACTER_SOURCE_THROW_ITEM = 0x1,
+        CHARACTER_SOURCE_USE_STAR_MEGA = 0x2,
+        CHARACTER_SOURCE_HIT_ITEM = 0x3,
+        CHARACTER_SOURCE_BOOST = 0x6,
+        CHARACTER_SOURCE_NO_STUNTTRICK = 0x8, // when you don't trick on a trickable surface
+        CHARACTER_SOURCE_NO_FLIPTRICK = 0xA,  // when you don't trick off a boost ramp
+        CHARACTER_SOURCE_STUNT_1FLIP = 0xB,
+        CHARACTER_SOURCE_2FLIPS = 0xC,
+        CHARACTER_SOURCE_NO_FLIP_LANDING = 0xD, // from landing without tricking
+        CHARACTER_SOURCE_WHEELIE = 0xf,
+        CHARACTER_SOURCE_WHEELIE_LOW_SPEED = 0x10,
+        CHARACTER_SOURCE_HIT_WALL = 0x11,
+        CHARACTER_SOURCE_HITBY_OBJECT = 0x12,
+        CHARACTER_SOURCE_HITBY_EXPLOSION = 0x13,
+        CHARACTER_SOURCE_HITBY_FIRE = 0x14,
+        CHARACTER_SOURCE_HITBY_BANANA = 0x15,
+        CHARACTER_SOURCE_RESPAWN = 0x1A,
+        CHARACTER_SOURCE_DRAFT = 0x1C
+    };
 
-class CharacterActor;
-class RandomCharacterActorPicker : public RandomSoundPicker { //one per type
-    RandomCharacterActorPicker(); //808676e0
-    ~RandomCharacterActorPicker() override; //808639e8 vtable 808dbe18
-    CharacterActor* sound; //2c
-}; //0x30
+    class CharacterActor;
+    class RandomCharacterActorPicker : public RandomSoundPicker
+    {                                           // one per type
+        RandomCharacterActorPicker();           // 808676e0
+        ~RandomCharacterActorPicker() override; // 808639e8 vtable 808dbe18
+        CharacterActor *sound;                  // 2c
+    }; // 0x30
 
-class CharacterActor : public RaceAnimActor {
-    CharacterActor(); //80863928
+    class CharacterActor : public RaceAnimActor
+    {
+        CharacterActor(); // 80863928
 
-    //AUDIOACTOR
-    //SoundActor vtable 808dbbf0
-    ~CharacterActor() override; //80866c08
-    //Actor vtable 808dbc0c
-    //~CharacterActor thunk 80866d0c func 80866c08
+        // AUDIOACTOR
+        // SoundActor vtable 808dbbf0
+        ~CharacterActor() override; // 80866c08
+        // Actor vtable 808dbc0c
+        //~CharacterActor thunk 80866d0c func 80866c08
 
-    //LinkedRaceActor vtable 808dbc6c at 0x94 
-    void Link(void* pointer, u16 objectId) override; //thunk 80866d3c func 80863a9c pointer is KartModel
-    void Unlink() override; //thunk 80866d34 func 80863ff8
-    void Update() override; //thunk 80866d2c func 80864000
-    bool StartSound(u32 soundId) override; //40 thunk 80866d24 func 80865618
-    bool HoldSound(u32 soundId) override; //44 thunk 80866d1c func 808656c4
-    void StopSound(int fadeOutFrames) override; //4c thunk 80866d14 func 80855984
+        // LinkedRaceActor vtable 808dbc6c at 0x94
+        void Link(void *pointer, u16 objectId) override; // thunk 80866d3c func 80863a9c pointer is KartModel
+        void Unlink() override;                          // thunk 80866d34 func 80863ff8
+        void Update() override;                          // thunk 80866d2c func 80864000
+        bool StartSound(u32 soundId) override;           // 40 thunk 80866d24 func 80865618
+        bool HoldSound(u32 soundId) override;            // 44 thunk 80866d1c func 808656c4
+        void StopSound(int fadeOutFrames) override;      // 4c thunk 80866d14 func 80855984
 
-    void PlayCharacterActor(CharacterSourceType type); //80864914
-    void PlayCharacterActorConditional(CharacterSourceType type); //808646f0, conditional to prevent too much overlapping
-    //big switch depending on type to then call PlayCharacterActor
-    void PlayCharacterCollisionSound(DamageType type); //80865448
-    u32 GetCharacterGroupId(); //80866388
-    u32 GetCharacterCannonGroupId(); //80866404
+        void PlayCharacterActor(CharacterSourceType type);            // 80864914
+        void PlayCharacterActorConditional(CharacterSourceType type); // 808646f0, conditional to prevent too much overlapping
+        // big switch depending on type to then call PlayCharacterActor
+        void PlayCharacterCollisionSound(DamageType type); // 80865448
+        u32 GetCharacterGroupId();                         // 80866388
+        u32 GetCharacterCannonGroupId();                   // 80866404
 
-    CharacterSourceType requestedType; //0xFC can be used to request but can also just call 808646f0
-    u32 delay; //0x100 if request, delay until request is executed
-    u8 unknown_0x104[0x150 - 0x104];
-    RandomCharacterActorPicker randomSoundPickers[0x1D]; //0x150 use type enum
-    DriverController* model; //0x6c0
-    u32 wiiRemoteChannelx2; //0x6c4 only if controller is wheel/nunchuck ofc
-    CharacterSourceType prevType; //0x6c8
-    u32 unknown_0x6CC[4];
-    u8 unknown_0x6dc[0x6e4 - 0x6dc];
-    float unknown_0x6e4;
-    Team team; //0x6e8
-    u8 playerId; //0x6ec only if not a ghost
-    u8 hudSlotId; //0x6ed same
-    u8 padding;
-    u32 unkwown_0x6f0[2];
-    u8 unknown_0x6f8;
-    bool isNotLocal; //0x6f9
-    bool isLocal; //0x6fa
-    bool isMii; //0x6fb
-    bool isGhost; //0x6fc
-    bool isReplay; //0x6fd
-    u8 unknown_0x6fe;
-    bool unknown_0x6ff;
-    u8 unknown_0x700[8];
-    static u32 charactersGroupIds[24]; //808afb58
-}; //0x708
-size_assert(CharacterActor, 0x708);
-}//namespace Audio
+        CharacterSourceType requestedType; // 0xFC can be used to request but can also just call 808646f0
+        u32 delay;                         // 0x100 if request, delay until request is executed
+        u8 unknown_0x104[0x150 - 0x104];
+        RandomCharacterActorPicker randomSoundPickers[0x1D]; // 0x150 use type enum
+        DriverController *model;                             // 0x6c0
+        u32 wiiRemoteChannelx2;                              // 0x6c4 only if controller is wheel/nunchuck ofc
+        CharacterSourceType prevType;                        // 0x6c8
+        u32 unknown_0x6CC[4];
+        u8 unknown_0x6dc[0x6e4 - 0x6dc];
+        float unknown_0x6e4;
+        Team team;    // 0x6e8
+        u8 playerId;  // 0x6ec only if not a ghost
+        u8 hudSlotId; // 0x6ed same
+        u8 padding;
+        u32 unkwown_0x6f0[2];
+        u8 unknown_0x6f8;
+        bool isNotLocal; // 0x6f9
+        bool isLocal;    // 0x6fa
+        bool isMii;      // 0x6fb
+        bool isGhost;    // 0x6fc
+        bool isReplay;   // 0x6fd
+        u8 unknown_0x6fe;
+        bool unknown_0x6ff;
+        u8 unknown_0x700[8];
+        static u32 charactersGroupIds[24]; // 808afb58
+    }; // 0x708
+    size_assert(CharacterActor, 0x708);
+} // namespace Audio
 #endif

--- a/GameSource/MarioKartWii/Audio/RaceMgr.hpp
+++ b/GameSource/MarioKartWii/Audio/RaceMgr.hpp
@@ -2,7 +2,7 @@
 #define _RACEAUDIOMGR_
 #include <kamek.hpp>
 #include <core/nw4r/ut/List.hpp>
-#include <MarioKartWii/Race/racedata.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
 #include <MarioKartWii/System/timer.hpp>
 #include <MarioKartWii/Audio/Other/AudioValues.hpp>
 #include <MarioKartWii/Audio/Actors/KartActor.hpp>
@@ -11,88 +11,92 @@ Contributors:
 -kHacker35000vr, Melg
 */
 
-namespace Audio {
-enum RaceState {
-    RACE_STATE_INTRO = 0x2,
-    RACE_STATE_BEFORECOUNTDOWN = 0x3,
-    RACE_STATE_NORMAL = 0x4,
-    RACE_STATE_FAST = 0x5,
-    RACE_STATE_FINISHED = 0x7
-};
-
-struct CourseIdxToCourseID {
-    CourseId courseID;
-};
-
-struct CourseIDToMusicID {
-    u32 musicID;
-};
-
-class RaceMgr {
-public:
-
-    struct ActorHolder {
-        static int Compare(ActorHolder* first, ActorHolder* second); //80710664
-        LinkedRaceActor* actor;
-        float lowestTaxicabDistanceToAnyPlayer;
+namespace Audio
+{
+    enum RaceState
+    {
+        RACE_STATE_INTRO = 0x2,
+        RACE_STATE_BEFORECOUNTDOWN = 0x3,
+        RACE_STATE_NORMAL = 0x4,
+        RACE_STATE_FAST = 0x5,
+        RACE_STATE_FINISHED = 0x7
     };
 
-    static RaceMgr* sInstance; //809c27f8
-    static RaceMgr* CreateInstance(); //807104d0
-    static void* DestroyInstance(); //80710520
+    struct CourseIdxToCourseID
+    {
+        CourseId courseID;
+    };
 
-    RaceMgr(); //80710688 also appends the Sound3DListeners (one per local player) to the 3DManager list
-    ~RaceMgr(); //807108e8
+    struct CourseIDToMusicID
+    {
+        u32 musicID;
+    };
 
+    class RaceMgr
+    {
+    public:
+        struct ActorHolder
+        {
+            static int Compare(ActorHolder *first, ActorHolder *second); // 80710664
+            LinkedRaceActor *actor;
+            float lowestTaxicabDistanceToAnyPlayer;
+        };
 
-    SoundIDs GetEndFanfareId() const; //807121c0
+        static RaceMgr *sInstance;        // 809c27f8
+        static RaceMgr *CreateInstance(); // 807104d0
+        static void *DestroyInstance();   // 80710520
 
-    void SetRaceState(RaceState raceState); //80711ac4 changes music accordingly etc...
-    void SetKartActor(KartActor* sound); //80713754
-    void Init(); //80710a00
-    void Shutdown(); //80710bac unlinks the actors, shutdowns all the sounds (ambience, etc...)
-    void Calc(); //80710ca0
-    void UpdateLocalPlayerParams(); //80711514
-    void CheckRaceState(); //807125d4 can play final lap jingle, the winning/losing music etc...
-    bool IsAPlayerInMega() const; //807117a0
-    bool IsAPlayerInStar() const; //8071172c
-    bool IsAPlayerSquishedOrSmall() const; //80711668
+        RaceMgr();  // 80710688 also appends the Sound3DListeners (one per local player) to the 3DManager list
+        ~RaceMgr(); // 807108e8
 
-    void UpdatePlayerMatrix(); //80711198
-    void StartRace(); //80711418 called by RSARSounds when trying to play the GO! sound
-    void SortAndToggleActors(); //80712b58
-    void UpdateActors(); //807114a4 inlined
-    void SetEngineVolume(u32 stepCount, float maxValue); //80711a0c inlined
-    void SetNonTrackVolumes(float volume); //80711960 see AudioMgr.hpp's enum
-    void SetNonTrackAndEngineVolumes(float volume); //80711a14
+        SoundIDs GetEndFanfareId() const; // 807121c0
 
-    EGG::TDisposer<RaceMgr> disposer; //80710340 vtable 808c8fdc
-    CourseId courseId; //0x10   
-    u8 unknown_0x14[4];
-    KartActor* kartActors[4]; //0x18
-    u8 lastUsedKartActorSlot; //0x28
-    u8 totalKartActors; //0x29
-    u8 unknown_0x2a[0x30 - 0x2a];
-    Timer unk_Timer;
-    u8 maxLap; //0x3c all of these of the player mostinfront
-    u8 lap; //0x3d
-    u8 position;
-    u8 playerIdFirstLocalPlayer; //0x3f 
-    RaceState raceState; //0x40
-    GameMode gameMode; //0x44
-    GameType gameType; //0x48
-    u8 localPlayerCount; //0x4c
-    u8 playerCount; //0x4d
-    u8 unknown_0x4e[0x54 - 0x4e];
-    Track engineVolume; //0x54
-    u8 unknown_0x70[0x8];
-    nw4r::ut::List raceActorsList; //0x78 contains all the LinkedRaceActors
-    //in Calc a loop calls their update function
-    Mtx34 playerMats[4]; //0x84 used for Sound3DListener's mtx
-    Vec3 playerTargetPos[4]; //0x144 
-    u8 unknown_0x174[4];
-};//Total Size 0x178
-size_assert(RaceMgr, 0x178);
-}//namespace Audio
+        void SetRaceState(RaceState raceState); // 80711ac4 changes music accordingly etc...
+        void SetKartActor(KartActor *sound);    // 80713754
+        void Init();                            // 80710a00
+        void Shutdown();                        // 80710bac unlinks the actors, shutdowns all the sounds (ambience, etc...)
+        void Calc();                            // 80710ca0
+        void UpdateLocalPlayerParams();         // 80711514
+        void CheckRaceState();                  // 807125d4 can play final lap jingle, the winning/losing music etc...
+        bool IsAPlayerInMega() const;           // 807117a0
+        bool IsAPlayerInStar() const;           // 8071172c
+        bool IsAPlayerSquishedOrSmall() const;  // 80711668
+
+        void UpdatePlayerMatrix();                           // 80711198
+        void StartRace();                                    // 80711418 called by RSARSounds when trying to play the GO! sound
+        void SortAndToggleActors();                          // 80712b58
+        void UpdateActors();                                 // 807114a4 inlined
+        void SetEngineVolume(u32 stepCount, float maxValue); // 80711a0c inlined
+        void SetNonTrackVolumes(float volume);               // 80711960 see AudioMgr.hpp's enum
+        void SetNonTrackAndEngineVolumes(float volume);      // 80711a14
+
+        EGG::TDisposer<RaceMgr> disposer; // 80710340 vtable 808c8fdc
+        CourseId courseId;                // 0x10
+        u8 unknown_0x14[4];
+        KartActor *kartActors[4]; // 0x18
+        u8 lastUsedKartActorSlot; // 0x28
+        u8 totalKartActors;       // 0x29
+        u8 unknown_0x2a[0x30 - 0x2a];
+        Timer unk_Timer;
+        u8 maxLap; // 0x3c all of these of the player mostinfront
+        u8 lap;    // 0x3d
+        u8 position;
+        u8 playerIdFirstLocalPlayer; // 0x3f
+        RaceState raceState;         // 0x40
+        GameMode gameMode;           // 0x44
+        GameType gameType;           // 0x48
+        u8 localPlayerCount;         // 0x4c
+        u8 playerCount;              // 0x4d
+        u8 unknown_0x4e[0x54 - 0x4e];
+        Track engineVolume; // 0x54
+        u8 unknown_0x70[0x8];
+        nw4r::ut::List raceActorsList; // 0x78 contains all the LinkedRaceActors
+        // in Calc a loop calls their update function
+        Mtx34 playerMats[4];     // 0x84 used for Sound3DListener's mtx
+        Vec3 playerTargetPos[4]; // 0x144
+        u8 unknown_0x174[4];
+    }; // Total Size 0x178
+    size_assert(RaceMgr, 0x178);
+} // namespace Audio
 
 #endif

--- a/GameSource/MarioKartWii/Input/Controller.hpp
+++ b/GameSource/MarioKartWii/Input/Controller.hpp
@@ -9,9 +9,9 @@ Contributors:
 #ifndef _INPUT_CONTROLLER_
 #define _INPUT_CONTROLLER_
 #include <kamek.hpp>
-#include <core/rvl/pad.hpp>
-#include <core/rvl/kpad.hpp>
-#include <core/rvl/wpad.hpp>
+#include <core/rvl/PAD.hpp>
+#include <core/rvl/KPAD.hpp>
+#include <core/rvl/WPAD.hpp>
 #include <MarioKartWii/Input/InputState.hpp>
 #include <MarioKartWii/Input/GhostWriter.hpp>
 #include <MarioKartWii/System/Identifiers.hpp>

--- a/GameSource/MarioKartWii/NAND/NandUtils.hpp
+++ b/GameSource/MarioKartWii/NAND/NandUtils.hpp
@@ -1,7 +1,7 @@
 #ifndef _NANDUTILS_
 #define _NANDUTILS_
 #include <kamek.hpp>
-#include <core/rvl/nand.hpp>
+#include <core/rvl/NAND.hpp>
 
 namespace NandUtils {
 enum Result {

--- a/GameSource/MarioKartWii/RKNet/FriendMgr.hpp
+++ b/GameSource/MarioKartWii/RKNet/FriendMgr.hpp
@@ -1,42 +1,42 @@
 #ifndef _RKNETFRIENDMGR_
 #define _RKNETFRIENDMGR_
 #include <kamek.hpp>
-#include <core/rvl/os/OSmutex.hpp>
+#include <core/rvl/OS/OSMutex.hpp>
 #include <core/rvl/DWC/DWC.hpp>
 
-namespace RKNet {
-class FriendMgr {
-public:
-    static FriendMgr* sInstance; //809c2110
-    static FriendMgr* CreateInstance(); //80663194
-    static void DestroyInstance(); //806632bc
-    FriendMgr(); //806639a0 inlined
-    virtual ~FriendMgr(); //806573dc vtable 808c0988
+namespace RKNet
+{
+    class FriendMgr
+    {
+    public:
+        static FriendMgr *sInstance;        // 809c2110
+        static FriendMgr *CreateInstance(); // 80663194
+        static void DestroyInstance();      // 806632bc
+        FriendMgr();                        // 806639a0 inlined
+        virtual ~FriendMgr();               // 806573dc vtable 808c0988
 
-
-
-    void ReadDataFromRKSYS(); //806632fc
-    void Update(); //80663444
-    void CreateAccUserData(u32 gameCode); //806635a8
-    bool CheckAccUserData() const; //806635b0
-    bool IsAccUserDataDirty() const; //806635e0
-    void ClearAccUserDataDirtyFlag(); //80663610
-    u64 CreateFriendCode() const; //80663618
-    void SetCodesForUnusedIdxs(u64* friendCodes); //80663644
-    bool IsAvailable() const; //8066374c IsFriendCodes == nullptr
-    bool IsBuddyFriend(u8 idx) const; //8066375c
-    bool IsValidFriend(const DWC::AccFriendData* data) const; //80663794
-    bool CheckFriendCode(const u64& friendCode) const; //806637c4
-    s32 GetFriendIdx(const u64& friendCode) const; //806637fc returns -1 if code is not a friend
-    s32 GetFriendCodeLicenseIdx(const u64& friendCode) const; //80663874 returns -1 if code is not one of the licenses
-    u64 GetLicenseFriendCode(u8 licenseIdx) const; //80663918
-    s32 GetFirstFreeFriendIdx() const; //80663940 goes through every frienddata until one is valid, and return its idx, else return -1
-    OS::Mutex mutex;
-    DWC::AccUserData myUserData[2]; //0x1c
-    DWC::AccFriendData friends[30][2]; //0x9c
-    u32 friendPids[30]; //0x36c GPProfiles
-    u64* friendCodes; //0x3e4
-}; //total size 0x3e8
-size_assert(RKNet::FriendMgr, 0x3e8);
-}//namespace RKNet
+        void ReadDataFromRKSYS();                                 // 806632fc
+        void Update();                                            // 80663444
+        void CreateAccUserData(u32 gameCode);                     // 806635a8
+        bool CheckAccUserData() const;                            // 806635b0
+        bool IsAccUserDataDirty() const;                          // 806635e0
+        void ClearAccUserDataDirtyFlag();                         // 80663610
+        u64 CreateFriendCode() const;                             // 80663618
+        void SetCodesForUnusedIdxs(u64 *friendCodes);             // 80663644
+        bool IsAvailable() const;                                 // 8066374c IsFriendCodes == nullptr
+        bool IsBuddyFriend(u8 idx) const;                         // 8066375c
+        bool IsValidFriend(const DWC::AccFriendData *data) const; // 80663794
+        bool CheckFriendCode(const u64 &friendCode) const;        // 806637c4
+        s32 GetFriendIdx(const u64 &friendCode) const;            // 806637fc returns -1 if code is not a friend
+        s32 GetFriendCodeLicenseIdx(const u64 &friendCode) const; // 80663874 returns -1 if code is not one of the licenses
+        u64 GetLicenseFriendCode(u8 licenseIdx) const;            // 80663918
+        s32 GetFirstFreeFriendIdx() const;                        // 80663940 goes through every frienddata until one is valid, and return its idx, else return -1
+        OS::Mutex mutex;
+        DWC::AccUserData myUserData[2];    // 0x1c
+        DWC::AccFriendData friends[30][2]; // 0x9c
+        u32 friendPids[30];                // 0x36c GPProfiles
+        u64 *friendCodes;                  // 0x3e4
+    }; // total size 0x3e8
+    size_assert(RKNet::FriendMgr, 0x3e8);
+} // namespace RKNet
 #endif

--- a/GameSource/MarioKartWii/Race/RaceInfo/RaceInfo.hpp
+++ b/GameSource/MarioKartWii/Race/RaceInfo/RaceInfo.hpp
@@ -19,84 +19,89 @@ Contributors:
 #include <MarioKartWii/System/ElineManager.hpp>
 #include <MarioKartWii/System/Random.hpp>
 #include <MarioKartWii/Input/ControllerHolder.hpp>
-#include <MarioKartWii/Race/Racedata.hpp>
-#include <MarioKartWii/Race/Raceinfo/GameModeData.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
+#include <MarioKartWii/Race/RaceInfo/GameModeData.hpp>
 
-enum RaceStage {
+enum RaceStage
+{
     RACESTAGE_INTRO,
     RACESTAGE_COUNTDOWN,
     RACESTAGE_RACE,
-    RACESTAGE_IS_FINISHING, //held for 1 frame
+    RACESTAGE_IS_FINISHING, // held for 1 frame
     RACESTAGE_FINISHED
 };
 
-class KMGHolder {
+class KMGHolder
+{
 public:
-    static u16 ConvertStageIdToIdx; //80538344 block plaza -> idx 0 etc...
-    virtual ~KMGHolder(); //805371a8 vtable 808b34d8
-    void SetKMG(KMG* rawKMG); //8053831c
-    KMG* rawKMG;
-}; //0x8
+    static u16 ConvertStageIdToIdx; // 80538344 block plaza -> idx 0 etc...
+    virtual ~KMGHolder();           // 805371a8 vtable 808b34d8
+    void SetKMG(KMG *rawKMG);       // 8053831c
+    KMG *rawKMG;
+}; // 0x8
 
-class RaceTimerMgrBase {
+class RaceTimerMgrBase
+{
 public:
-    virtual ~RaceTimerMgrBase(); //80532de0 vtable 808b34c4
-    virtual void Reset(); //80532d44
-    virtual void Update(); //805336a0
+    virtual ~RaceTimerMgrBase(); // 80532de0 vtable 808b34c4
+    virtual void Reset();        // 80532d44
+    virtual void Update();       // 805336a0
     Timer timers[3];
     Random random;
 };
 
-class RaceTimerMgr : public RaceTimerMgrBase {
+class RaceTimerMgr : public RaceTimerMgrBase
+{
 public:
-    ~RaceTimerMgr() override; //805376e0 vtable 808b34b0
-    void Reset() override; //80535864
-    void Update() override; //80535904
-    bool hasRaceTimeRanOut; // 0x40
-    bool hasRaceStarted; // 0x41
-    bool isTimerReversed; // 0x42
-    u8 unknown_0x43; 
-    u32 raceDurationMs; //0x44
-    u32 raceFrameCounter; //0x48
+    ~RaceTimerMgr() override; // 805376e0 vtable 808b34b0
+    void Reset() override;    // 80535864
+    void Update() override;   // 80535904
+    bool hasRaceTimeRanOut;   // 0x40
+    bool hasRaceStarted;      // 0x41
+    bool isTimerReversed;     // 0x42
+    u8 unknown_0x43;
+    u32 raceDurationMs;   // 0x44
+    u32 raceFrameCounter; // 0x48
     u8 unknown_0x40[0x50 - 0x4c];
-}; //Total size 0x50
+}; // Total size 0x50
 
-class RaceinfoPlayer {
+class RaceinfoPlayer
+{
 public:
-    RaceinfoPlayer(u8 id, u8 lapCount); //80533ed8
-    virtual ~RaceinfoPlayer(); //80532f48 vtable 808b34a4
-    void Init(); //80534194
-    u8 UpdateGPHiddenScore(); //805368f8
-    void FillTimerWithSplits(u8 lap, Timer* timer); //8053572c
-    void UpdateRealLocal(); //805342e8 inlined
-    void EndLap(); //805349b8
-    void EndRace(const Timer& finishTime, bool hasNoCameras, u32 r6); //805347f4
-    void Vanish(); //80534c78 for example when a ghost ends its race
-    void Disconnect(); //80534cbc sets state to |0x10
+    RaceinfoPlayer(u8 id, u8 lapCount);                               // 80533ed8
+    virtual ~RaceinfoPlayer();                                        // 80532f48 vtable 808b34a4
+    void Init();                                                      // 80534194
+    u8 UpdateGPHiddenScore();                                         // 805368f8
+    void FillTimerWithSplits(u8 lap, Timer *timer);                   // 8053572c
+    void UpdateRealLocal();                                           // 805342e8 inlined
+    void EndLap();                                                    // 805349b8
+    void EndRace(const Timer &finishTime, bool hasNoCameras, u32 r6); // 805347f4
+    void Vanish();                                                    // 80534c78 for example when a ghost ends its race
+    void Disconnect();                                                // 80534cbc sets state to |0x10
     void UpdateCheckPoint(u16 cpId, bool isDrivingBackwards, float completion);
-    void CopyCPUInputs(const Input::State& cpuState); //80535718
+    void CopyCPUInputs(const Input::State &cpuState); // 80535718
 
     u8 unknown_0x4[0x8 - 0x4];
-    u8 id; //0x8
-    u8 unknown_0x9; //might be padding
-    u16 checkpoint; //0xa
-    float raceCompletion; //0xc fraction of way through a lap (ex. 1.0 is the start of lap 1, 2.5 is half way through lap 2)
-    float raceCompletionMax; //0x10
-    float firstKcpLapCompletion; //0x14
-    float nextCheckpointLapCompletion; //0x18
-    float nextCheckpointLapCompletionMax; //0x1c
-    u8 position; //0x20
-    u8 respawn; //0x21
-    u16 battleScore; //0x22
-    u16 currentLap; //0x24
-    u8 maxLap; //0x26
+    u8 id;                                // 0x8
+    u8 unknown_0x9;                       // might be padding
+    u16 checkpoint;                       // 0xa
+    float raceCompletion;                 // 0xc fraction of way through a lap (ex. 1.0 is the start of lap 1, 2.5 is half way through lap 2)
+    float raceCompletionMax;              // 0x10
+    float firstKcpLapCompletion;          // 0x14
+    float nextCheckpointLapCompletion;    // 0x18
+    float nextCheckpointLapCompletionMax; // 0x1c
+    u8 position;                          // 0x20
+    u8 respawn;                           // 0x21
+    u16 battleScore;                      // 0x22
+    u16 currentLap;                       // 0x24
+    u8 maxLap;                            // 0x26
     u8 currentKCP;
-    u8 maxKCP; //0x28
+    u8 maxKCP; // 0x28
     u8 unknown_0x29[0x2c - 0x29];
-    u32 frameCounter; //0x2c
-    u32 framesInFirst; //0x30
+    u32 frameCounter;  // 0x2c
+    u32 framesInFirst; // 0x30
     u8 unknown_0x34[0x38 - 0x34];
-    u32 stateFlags; //0x38 bit flags:
+    u32 stateFlags; // 0x38 bit flags:
     /*
       0x40 is coming last animation?
       0x20 is finishing the race?
@@ -105,68 +110,67 @@ public:
       0x2 is end of race camera
       0x1 is in race?
     */
-    Timer* lapSplits; //0x3c array of lapCount length
-    Timer* raceFinishTime; //0x40
-    u32 status; //0x44
-    Input::RealControllerHolder* realControllerHolder; //0x48
+    Timer *lapSplits;                                  // 0x3c array of lapCount length
+    Timer *raceFinishTime;                             // 0x40
+    u32 status;                                        // 0x44
+    Input::RealControllerHolder *realControllerHolder; // 0x48
     u8 unknown_0x4c[0x54 - 0x4c];
-}; //Total size 0x54
+}; // Total size 0x54
 size_assert(RaceinfoPlayer, 0x54);
 
-class Raceinfo {
+class Raceinfo
+{
 public:
+    static Raceinfo *sInstance;        // 809bd730
+    static Raceinfo *CreateInstance(); // 80532084
+    static void DestroyInstance();     // 805320d4
 
-    static Raceinfo* sInstance; //809bd730
-    static Raceinfo* CreateInstance(); //80532084
-    static void DestroyInstance(); //805320d4
+    Raceinfo();                                                              // 805327a0
+    virtual ~Raceinfo();                                                     // 80532e3c vtable 808b3350
+    GMData *CreateGMData(GameMode gamemode);                                 // 80532188
+    void Init();                                                             // 80532f88
+    void Update();                                                           // 805331b4
+    u8 GetLapCount();                                                        // 805336a4
+    void SetPlayerDisconnected(u8 playerId);                                 // 80533d84 used if a player is disconnected
+    bool IsAtLeastStage(RaceStage stage) const;                              // 80536230
+    bool CanRaceEnd();                                                       // 80536208
+    const KMP::Holder<JGPT> *GetJGPTHolder(u8 playerId);                     // 8053621c just wraps around GMData's virtual func
+    const KMP::Holder<KTPT> *GetKTPTHolder(u8 playerId);                     // 805365c8
+    void GetInitialPhysicsValues(Vec3 *position, Vec3 *angles, u8 playerId); // 805362dc
+    s8 GetStartENPT(u8 playerId);                                            // 80536828 from ENPH 0
+    KRT **GetRawKRT();                                                       // 805368c4 from GPDataGP else returns 0
+    int GetBattleDuration();                                                 // 805326ec
+    void ComputeDelfinoPierTideState();                                      // 805330c0 inlined
+    void CloneTimer(Timer *dest);                                            // 80535ca0
+    void EndPlayerRace(u8 playerId);                                         // 80533c6c
+    void CheckEndRaceOnline(u8 playerId);                                    // 80533dd4
 
-    Raceinfo(); //805327a0
-    virtual ~Raceinfo(); //80532e3c vtable 808b3350
-    GMData* CreateGMData(GameMode gamemode); //80532188
-    void Init(); //80532f88
-    void Update(); //805331b4
-    u8 GetLapCount(); //805336a4
-    void SetPlayerDisconnected(u8 playerId); //80533d84 used if a player is disconnected
-    bool IsAtLeastStage(RaceStage stage) const; //80536230
-    bool CanRaceEnd(); //80536208
-    const KMP::Holder<JGPT>* GetJGPTHolder(u8 playerId); //8053621c just wraps around GMData's virtual func
-    const KMP::Holder<KTPT>* GetKTPTHolder(u8 playerId); //805365c8
-    void GetInitialPhysicsValues(Vec3* position, Vec3* angles, u8 playerId); //805362dc
-    s8 GetStartENPT(u8 playerId); //80536828 from ENPH 0
-    KRT** GetRawKRT(); //805368c4 from GPDataGP else returns 0
-    int GetBattleDuration(); //805326ec
-    void ComputeDelfinoPierTideState(); //805330c0 inlined
-    void CloneTimer(Timer* dest); //80535ca0
-    void EndPlayerRace(u8 playerId); //80533c6c
-    void CheckEndRaceOnline(u8 playerId); //80533dd4
-
-    Random* random;
-    Random* onlineAndTTRandom;
-    RaceinfoPlayer** players; //pointer to an array of pointers, length is player count
-    GMData* gamemodeData; //0x10
-    RaceTimerMgr* timerMgr; //0x14
-    u8* playerIdInEachPosition; //0x18 pointer to an array of player ids, 0 is the id in 1st, 1 is 2nd...
+    Random *random;
+    Random *onlineAndTTRandom;
+    RaceinfoPlayer **players;   // pointer to an array of pointers, length is player count
+    GMData *gamemodeData;       // 0x10
+    RaceTimerMgr *timerMgr;     // 0x14
+    u8 *playerIdInEachPosition; // 0x18 pointer to an array of player ids, 0 is the id in 1st, 1 is 2nd...
     u8 unknown_0x1c[2];
     s16 introTimer;
-    u32 raceFrames; //0x20
-    u8 randomUsedForBattleStartPoints; //0x24
+    u32 raceFrames;                    // 0x20
+    u8 randomUsedForBattleStartPoints; // 0x24
     u8 randomUnknown_0x25;
-    u8 padding[2]; //0x26
-    RaceStage stage; //0x28
-    u8 unknown_0x2c; //0x2c
-    bool isSpectating; //0x2d
-    bool canCountdownStart; //0x2e instantly true offline, needs syncing online
-    bool cutSectionMode; //true for modes 11 & 12
+    u8 padding[2];          // 0x26
+    RaceStage stage;        // 0x28
+    u8 unknown_0x2c;        // 0x2c
+    bool isSpectating;      // 0x2d
+    bool canCountdownStart; // 0x2e instantly true offline, needs syncing online
+    bool cutSectionMode;    // true for modes 11 & 12
     bool unknown_0x30;
     u8 padding2[3];
-    BitRotator bitRotator; //0x34
-    KMGHolder* kmg; //0x3c
-    ElineMgr* elineManager; //0x40
+    BitRotator bitRotator;  // 0x34
+    KMGHolder *kmg;         // 0x3c
+    ElineMgr *elineManager; // 0x40
     float unknown_0x44;
-    bool isDelfinoPierTideLow; //0x48 unsure
+    bool isDelfinoPierTideLow; // 0x48 unsure
     u8 unknown_0x49[3];
-}; //Total size 0x4c
+}; // Total size 0x4c
 size_assert(Raceinfo, 0x4c);
-
 
 #endif

--- a/GameSource/MarioKartWii/System/CINS.hpp
+++ b/GameSource/MarioKartWii/System/CINS.hpp
@@ -1,62 +1,65 @@
 #ifndef _CHANNELINSTALLER_
 #define _CHANNELINSTALLER_
 #include <kamek.hpp>
-#include <core/rvl/os/OSTitle.hpp>
+#include <core/rvl/OS/OSTitle.hpp>
 #include <core/egg/mem/Disposer.hpp>
 #include <core/egg/mem/Heap.hpp>
 
-struct WadListEntry {
+struct WadListEntry
+{
     u16 fsBlock;
     u16 inode;
 };
 
-struct WadList {
-    u32 magic; //RKWD
+struct WadList
+{
+    u32 magic; // RKWD
     u16 entryCount;
-    u16 unknown_0x6; //padding?
+    u16 unknown_0x6; // padding?
     WadListEntry entries[1];
 };
 
-class WadListHolder {
+class WadListHolder
+{
 public:
-    virtual ~WadListHolder(); //80510a50 vtable 808b2c04
-    WadList* wadList;
+    virtual ~WadListHolder(); // 80510a50 vtable 808b2c04
+    WadList *wadList;
 };
 
-
-//This is obviously used to install the MKChannel, but this is also how the game launches "HALP", the "Region Select" channel, it corresponds to idx 3 (see 8088f720)
-class CINS { //official name? "channel installer"
+// This is obviously used to install the MKChannel, but this is also how the game launches "HALP", the "Region Select" channel, it corresponds to idx 3 (see 8088f720)
+class CINS
+{ // official name? "channel installer"
 public:
-    enum ChannelErrCode {
+    enum ChannelErrCode
+    {
         IS_INSTALLED,
         NOT_INSTALLED = 1,
         SYS_INSSPACE,
         SYS_INSINODE,
         SYS_INSCHAN,
-        INVALIDPARAMS, //the wadidx led to invalid OS::CheckInstall args
+        INVALIDPARAMS, // the wadidx led to invalid OS::CheckInstall args
     };
-    static CINS* sInstance; //809bd6e0
-    static CINS* CreateInstance(); //80510468
-    static CINS* DestroyInstance(); //805104dc
+    static CINS *sInstance;         // 809bd6e0
+    static CINS *CreateInstance();  // 80510468
+    static CINS *DestroyInstance(); // 805104dc
 
-    void Init(EGG::Heap* heap); //80510510
-    void ReportInstallStatus(u32 wadIdx); //805106b0 only 0 works since the used list only has 1 entry, but the struct has support for 0-3
-    bool GetReqSizeAndInode(u32 wadIdx, u16* reqSize, u16* inode) const; //80510670
-    void InstallChannel(u32 wadIdx, u32 launchCodeIdx); //805107d0
-    void LaunchTitleOrDisk(u32 wadIdx, u32 launchCodeIdx, const char* arg0); //8051088c
+    void Init(EGG::Heap *heap);                                              // 80510510
+    void ReportInstallStatus(u32 wadIdx);                                    // 805106b0 only 0 works since the used list only has 1 entry, but the struct has support for 0-3
+    bool GetReqSizeAndInode(u32 wadIdx, u16 *reqSize, u16 *inode) const;     // 80510670
+    void InstallChannel(u32 wadIdx, u32 launchCodeIdx);                      // 805107d0
+    void LaunchTitleOrDisk(u32 wadIdx, u32 launchCodeIdx, const char *arg0); // 8051088c
 
-    EGG::TDisposer<CINS> disposer; //vtable 808b2c10 func 805103d0
-    virtual ~CINS(); //0x10 805105d4
-    WadListHolder* wadListHolder;
-    DVD::DiskID dvdDiskID; //0x18 for LaunchTitleOrDisk
+    EGG::TDisposer<CINS> disposer; // vtable 808b2c10 func 805103d0
+    virtual ~CINS();               // 0x10 805105d4
+    WadListHolder *wadListHolder;
+    DVD::DiskID dvdDiskID; // 0x18 for LaunchTitleOrDisk
     u8 unknown_0x18[0x68 - 0x38];
-    ChannelErrCode titleErrCodes[4]; //0x68
+    ChannelErrCode titleErrCodes[4]; // 0x68
     u8 unknown_0x78[4];
 
-    static const char** company; //808b2bf0 "01"
-    static const char** wadListName; //808b2bf4
-    static OS::InstallInfo installInfo; //808b2bd0
-}; //0x7c
-
+    static const char **company;        // 808b2bf0 "01"
+    static const char **wadListName;    // 808b2bf4
+    static OS::InstallInfo installInfo; // 808b2bd0
+}; // 0x7c
 
 #endif

--- a/GameSource/MarioKartWii/System/Ghost.hpp
+++ b/GameSource/MarioKartWii/System/Ghost.hpp
@@ -6,7 +6,7 @@
 #include <MarioKartWii/File/RKG.hpp>
 #include <MarioKartWii/Input/Controller.hpp>
 #include <MarioKartWii/Mii/Mii.hpp>
-#include <MarioKartWii/System/identifiers.hpp>
+#include <MarioKartWii/System/Identifiers.hpp>
 #include <MarioKartWii/System/Timer.hpp>
 
 enum GhostGroupType {

--- a/GameSource/MarioKartWii/THP/THPAudio.hpp
+++ b/GameSource/MarioKartWii/THP/THPAudio.hpp
@@ -1,34 +1,34 @@
 #ifndef _THPAUDIO_
 #define _THPAUDIO_
 #include <kamek.hpp>
-#include <core/rvl/os/OSMessage.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
 #include <MarioKartWii/THP/THPStructs.hpp>
 
-namespace THP {
+namespace THP
+{
 
-extern s32 audioDecodeThreadCreated; //809bd758
-extern OS::Thread audioDecodeThread; //809bd760
-extern u8 audioDecodeThreadStack[4 * 1024]; //809bda78
-extern OS::MessageQueue freeAudioBufferQueue; //809bea78
-extern OS::MessageQueue decodedAudioBufferQueue; //809bea98
-extern OS::Message freeAudioBufferMessage[6]; //809beab8
-extern OS::Message dDecodedAudioBufferMessage[6]; //809bead0
+    extern s32 audioDecodeThreadCreated;              // 809bd758
+    extern OS::Thread audioDecodeThread;              // 809bd760
+    extern u8 audioDecodeThreadStack[4 * 1024];       // 809bda78
+    extern OS::MessageQueue freeAudioBufferQueue;     // 809bea78
+    extern OS::MessageQueue decodedAudioBufferQueue;  // 809bea98
+    extern OS::Message freeAudioBufferMessage[6];     // 809beab8
+    extern OS::Message dDecodedAudioBufferMessage[6]; // 809bead0
 
+    // AudioDecode
+    BOOL CreateAudioDecodeThread(s32 priority, u8 *ptr); // 805507b0
+    void AudioDecodeThreadStart();                       // 80550880
+    void AudioDecodeThreadCancel();                      // 805508a0
 
-//AudioDecode
-BOOL CreateAudioDecodeThread(s32 priority, u8* ptr); //805507b0
-void AudioDecodeThreadStart(); //80550880
-void AudioDecodeThreadCancel(); //805508a0
+    // Thread run funcs
+    void *AudioDecoder(void *ptr);            // 805508e8 ptr will be null since not OnMemory
+    void *AudioDecoderForOnMemory(void *ptr); // 80550910
 
-//Thread run funcs
-void* AudioDecoder(void* ptr); //805508e8 ptr will be null since not OnMemory
-void* AudioDecoderForOnMemory(void* ptr); //80550910
+    void AudioDecode(ReadBuffer *readBuffer);  // 805509bc
+    void *PopFreeAudioBuffer();                // 80550aa8
+    void PushFreeAudioBuffer(void *buffer);    // 80550adc free audio data
+    void *PopDecodedAudioBuffer(s32 flag);     // 80550af0
+    void PushDecodedAudioBuffer(void *buffer); // 80550b34
 
-void AudioDecode(ReadBuffer* readBuffer); //805509bc
-void* PopFreeAudioBuffer(); //80550aa8
-void PushFreeAudioBuffer(void* buffer); //80550adc free audio data
-void* PopDecodedAudioBuffer(s32 flag); //80550af0
-void PushDecodedAudioBuffer(void* buffer);  //80550b34
-
-}//namespace THP
+} // namespace THP
 #endif

--- a/GameSource/MarioKartWii/THP/THPReading.hpp
+++ b/GameSource/MarioKartWii/THP/THPReading.hpp
@@ -1,36 +1,34 @@
 #ifndef _THPREADING_
 #define _THPREADING_
 #include <kamek.hpp>
-#include <core/rvl/os/OSMessage.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
 
-namespace THP {
+namespace THP
+{
 
-extern s32 ReadThreadCreated; //809bf0b8
-extern OS::MessageQueue FreeReadBufferQueue; //809bf0c0
-extern OS::MessageQueue ReadedBufferQueue; //809bf0e0
-extern OS::MessageQueue ReadedBufferQueue2; //809bf100
-extern OS::Message FreeReadBufferMessage[10]; //809bf120
-extern OS::Message ReadedBufferMessage[10]; //809bf148
-extern OS::Message ReadedBufferMessage2[10]; //809bf170
-extern OS::Thread ReadThread; //809bf198
-extern u8 ReadThreadStack[4 * 1024]; //809bf4b0
+    extern s32 ReadThreadCreated;                 // 809bf0b8
+    extern OS::MessageQueue FreeReadBufferQueue;  // 809bf0c0
+    extern OS::MessageQueue ReadedBufferQueue;    // 809bf0e0
+    extern OS::MessageQueue ReadedBufferQueue2;   // 809bf100
+    extern OS::Message FreeReadBufferMessage[10]; // 809bf120
+    extern OS::Message ReadedBufferMessage[10];   // 809bf148
+    extern OS::Message ReadedBufferMessage2[10];  // 809bf170
+    extern OS::Thread ReadThread;                 // 809bf198
+    extern u8 ReadThreadStack[4 * 1024];          // 809bf4b0
 
+    BOOL CreateReadThread(s32 priority); // 8055259c
+    void ReadThreadStart();              // 8055263c
+    void ReadThreadCancel();             // 8055265c
+    void *PopReadedBuffer();             // 80552794
+    void PushReadedBuffer(void *buffer);
+    void *PopFreeReadBuffer(); // 805527dc
 
-BOOL CreateReadThread(s32 priority); //8055259c
-void ReadThreadStart(); //8055263c
-void ReadThreadCancel(); //8055265c
-void* PopReadedBuffer(); //80552794
-void PushReadedBuffer(void* buffer);
-void* PopFreeReadBuffer(); //805527dc
+    void PushFreeReadBuffer(void *buffer); // 80552810 free used buffers
+    void *PopReadedBuffer2();              // 80552824
+    void PushReadedBuffer2(void *buffer);  // 80552858
 
-void PushFreeReadBuffer(void* buffer); //80552810 free used buffers
-void* PopReadedBuffer2(); //80552824
-void PushReadedBuffer2(void* buffer); //80552858
+    // Thread run funcs
+    void *Reader(void *ptr); // 805526a4 ptr will be null
 
-//Thread run funcs
-void* Reader(void* ptr); //805526a4 ptr will be null 
-
-
-
-}//namespace THP
+} // namespace THP
 #endif

--- a/GameSource/MarioKartWii/THP/THPStructs.hpp
+++ b/GameSource/MarioKartWii/THP/THPStructs.hpp
@@ -1,9 +1,9 @@
 #ifndef _THPSTRUCTS_
 #define _THPSTRUCTS_
 #include <kamek.hpp>
-#include <core/rvl/os/OSMessage.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
 #include <core/rvl/dvd/dvd.hpp>
-#include <core/rvl/VI/vi.hpp>
+#include <core/rvl/VI/VI.hpp>
 #include <core/rvl/AI.hpp>
 #include <core/rvl/gx/GXStruct.hpp>
 #include <MarioKartWii/THP/THPFile.hpp>

--- a/GameSource/MarioKartWii/THP/THPVideo.hpp
+++ b/GameSource/MarioKartWii/THP/THPVideo.hpp
@@ -1,35 +1,35 @@
 #ifndef _THPVIDEO_
 #define _THPVIDEO_
 #include <kamek.hpp>
-#include <core/rvl/os/OSMessage.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
 #include <MarioKartWii/THP/THPStructs.hpp>
 
-namespace THP {
+namespace THP
+{
 
-extern s32 VideoDecodeThreadCreated; //809c04b0
-extern OS::Thread VideoDecodeThread; //809c04b8
-extern u8 VideoDecodeThreadStack[4 * 1024]; //809c07d0
-extern OS::MessageQueue FreeTextureSetQueue; //809c17d0
-extern OS::MessageQueue DecodedTextureSetQueue; //809c17f0
-extern OS::Message FreeTextureSetMessage[3]; //809c1810
-extern OS::Message DecodedTextureSetMessage[3]; //809c181c
-extern s32 First; //809C1828
+    extern s32 VideoDecodeThreadCreated;            // 809c04b0
+    extern OS::Thread VideoDecodeThread;            // 809c04b8
+    extern u8 VideoDecodeThreadStack[4 * 1024];     // 809c07d0
+    extern OS::MessageQueue FreeTextureSetQueue;    // 809c17d0
+    extern OS::MessageQueue DecodedTextureSetQueue; // 809c17f0
+    extern OS::Message FreeTextureSetMessage[3];    // 809c1810
+    extern OS::Message DecodedTextureSetMessage[3]; // 809c181c
+    extern s32 First;                               // 809C1828
 
+    // VideoDecode
+    BOOL CreateVideoDecodeThread(s32 priority, u8 *ptr); // 8055286c
+    void VideoDecodeThreadStart();                       // 80552940
+    void VideoDecodeThreadCancel();                      // 80552960
 
-//VideoDecode
-BOOL CreateVideoDecodeThread(s32 priority, u8* ptr); //8055286c
-void VideoDecodeThreadStart(); //80552940
-void VideoDecodeThreadCancel(); //80552960
+    // Thread run funcs
+    void *VideoDecoder(void *ptr);            // 805529a8 ptr will be null since not OnMemory
+    void *VideoDecoderForOnMemory(void *ptr); // 80552a74
 
-//Thread run funcs
-void* VideoDecoder(void* ptr); //805529a8 ptr will be null since not OnMemory
-void* VideoDecoderForOnMemory(void* ptr); //80552a74
+    u32 VideoDecode(ReadBuffer *readBuffer);  // 80552ba4
+    void *PopFreeTextureSet();                // 80552cf0
+    void PushFreeTextureSet(void *buffer);    // 80552d24 Free video data
+    void *PopDecodedTextureSet(s32 flag);     // 80552d38 get decoded
+    void PushDecodedTextureSet(void *buffer); // 80552d7c
 
-u32 VideoDecode(ReadBuffer* readBuffer); //80552ba4
-void* PopFreeTextureSet(); //80552cf0
-void PushFreeTextureSet(void* buffer); //80552d24 Free video data
-void* PopDecodedTextureSet(s32 flag); //80552d38 get decoded
-void PushDecodedTextureSet(void* buffer); //80552d7c
-
-}//namespace THP
+} // namespace THP
 #endif

--- a/GameSource/MarioKartWii/UI/Ctrl/CtrlRace/CtrlRaceBase.hpp
+++ b/GameSource/MarioKartWii/UI/Ctrl/CtrlRace/CtrlRaceBase.hpp
@@ -2,7 +2,7 @@
 #define _CTRLRACEBASE_
 #include <MarioKartWii/UI/Ctrl/UIControl.hpp>
 #include <MarioKartWii/UI/Section/SectionMgr.hpp>
-#include <MarioKartWii/Race/Racedata.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
 
 
 class CtrlRaceBase : public LayoutUIControl { //one element is one CtrlRaceBase

--- a/GameSource/MarioKartWii/UI/Page/Menu/KartSelect.hpp
+++ b/GameSource/MarioKartWii/UI/Page/Menu/KartSelect.hpp
@@ -5,8 +5,8 @@
 #include <MarioKartWii/UI/Page/Page.hpp>
 #include <MarioKartWii/UI/Page/Menu/Menu.hpp>
 #include <MarioKartWii/UI/Ctrl/Menu/CtrlMenuMachineGraph.hpp>
-#include <MarioKartWii/Race/racedata.hpp>
-#include <MarioKartWii/System/identifiers.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
+#include <MarioKartWii/System/Identifiers.hpp>
 #include <MarioKartWii/UI/Ctrl/ModelControl.hpp>
 #include <MarioKartWii/UI/Ctrl/CountDown.hpp>
 
@@ -16,7 +16,8 @@ Contributors:
 */
 
 //_sinit_ at 80847d00
-enum KartUIOrder {
+enum KartUIOrder
+{
     UIORDER_STANDARD_KART_S,
     UIORDER_BABY_BOOSTER,
     UIORDER_MINI_BEAST,
@@ -57,7 +58,8 @@ enum KartUIOrder {
     UIORDER_PHANTOM
 };
 
-enum KartUIStats {
+enum KartUIStats
+{
     UISTATS_SPEED,
     UISTATS_WEIGHT,
     UISTATS_ACCELERATION,
@@ -67,73 +69,76 @@ enum KartUIStats {
     UISTATS_MT
 };
 
-class ButtonMachine : public PushButton {
+class ButtonMachine : public PushButton
+{
 public:
-    //ctor inline
-    ~ButtonMachine() override; //80847ca8 vtable 808d9918
-    void InitSelf() override; //0x18 80847810
-    void OnUpdate() override; //0x1c 808476f0
-    const ut::detail::RuntimeTypeInfo* GetRuntimeTypeInfo() const override; //0x28 80847c9c
-    const char* GetClassName() const override; //0x2c 808448dc
+    // ctor inline
+    ~ButtonMachine() override;                                              // 80847ca8 vtable 808d9918
+    void InitSelf() override;                                               // 0x18 80847810
+    void OnUpdate() override;                                               // 0x1c 808476f0
+    const ut::detail::RuntimeTypeInfo *GetRuntimeTypeInfo() const override; // 0x28 80847c9c
+    const char *GetClassName() const override;                              // 0x2c 808448dc
     u8 unknown_0x254[0x260 - 0x254];
-}; //total size 0x260
+}; // total size 0x260
 
 //_sinit_ at 80847d00
-namespace Pages {
-class KartSelect : public MenuInteractable { //ID 0x6C
-public:
-    static const PageId id = PAGE_KART_SELECT;
-    KartSelect(); //80627060
-    ~KartSelect() override; //80847bf4 vtable 808d9880
-    void OnInit() override; //0x28 80844d68
-    void OnActivate() override; //0x30 80845510
-    void BeforeEntranceAnimations() override; //0x38 80847630
-    void BeforeExitAnimations() override; //0x44 80847690
-    void AfterControlUpdate() override; //0x4c 80846a2c
-    const ut::detail::RuntimeTypeInfo* GetRuntimeTypeInfo() const override; //0x60 80847c90
-    void OnExternalButtonSelect(PushButton& button, u32 r5) override; //0x64 80846ea4
-    int GetActivePlayerBitfield() const override; //0x68 80846a24
-    int GetPlayerBitfield() const override; //0x6c 80847bec
-    ManipulatorManager& GetManipulatorManager() override; //0x70 80846a1c
-    UIControl* CreateExternalControl(u32 id) override; //0x84 80845148
-    UIControl* CreateControl(u32 id) override; //0x88 80845150
-    void SetButtonHandlers(PushButton& pushButton) override; //0x8C 808454b4
+namespace Pages
+{
+    class KartSelect : public MenuInteractable
+    { // ID 0x6C
+    public:
+        static const PageId id = PAGE_KART_SELECT;
+        KartSelect();                                                           // 80627060
+        ~KartSelect() override;                                                 // 80847bf4 vtable 808d9880
+        void OnInit() override;                                                 // 0x28 80844d68
+        void OnActivate() override;                                             // 0x30 80845510
+        void BeforeEntranceAnimations() override;                               // 0x38 80847630
+        void BeforeExitAnimations() override;                                   // 0x44 80847690
+        void AfterControlUpdate() override;                                     // 0x4c 80846a2c
+        const ut::detail::RuntimeTypeInfo *GetRuntimeTypeInfo() const override; // 0x60 80847c90
+        void OnExternalButtonSelect(PushButton &button, u32 r5) override;       // 0x64 80846ea4
+        int GetActivePlayerBitfield() const override;                           // 0x68 80846a24
+        int GetPlayerBitfield() const override;                                 // 0x6c 80847bec
+        ManipulatorManager &GetManipulatorManager() override;                   // 0x70 80846a1c
+        UIControl *CreateExternalControl(u32 id) override;                      // 0x84 80845148
+        UIControl *CreateControl(u32 id) override;                              // 0x88 80845150
+        void SetButtonHandlers(PushButton &pushButton) override;                // 0x8C 808454b4
 
-    LayoutUIControl* GetExternalControl(u32 type, u8 row, u8 column); //0 = kart name, 1 = one column of buttonmachine (such as only bike), 2 = all buttonmachine, always inlined 80847094
-    ButtonMachine* GetButtonMachineById(u8 buttonId); //808471c4
-    void InitButtonMachine(ButtonMachine& machine, u8 buttonId); //80847344
-    KartId GetkartId(u8 weight, bool isBike, u32 UIPosition); //808448e8 UI Position from 0 to 5
-    u32 GetUnlockedKartsCountByWeightAndType(u8 weight, bool isBike); //80844960
-    u32 GetUnlockedKartsCountByWeight(u8 weight); //808449dc inlined
-    u32 GetMinUnlockedKartsCount() const; //80844abc inlined
-    static void func_8084745c(); //some weird random stuff that stores different karts in racedata scenario1, akin to char select
-    static void func_80847590(); //same, but without the random 
-    static Page* GetPageById(PageId id = PAGE_KART_SELECT); //808447cc only ever used with id = veh select so it's here
-    static KartId kartUIOrderToIDArray[36]; //808ad678
+        LayoutUIControl *GetExternalControl(u32 type, u8 row, u8 column); // 0 = kart name, 1 = one column of buttonmachine (such as only bike), 2 = all buttonmachine, always inlined 80847094
+        ButtonMachine *GetButtonMachineById(u8 buttonId);                 // 808471c4
+        void InitButtonMachine(ButtonMachine &machine, u8 buttonId);      // 80847344
+        KartId GetkartId(u8 weight, bool isBike, u32 UIPosition);         // 808448e8 UI Position from 0 to 5
+        u32 GetUnlockedKartsCountByWeightAndType(u8 weight, bool isBike); // 80844960
+        u32 GetUnlockedKartsCountByWeight(u8 weight);                     // 808449dc inlined
+        u32 GetMinUnlockedKartsCount() const;                             // 80844abc inlined
+        static void func_8084745c();                                      // some weird random stuff that stores different karts in racedata scenario1, akin to char select
+        static void func_80847590();                                      // same, but without the random
+        static Page *GetPageById(PageId id = PAGE_KART_SELECT);           // 808447cc only ever used with id = veh select so it's here
+        static KartId kartUIOrderToIDArray[36];                           // 808ad678
 
-    void OnButtonClick(PushButton& button, u32 hudSlotId); //80846c1c
-    void OnButtonDeselect(PushButton& button, u32 hudSlotId); //80846fbc
-    void OnBackPress(u32 hudSlotId); //80846fc0
+        void OnButtonClick(PushButton &button, u32 hudSlotId);    // 80846c1c
+        void OnButtonDeselect(PushButton &button, u32 hudSlotId); // 80846fbc
+        void OnBackPress(u32 hudSlotId);                          // 80846fc0
 
-    //onButtonClick    vtable = 0x808bd06c function = 80846c1c
-    //onButtonSelect   vtable = 0x808bd06c offset   = 0x64 call is virtual
-    //onButtonDeselect vtable = 0x808bd06c function = 80846fbc
-    //onBackPress      vtable = 0x808bd060 function = 80846fc0
-    //onStartPress     vtable = 0x808bd060 offset   = 0x7c call is virtual
+        // onButtonClick    vtable = 0x808bd06c function = 80846c1c
+        // onButtonSelect   vtable = 0x808bd06c offset   = 0x64 call is virtual
+        // onButtonDeselect vtable = 0x808bd06c function = 80846fbc
+        // onBackPress      vtable = 0x808bd060 function = 80846fc0
+        // onStartPress     vtable = 0x808bd060 offset   = 0x7c call is virtual
 
-    u32 unknwown_0x6C4; //init at -1
-    bool isUnlocked[36]; //in UIORDER
-    u32 kartsDisplayType; //0 = only karts, 1 = only bikes, 2 = all
-    CountDown* timer; //0x6f0
-    u32 curButtonId; //matches kart IDs
-    VehicleModelControl vehicleModel;
-    CtrlMenuMachineGraph ctrlMenuMachineGraph; //0x87c 808d3420 inherited from LayoutUIControl,
-    Vec2 kartScale; //0xA00 depends on minUnlockedKartCount
-    u32 minUnlockedKartsCount; //0xA08 min unlocked karts out of all weight classes and types
-}; //Total Size 0xA0C
-size_assert(KartSelect, 0xA0C);
-}//namespace Pages
-extern KartId kartsSortedByWeight[3][12]; //808ab770
+        u32 unknwown_0x6C4;   // init at -1
+        bool isUnlocked[36];  // in UIORDER
+        u32 kartsDisplayType; // 0 = only karts, 1 = only bikes, 2 = all
+        CountDown *timer;     // 0x6f0
+        u32 curButtonId;      // matches kart IDs
+        VehicleModelControl vehicleModel;
+        CtrlMenuMachineGraph ctrlMenuMachineGraph; // 0x87c 808d3420 inherited from LayoutUIControl,
+        Vec2 kartScale;                            // 0xA00 depends on minUnlockedKartCount
+        u32 minUnlockedKartsCount;                 // 0xA08 min unlocked karts out of all weight classes and types
+    }; // Total Size 0xA0C
+    size_assert(KartSelect, 0xA0C);
+} // namespace Pages
+extern KartId kartsSortedByWeight[3][12]; // 808ab770
 /* controlGroup:
 index 0 = CharaName (MachineSelectName.brctr)
 Index 1 = LayoutUIControl (MachineSelectNULL6 variant MachineSelectNULL) which contains 6 controls MachineSelectNULLX

--- a/GameSource/MarioKartWii/UI/Page/Menu/MultiKartSelect.hpp
+++ b/GameSource/MarioKartWii/UI/Page/Menu/MultiKartSelect.hpp
@@ -5,8 +5,8 @@
 #include <MarioKartWii/UI/Page/Page.hpp>
 #include <MarioKartWii/UI/Page/Menu/Menu.hpp>
 #include <MarioKartWii/UI/Ctrl/Menu/CtrlMenuMachineGraph.hpp>
-#include <MarioKartWii/Race/racedata.hpp>
-#include <MarioKartWii/System/identifiers.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
+#include <MarioKartWii/System/Identifiers.hpp>
 #include <MarioKartWii/UI/Ctrl/ModelControl.hpp>
 #include <MarioKartWii/UI/Ctrl/CountDown.hpp>
 #include <MarioKartWii/UI/Ctrl/UpDown.hpp>
@@ -18,66 +18,69 @@ Contributors:
 
 //_sinit_ at 8084a9a0
 
-class MultiKartBox : public LayoutUIControl { //doesn't seem to have any discerneable different
-    MultiKartBox(); //8062b828
-    ~MultiKartBox() override; //8062b864 vtable 808bd270
+class MultiKartBox : public LayoutUIControl
+{                             // doesn't seem to have any discerneable different
+    MultiKartBox();           // 8062b828
+    ~MultiKartBox() override; // 8062b864 vtable 808bd270
 };
 
 //_sinit_ at 8084a9a0
-namespace Pages {
-class MultiKartSelect : public MenuInteractable { //ID 0x81
-public:
-    static const PageId id = PAGE_MULTIPLAYER_KART_SELECT;
-    MultiKartSelect(); //8062b4f4
-    ~MultiKartSelect() override; //8084a824 vtable 808d9b08
-    void OnInit() override; //0x28 808496a4
-    void OnActivate() override; //0x30 80849c24
-    void BeforeEntranceAnimations() override; //0x38 8084a668
-    void BeforeExitAnimations() override; //0x40 8084a710
-    void AfterControlUpdate() override; //0x4c 80849d80
-    const ut::detail::RuntimeTypeInfo* GetRuntimeTypeInfo() const override; //0x60 8084a904
-    void OnExternalButtonSelect(PushButton& button, u32 hudSlotId) override; //0x64 80849f60
-    int GetActivePlayerBitfield() const override; //0x68 8084a7c0
-    int GetPlayerBitfield() const override; //0x6C 8084a7b8
-    ManipulatorManager& GetManipulatorManager() override; //0x70 80849e64
-    UIControl* CreateExternalControl(u32 externControlId) override; //0x84 80849940
-    UIControl* CreateControl(u32 controlId) override; //0x88 80849948
-    void SetButtonHandlers(PushButton& button) override; //0x8c 8084a7c8
+namespace Pages
+{
+    class MultiKartSelect : public MenuInteractable
+    { // ID 0x81
+    public:
+        static const PageId id = PAGE_MULTIPLAYER_KART_SELECT;
+        MultiKartSelect();                                                       // 8062b4f4
+        ~MultiKartSelect() override;                                             // 8084a824 vtable 808d9b08
+        void OnInit() override;                                                  // 0x28 808496a4
+        void OnActivate() override;                                              // 0x30 80849c24
+        void BeforeEntranceAnimations() override;                                // 0x38 8084a668
+        void BeforeExitAnimations() override;                                    // 0x40 8084a710
+        void AfterControlUpdate() override;                                      // 0x4c 80849d80
+        const ut::detail::RuntimeTypeInfo *GetRuntimeTypeInfo() const override;  // 0x60 8084a904
+        void OnExternalButtonSelect(PushButton &button, u32 hudSlotId) override; // 0x64 80849f60
+        int GetActivePlayerBitfield() const override;                            // 0x68 8084a7c0
+        int GetPlayerBitfield() const override;                                  // 0x6C 8084a7b8
+        ManipulatorManager &GetManipulatorManager() override;                    // 0x70 80849e64
+        UIControl *CreateExternalControl(u32 externControlId) override;          // 0x84 80849940
+        UIControl *CreateControl(u32 controlId) override;                        // 0x88 80849948
+        void SetButtonHandlers(PushButton &button) override;                     // 0x8c 8084a7c8
 
-    void OnButtonClick(PushButton& button, u32 hudSlotId); //80849e6c
-    void OnButtonDeselect(PushButton& button, u32 hudSlotId); //80849f64
-    void OnBackPress(u32 hudSlotId); //80849f68
+        void OnButtonClick(PushButton &button, u32 hudSlotId);    // 80849e6c
+        void OnButtonDeselect(PushButton &button, u32 hudSlotId); // 80849f64
+        void OnBackPress(u32 hudSlotId);                          // 80849f68
 
-    void OnUpDownChange(UpDownControl& control, u32 hudSlotId, u32 optionId); //8084a2a4
-    void OnUpDownClick(UpDownControl& control, u32 hudSlotId); //8084a100
-    void OnTextChange(TextUpDownValueControl::TextControl& control, u32 optionId); //8084a2a8
+        void OnUpDownChange(UpDownControl &control, u32 hudSlotId, u32 optionId);      // 8084a2a4
+        void OnUpDownClick(UpDownControl &control, u32 hudSlotId);                     // 8084a100
+        void OnTextChange(TextUpDownValueControl::TextControl &control, u32 optionId); // 8084a2a8
 
-    u32 FillPossibleKarts(u8 hudSlotId); //8084a3f8 returns number of possible karts
+        u32 FillPossibleKarts(u8 hudSlotId); // 8084a3f8 returns number of possible karts
 
-    static Page* GetPageById(PageId id = PAGE_MULTIPLAYER_KART_SELECT); //80849594
+        static Page *GetPageById(PageId id = PAGE_MULTIPLAYER_KART_SELECT); // 80849594
 
-    //onButtonClick    vtable = 0x808bd06c function = 80849e6c
-    //onButtonSelect   vtable = 0x808bd06c offset   = 0x64 call is virtual
-    //onButtonDeselect vtable = 0x808bd06c function = 80849f64
-    //onBackPress      vtable = 0x808bd060 function = 80849f68
-    //onStartPress     vtable = 0x808bd060 offset   = 0x7c call is virtual
+        // onButtonClick    vtable = 0x808bd06c function = 80849e6c
+        // onButtonSelect   vtable = 0x808bd06c offset   = 0x64 call is virtual
+        // onButtonDeselect vtable = 0x808bd06c function = 80849f64
+        // onBackPress      vtable = 0x808bd060 function = 80849f68
+        // onStartPress     vtable = 0x808bd060 offset   = 0x7c call is virtual
 
-    CountDown* timer; //0x6c4
+        CountDown *timer; // 0x6c4
 
-    CharacterId selCharacters[4]; //0x6c8
-    KartId possibleKartIds[12][4]; //0x6d8 first idx is option Id of textcontrol, 2nd is hudSlotId
-    u8 unknown_0x798[0x7c0 - 0x798];
-    MultiKartBox boundingBoxes[4]; //0x7c0
-    UpDownControl arrows[4]; //0xd90
-    TextUpDownValueControl text[6]; //0x24b0
-    PtmfHolder_3A<Page, void, UpDownControl&, u32, u32>* upDownChangeHandler; //0x3f68 8084a2a4
-    PtmfHolder_2A<Page, void, UpDownControl&, u32>* upDownClickHandler; //0x3f6c 8084a100
-    PtmfHolder_2A<Page, void, TextUpDownValueControl::TextControl&, u32>* onTextChangeHandler; //0x3f70 8084a2a8
-    VehicleModelControl* vehicleModels; //0x3f74 size local player count
-    CtrlMenuMachineGraph machineGraphs[2]; //0x3f78
-};
-size_assert(MultiKartSelect, 0x4280);
-}//namespace Pages
+        CharacterId selCharacters[4];  // 0x6c8
+        KartId possibleKartIds[12][4]; // 0x6d8 first idx is option Id of textcontrol, 2nd is hudSlotId
+        u8 unknown_0x798[0x7c0 - 0x798];
+        MultiKartBox boundingBoxes[4];                                                              // 0x7c0
+        UpDownControl arrows[4];                                                                    // 0xd90
+        TextUpDownValueControl text[6];                                                             // 0x24b0
+        PtmfHolder_3A<Page, void, UpDownControl &, u32, u32> *upDownChangeHandler;                  // 0x3f68 8084a2a4
+        PtmfHolder_2A<Page, void, UpDownControl &, u32> *upDownClickHandler;                        // 0x3f6c 8084a100
+        PtmfHolder_2A<Page, void, TextUpDownValueControl::TextControl &, u32> *onTextChangeHandler; // 0x3f70 8084a2a8
+        VehicleModelControl *vehicleModels;                                                         // 0x3f74 size local player count
+        CtrlMenuMachineGraph machineGraphs[2];                                                      // 0x3f78
+    };
+    size_assert(MultiKartSelect, 0x4280);
+} // namespace Pages
 /* controlGroup:
 index 0 = CharaName (MachineSelectName.brctr)
 Index 1 = LayoutUIControl (MachineSelectNULL6 variant MachineSelectNULL) which contains 6 controls MachineSelectNULLX

--- a/GameSource/MarioKartWii/UI/Page/Other/FriendRoom.hpp
+++ b/GameSource/MarioKartWii/UI/Page/Other/FriendRoom.hpp
@@ -9,247 +9,259 @@
 #include <MarioKartWii/UI/Ctrl/SheetSelect.hpp>
 #include <MarioKartWii/UI/Ctrl/CountDown.hpp>
 #include <MarioKartWii/UI/Ctrl/MessageWindowControl.hpp>
-#include <MarioKartWii/RKNet/Room.hpp>
+#include <MarioKartWii/RKNet/ROOM.hpp>
 
 //_sinit_ at 805de9bc
-namespace Pages {
-class FriendRoomMessages;
-} //namespace Pages
+namespace Pages
+{
+    class FriendRoomMessages;
+} // namespace Pages
 
-class UnkUnkFriendRoomManager {
+class UnkUnkFriendRoomManager
+{
     RKNet::ROOMPacket packet;
-    u8 index; //id * 2 + isGuest
+    u8 index; // id * 2 + isGuest
     u8 unknown_0x5[0x8 - 0x5];
-}; size_assert(UnkUnkFriendRoomManager, 0x8);
+};
+size_assert(UnkUnkFriendRoomManager, 0x8);
 
-class UnkFriendRoomManager {
+class UnkFriendRoomManager
+{
 public:
-    ~UnkFriendRoomManager(); //805dae80
-    UnkFriendRoomManager(); //805daec0
+    ~UnkFriendRoomManager(); // 805dae80
+    UnkFriendRoomManager();  // 805daec0
     UnkUnkFriendRoomManager packetHolders[12];
     u8 unknown[0xf0 - 0x60];
     u32 lastSentAid;
-    RKNet::ROOMPacket receivedPackets[24]; //0xf4 arranged by pairs
+    RKNet::ROOMPacket receivedPackets[24]; // 0xf4 arranged by pairs
     u8 unknown_0x154[4];
-    RKNet::ROOMPacket lastSentPacket; //0x158
-    u8 localAid; //0x15c
+    RKNet::ROOMPacket lastSentPacket; // 0x158
+    u8 localAid;                      // 0x15c
     u8 unknown_0x15d[3];
 
-    void HandleROOMPacket(u8 playerId, u8 myAid, RKNet::ROOMPacket& packet); //805db358
-    void Update(); //805daf38
-}; //0x160
+    void HandleROOMPacket(u8 playerId, u8 myAid, RKNet::ROOMPacket &packet); // 805db358
+    void Update();                                                           // 805daf38
+}; // 0x160
 size_assert(UnkFriendRoomManager, 0x160);
 
-class FriendMatchingPlayer : public LayoutUIControl {
-    FriendMatchingPlayer(); //805d945c
-    ~FriendMatchingPlayer() override; //805d94d0 vtable 808b8f90
-    void InitSelf() override; //0x18 805d9614
-    void OnUpdate() override; //0x1c 805d9700
-    const ut::detail::RuntimeTypeInfo* GetRuntimeTypeInfo() const override; //0x28 805de884
-    const char* GetClassName() const override; //0x2c 805d944c
-    void Load(MiiGroup* miiGroup, u8 id, bool isGuest); //805d9528
-    void OnMessageSent(Mii& mii); //805d9aa8 just does the animation, mii isn't actually used
-    PtmfHolder_1A<FriendMatchingPlayer, void, Mii&> onMessageSentHandler; //0x174 805d9aa8 808b8fcc
-    MiiGroup* miiGroup; //0x188
-    u8 id; //0x18c
-    bool isGuest; //0x18d
+class FriendMatchingPlayer : public LayoutUIControl
+{
+    FriendMatchingPlayer();                                                 // 805d945c
+    ~FriendMatchingPlayer() override;                                       // 805d94d0 vtable 808b8f90
+    void InitSelf() override;                                               // 0x18 805d9614
+    void OnUpdate() override;                                               // 0x1c 805d9700
+    const ut::detail::RuntimeTypeInfo *GetRuntimeTypeInfo() const override; // 0x28 805de884
+    const char *GetClassName() const override;                              // 0x2c 805d944c
+    void Load(MiiGroup *miiGroup, u8 id, bool isGuest);                     // 805d9528
+    void OnMessageSent(Mii &mii);                                           // 805d9aa8 just does the animation, mii isn't actually used
+    PtmfHolder_1A<FriendMatchingPlayer, void, Mii &> onMessageSentHandler;  // 0x174 805d9aa8 808b8fcc
+    MiiGroup *miiGroup;                                                     // 0x188
+    u8 id;                                                                  // 0x18c
+    bool isGuest;                                                           // 0x18d
     u8 padding[2];
-    u32 managerArrayIndex; //0x190 id * 2 + isGuest
-    nw4r::lyt::Pane* all_null; //0x194
-    float slidingXPos; //some kind of sliding thing, changing it makes the icon slide
-    bool hasJoined; //0x19c 0->1 triggers the join animation
+    u32 managerArrayIndex;     // 0x190 id * 2 + isGuest
+    nw4r::lyt::Pane *all_null; // 0x194
+    float slidingXPos;         // some kind of sliding thing, changing it makes the icon slide
+    bool hasJoined;            // 0x19c 0->1 triggers the join animation
     u8 padding2[3];
-}; //total size 0x1a0
+}; // total size 0x1a0
 size_assert(FriendMatchingPlayer, 0x1a0);
 
-class MessageSelectControl : public LayoutUIControl {
+class MessageSelectControl : public LayoutUIControl
+{
 public:
-    MessageSelectControl(); //805db6c8
-    ~MessageSelectControl() override; //805db724 vtable 808b8ef0
-    void InitSelf() override; //0x18 805db8ec
-    void OnUpdate() override; //0x1c 805db8f0
-    void SetPositionAnim(PositionAndScale& positionAndScale, float curFrame) override; //0x20  805db9e8
-    const ut::detail::RuntimeTypeInfo* GetRuntimeTypeInfo() const override; //0x28 805de86c
-    const char* GetClassName() const override; //0x2c 805db6b8
-    void Load(); //805db798
-    void Activate(); //805dba20 plays show anim + sets playerbitfield
-    void Deactivate(); //805dbab8 opposite plays hide anim
-    void ChangeToPage(u8 direction); //805dbb28 0 for right plays slide in animation
-    void ChangeFromPage(u8 direction); //805dbb88 plays slide out animation and disables buttons
-    bool IsActivated(); //805dbc20
-    bool IsDeactivated(); //805dbc58
-    void SetButtonBmg(u8 id, u32 r5, u32 bmgId, const Text::Info* text = nullptr); //805dbc8c
-    void SetOnClickHandler(const PtmfHolder_2A<Pages::FriendRoomMessages, void, PushButton&, u32>& handler); //805dbcc4
-    void SelectInitialButton(u32 hudSlotId, u8 id); //805dbd24
-    u32 GetSelectedButtonId() const; //805dbd34
-    PushButton buttons[4]; //0x174
-}; //total size 0xac4
+    MessageSelectControl();                                                                                   // 805db6c8
+    ~MessageSelectControl() override;                                                                         // 805db724 vtable 808b8ef0
+    void InitSelf() override;                                                                                 // 0x18 805db8ec
+    void OnUpdate() override;                                                                                 // 0x1c 805db8f0
+    void SetPositionAnim(PositionAndScale &positionAndScale, float curFrame) override;                        // 0x20  805db9e8
+    const ut::detail::RuntimeTypeInfo *GetRuntimeTypeInfo() const override;                                   // 0x28 805de86c
+    const char *GetClassName() const override;                                                                // 0x2c 805db6b8
+    void Load();                                                                                              // 805db798
+    void Activate();                                                                                          // 805dba20 plays show anim + sets playerbitfield
+    void Deactivate();                                                                                        // 805dbab8 opposite plays hide anim
+    void ChangeToPage(u8 direction);                                                                          // 805dbb28 0 for right plays slide in animation
+    void ChangeFromPage(u8 direction);                                                                        // 805dbb88 plays slide out animation and disables buttons
+    bool IsActivated();                                                                                       // 805dbc20
+    bool IsDeactivated();                                                                                     // 805dbc58
+    void SetButtonBmg(u8 id, u32 r5, u32 bmgId, const Text::Info *text = nullptr);                            // 805dbc8c
+    void SetOnClickHandler(const PtmfHolder_2A<Pages::FriendRoomMessages, void, PushButton &, u32> &handler); // 805dbcc4
+    void SelectInitialButton(u32 hudSlotId, u8 id);                                                           // 805dbd24
+    u32 GetSelectedButtonId() const;                                                                          // 805dbd34
+    PushButton buttons[4];                                                                                    // 0x174
+}; // total size 0xac4
 size_assert(MessageSelectControl, 0xAC4);
 
-namespace Pages {
+namespace Pages
+{
 
-class FriendJoinMgr : public Page { //ID 0x9a when joining via channel
-public:
-    static const PageId id = PAGE_FRIEND_JOIN_MGR;
-    FriendJoinMgr(); //805d796c
-    ~FriendJoinMgr() override; //805d79b0
-    PageId GetNextPage() const override; //0x10 805d7d6c
-    void OnInit() override; //0x28 805d7a18
-    void OnActivate() override; //0x30 805D7A84
-    void BeforeEntranceAnimations() override; //0x38 805D7D54
-    void AfterEntranceAnimations() override; //0x3c 805d7d58
-    void BeforeExitAnimations() override; //0x40 805d7d68
-    const ut::detail::RuntimeTypeInfo* GetRuntimeTypeInfo() const override; //0x60 805d7d74
-    ManipulatorManager manipulatorManager;
-    PageId nextPage; //0x54
-}; //0x58
-class FriendRoomWaiting : public Page { //ID 0x9b
-public:
-    static const PageId id = PAGE_FRIEND_ROOM_WAITING;
-    FriendRoomWaiting(); //805dd330
-    ~FriendRoomWaiting(); //805dd38c vtable 808b8df8
-    PageId GetNextPage() const override; //0x10 805de844
-    int IsHomeMenuWorking() const  override; //0x14 805de84c
-    void OnInit() override; //0x28 805dd418
-    void OnActivate() override; //0x30 805dd5ac
-    void OnDeactivate() override; //0x34 805dd724
-    void BeforeEntranceAnimations() override; //0x38 805dd734
-    void BeforeExitAnimations() override; //0x40 805dd7c0
-    void AfterControlUpdate() override; //0x4c 805dd7c4
-    void OnResume() override; //0x54 805ddcc8
-    const ut::detail::RuntimeTypeInfo* GetRuntimeTypeInfo() const override; //0x60 805de854
-    void StartRoom(); //805de090 resets SectionParams, sets initial countdown, goes to character select etc..
-    ManipulatorManager manipulatorManager; //0x44
-    MatchingMessageWindow messageWindow; //0x54
-    CountDownTimerControl countdownControl; //0x1c8
-    CountDown countdown; //0x344
-    u8 unknown_0x350[0x360 - 0x350];
-    PageId nextPageId;
-};
-size_assert(FriendRoomWaiting, 0x364);
+    class FriendJoinMgr : public Page
+    { // ID 0x9a when joining via channel
+    public:
+        static const PageId id = PAGE_FRIEND_JOIN_MGR;
+        FriendJoinMgr();                                                        // 805d796c
+        ~FriendJoinMgr() override;                                              // 805d79b0
+        PageId GetNextPage() const override;                                    // 0x10 805d7d6c
+        void OnInit() override;                                                 // 0x28 805d7a18
+        void OnActivate() override;                                             // 0x30 805D7A84
+        void BeforeEntranceAnimations() override;                               // 0x38 805D7D54
+        void AfterEntranceAnimations() override;                                // 0x3c 805d7d58
+        void BeforeExitAnimations() override;                                   // 0x40 805d7d68
+        const ut::detail::RuntimeTypeInfo *GetRuntimeTypeInfo() const override; // 0x60 805d7d74
+        ManipulatorManager manipulatorManager;
+        PageId nextPage; // 0x54
+    }; // 0x58
+    class FriendRoomWaiting : public Page
+    { // ID 0x9b
+    public:
+        static const PageId id = PAGE_FRIEND_ROOM_WAITING;
+        FriendRoomWaiting();                                                    // 805dd330
+        ~FriendRoomWaiting();                                                   // 805dd38c vtable 808b8df8
+        PageId GetNextPage() const override;                                    // 0x10 805de844
+        int IsHomeMenuWorking() const override;                                 // 0x14 805de84c
+        void OnInit() override;                                                 // 0x28 805dd418
+        void OnActivate() override;                                             // 0x30 805dd5ac
+        void OnDeactivate() override;                                           // 0x34 805dd724
+        void BeforeEntranceAnimations() override;                               // 0x38 805dd734
+        void BeforeExitAnimations() override;                                   // 0x40 805dd7c0
+        void AfterControlUpdate() override;                                     // 0x4c 805dd7c4
+        void OnResume() override;                                               // 0x54 805ddcc8
+        const ut::detail::RuntimeTypeInfo *GetRuntimeTypeInfo() const override; // 0x60 805de854
+        void StartRoom();                                                       // 805de090 resets SectionParams, sets initial countdown, goes to character select etc..
+        ManipulatorManager manipulatorManager;                                  // 0x44
+        MatchingMessageWindow messageWindow;                                    // 0x54
+        CountDownTimerControl countdownControl;                                 // 0x1c8
+        CountDown countdown;                                                    // 0x344
+        u8 unknown_0x350[0x360 - 0x350];
+        PageId nextPageId;
+    };
+    size_assert(FriendRoomWaiting, 0x364);
 
-class FriendRoomManager : public Page { //ID 0x9c
-public:
-    static const PageId id = PAGE_FRIEND_ROOM_MANAGER;
-    FriendRoomManager(); //805d9b38
-    ~FriendRoomManager() override; //805d9bcc vtable 808b8f2c
-    void OnInit() override; //0x28 805d9c74
-    void OnActivate() override; //0x30 805d9db0
-    void OnDeactivate() override; //0x34 805da0f4
-    void AfterEntranceAnimations() override; //0x3c 805d9f20
-    void BeforeExitAnimations() override; //0x40 805da028
-    void AfterControlUpdate() override; //0x4c 805da140
-    const ut::detail::RuntimeTypeInfo* GetRuntimeTypeInfo() const override; //0x60 805de878
-    static u32 GetMessageBmg(const RKNet::ROOMPacket& packet, u32 r4); //805dacb0
-    void SetToSendPacket(const RKNet::ROOMPacket& packet); //805dae30
-    void SetPacket(const RKNet::ROOMPacket& packet, u8 id); //805dae58
+    class FriendRoomManager : public Page
+    { // ID 0x9c
+    public:
+        static const PageId id = PAGE_FRIEND_ROOM_MANAGER;
+        FriendRoomManager();                                                    // 805d9b38
+        ~FriendRoomManager() override;                                          // 805d9bcc vtable 808b8f2c
+        void OnInit() override;                                                 // 0x28 805d9c74
+        void OnActivate() override;                                             // 0x30 805d9db0
+        void OnDeactivate() override;                                           // 0x34 805da0f4
+        void AfterEntranceAnimations() override;                                // 0x3c 805d9f20
+        void BeforeExitAnimations() override;                                   // 0x40 805da028
+        void AfterControlUpdate() override;                                     // 0x4c 805da140
+        const ut::detail::RuntimeTypeInfo *GetRuntimeTypeInfo() const override; // 0x60 805de878
+        static u32 GetMessageBmg(const RKNet::ROOMPacket &packet, u32 r4);      // 805dacb0
+        void SetToSendPacket(const RKNet::ROOMPacket &packet);                  // 805dae30
+        void SetPacket(const RKNet::ROOMPacket &packet, u8 id);                 // 805dae58
 
-    ManipulatorManager manipulatorManager; //0x44
-    CtrlMenuPageTitleText titleText; //0x54
-    FriendMatchingPlayer miiIcons[24]; //0x1c8 work by pairs of 2, normal player and guest
-    BusySymbol busySymbol; //0x28C8
-    u32 unknown_0x2A3C;
-    bool friendRoomIsEnding; //0x2a40 either by leaving/a gp starting, leads to the globe animation
-    u8 padding[3];
-    MiiGroup miiGroup; //0x2a44
-    u8 aidsBelongingToPlayerIds[12]; //0x2adc
-    u32 playerCount; //0x2ae8
-    u32 waitingDuration; //0x2aec at 3600 frames something happens with the globe (reset?)
-    bool isWaiting; //0x2af0 if true, busySymbol is made visible
-    u8 unknown_0x2af1[0x2af4 - 0x2af1];
-    u32 startedGameMode; // 0: VS, 1: Team VS, 2: Coin Runners, 3: Balloon Battle
-    u8 lastMessageId; //0x2af8 1 to 4 
-    u8 unknown_0x2af9[0x2b08 - 0x2af9];
-    UnkFriendRoomManager networkManager; //0x2b08
-}; //0x2c68
-size_assert(FriendRoomManager, 0x2c68);
+        ManipulatorManager manipulatorManager; // 0x44
+        CtrlMenuPageTitleText titleText;       // 0x54
+        FriendMatchingPlayer miiIcons[24];     // 0x1c8 work by pairs of 2, normal player and guest
+        BusySymbol busySymbol;                 // 0x28C8
+        u32 unknown_0x2A3C;
+        bool friendRoomIsEnding; // 0x2a40 either by leaving/a gp starting, leads to the globe animation
+        u8 padding[3];
+        MiiGroup miiGroup;               // 0x2a44
+        u8 aidsBelongingToPlayerIds[12]; // 0x2adc
+        u32 playerCount;                 // 0x2ae8
+        u32 waitingDuration;             // 0x2aec at 3600 frames something happens with the globe (reset?)
+        bool isWaiting;                  // 0x2af0 if true, busySymbol is made visible
+        u8 unknown_0x2af1[0x2af4 - 0x2af1];
+        u32 startedGameMode; // 0: VS, 1: Team VS, 2: Coin Runners, 3: Balloon Battle
+        u8 lastMessageId;    // 0x2af8 1 to 4
+        u8 unknown_0x2af9[0x2b08 - 0x2af9];
+        UnkFriendRoomManager networkManager; // 0x2b08
+    }; // 0x2c68
+    size_assert(FriendRoomManager, 0x2c68);
 
-class FriendRoom : public Page { //ID 0x9d
-public:
-    static const PageId id = PAGE_FRIEND_ROOM;
-    FriendRoom(); //805d7f78
-    ~FriendRoom() override; //805d8160 vtable 808b8fd8
-    void OnInit() override; //0x28 805d820c
-    void OnActivate() override; //0x30 805d8444
-    void OnDeactivate() override; //0x34 805d84fc
-    void AfterControlUpdate() override; //0x4c 805d8508
-    void OnResume() override; //0x54 805d8c98
-    const ut::detail::RuntimeTypeInfo* GetRuntimeTypeInfo() const override; //0x60 805de890
-    void SetStatus(u32 status); //805d8f40
-    void OnMessagesButtonClick(PushButton& button, u32 hudSlotId); //805d8f84
-    void OnStartButtonClick(PushButton& button, u32 hudSlotId); //805d906c
-    void OnAddFriendsButtonClick(PushButton& button, u32 hudSlotId); //805d9154
-    void OnBackButtonClick(PushButton& button, u32 hudSlotId); //805d9160
-    void OnButtonSelect(PushButton& button, u32 hudSlotId); //805d92a0
-    void OnBackPress(u32 hudSlotId); //805d930c
-    PtmfHolder_2A<FriendRoom, void, PushButton&, u32> onMessagesButtonsClickHandler; //0x44 805d8f84
-    PtmfHolder_2A<FriendRoom, void, PushButton&, u32> onStartButtonClickHandler; //0x58 805d906c
-    PtmfHolder_2A<FriendRoom, void, PushButton&, u32> onAddFriendsButtonClickHandler; //0x6c 805d9154
-    PtmfHolder_2A<FriendRoom, void, PushButton&, u32> onBackButtonClickHandler; //0x80 805d9160
-    PtmfHolder_2A<FriendRoom, void, PushButton&, u32> onButtonSelectHandler; //0x94 805d92a0
-    PtmfHolder_1A<FriendRoom, void, u32> onBackPressHandler; //0xa8 805d930c
-    ControlsManipulatorManager manipulatorManager; //0xbc
-    PushButton messagesButton; //0x2e0
-    PushButton startButton; //0x534
-    PushButton addFriendsButton; //0x788
-    CtrlMenuBackButton backButton; //0x9dc
-    CtrlMenuInstructionText bottomText; //0xc40
-    u32 status; //0xdb4 0 waiting
-    u32 displayedPage; //0xdb8 0 for none, 1 for messages, 3 for start, 4 for back?
-    u32 unknown_0xDBC;
-    bool unknown_0xdc0;
-    bool hasClickedAddFriends; //0xdc1
-    u8 unknown_0xdc2[2];
-}; //total size 0xdc4
-size_assert(FriendRoom, 0xdc4);
+    class FriendRoom : public Page
+    { // ID 0x9d
+    public:
+        static const PageId id = PAGE_FRIEND_ROOM;
+        FriendRoom();                                                                      // 805d7f78
+        ~FriendRoom() override;                                                            // 805d8160 vtable 808b8fd8
+        void OnInit() override;                                                            // 0x28 805d820c
+        void OnActivate() override;                                                        // 0x30 805d8444
+        void OnDeactivate() override;                                                      // 0x34 805d84fc
+        void AfterControlUpdate() override;                                                // 0x4c 805d8508
+        void OnResume() override;                                                          // 0x54 805d8c98
+        const ut::detail::RuntimeTypeInfo *GetRuntimeTypeInfo() const override;            // 0x60 805de890
+        void SetStatus(u32 status);                                                        // 805d8f40
+        void OnMessagesButtonClick(PushButton &button, u32 hudSlotId);                     // 805d8f84
+        void OnStartButtonClick(PushButton &button, u32 hudSlotId);                        // 805d906c
+        void OnAddFriendsButtonClick(PushButton &button, u32 hudSlotId);                   // 805d9154
+        void OnBackButtonClick(PushButton &button, u32 hudSlotId);                         // 805d9160
+        void OnButtonSelect(PushButton &button, u32 hudSlotId);                            // 805d92a0
+        void OnBackPress(u32 hudSlotId);                                                   // 805d930c
+        PtmfHolder_2A<FriendRoom, void, PushButton &, u32> onMessagesButtonsClickHandler;  // 0x44 805d8f84
+        PtmfHolder_2A<FriendRoom, void, PushButton &, u32> onStartButtonClickHandler;      // 0x58 805d906c
+        PtmfHolder_2A<FriendRoom, void, PushButton &, u32> onAddFriendsButtonClickHandler; // 0x6c 805d9154
+        PtmfHolder_2A<FriendRoom, void, PushButton &, u32> onBackButtonClickHandler;       // 0x80 805d9160
+        PtmfHolder_2A<FriendRoom, void, PushButton &, u32> onButtonSelectHandler;          // 0x94 805d92a0
+        PtmfHolder_1A<FriendRoom, void, u32> onBackPressHandler;                           // 0xa8 805d930c
+        ControlsManipulatorManager manipulatorManager;                                     // 0xbc
+        PushButton messagesButton;                                                         // 0x2e0
+        PushButton startButton;                                                            // 0x534
+        PushButton addFriendsButton;                                                       // 0x788
+        CtrlMenuBackButton backButton;                                                     // 0x9dc
+        CtrlMenuInstructionText bottomText;                                                // 0xc40
+        u32 status;                                                                        // 0xdb4 0 waiting
+        u32 displayedPage;                                                                 // 0xdb8 0 for none, 1 for messages, 3 for start, 4 for back?
+        u32 unknown_0xDBC;
+        bool unknown_0xdc0;
+        bool hasClickedAddFriends; // 0xdc1
+        u8 unknown_0xdc2[2];
+    }; // total size 0xdc4
+    size_assert(FriendRoom, 0xdc4);
 
-class FriendRoomMessages;
+    class FriendRoomMessages;
 
-class FriendRoomMessages : public Page { //ID 0x9e
-public:
-    static const PageId id = PAGE_FRIEND_ROOM_MESSAGES;
-    FriendRoomMessages(); //805dbd94
-    ~FriendRoomMessages() override; //805dc034 vtable 808b8e5c
-    void OnInit() override; //0x28 805dc104
-    void OnActivate() override; //0x30 805dc378
-    void OnDeactivate() override; //0x34 805dc71c
-    void BeforeControlUpdate() override; //0x48 805dc7b8
-    const ut::detail::RuntimeTypeInfo* GetRuntimeTypeInfo() const override; //0x60 805de860
-    void UpdateMessages(); //805dcab4
-    void OnMessageButtonClick(PushButton& button, u32 hudSlotId); //805dcc70
-    void OnModeButtonClick(PushButton& button, u32 hudSlotId); //805dcd78
-    void OnAddFriendsButtonClick(PushButton& button, u32 hudSlotId); //805dce80
-    void OnRightArrowPress(SheetSelectControlScaleFade* control, u32 hudSlotId); //805dd0c8
-    void OnLeftArrowPress(SheetSelectControlScaleFade* control, u32 hudSlotId); //805dd1d4
-    void OnBackButtonClick(CtrlMenuBackButton* backButton, u32 hudSlotId); //805dd2dc
-    void OnBackPress(u32 hudSlotId);  //805dd318
-    void End(); //805dca9c sets animLength and isEnding
-    PtmfHolder_2A<FriendRoomMessages, void, PushButton&, u32> onMessageButtonClickHandler; //0x44 805dcc70
-    PtmfHolder_2A<FriendRoomMessages, void, PushButton&, u32> onModeButtonClickHandler; //0x58 805dcd78
-    PtmfHolder_2A<FriendRoomMessages, void, PushButton&, u32> onAddFriendsButtonClickHandler; //0x6c 805dce80
-    PtmfHolder_2A<Page, void, SheetSelectControlScaleFade&, u32> onRightArrowPressHandler; //0x80 805dd0c8
-    PtmfHolder_2A<Page, void, SheetSelectControlScaleFade&, u32> onLeftArrowPressHandler; //0x94 805dd1d4
-    PtmfHolder_2A<FriendRoomMessages, void, CtrlMenuBackButton&, u32> onBackButtonClick; //0xa8 805dd2dc
-    PtmfHolder_1A<Page, void, u32> onBackPress; //0xbc 805dd318
-    ControlsManipulatorManager manipulatorManager; //0xd0
-    LayoutUIControlScaleFade messageBase; //0x2f4
-    MessageSelectControl messages[2]; //0x468 one for the purple, the other the blue?
-    SheetSelectControlScaleFade sheetSelect; //0x19f0
-    LayoutUIControlScaleFade pageNumber; //0x1f28
-    LayoutUIControl obiBottom; //0x209c
-    CtrlMenuBackButton backButton; //0x2210
-    MessageSelectControl* messagesPtrs[2]; //0x2474
-    u32 location; //0x247c messages = 0, mode selection = 1, add friends = 2
-    u32 msgCount; //0x2480
-    u32 pageCount; //0x2484
-    u32 curPageIdx; //0x2488
-    bool isEnding; //0x248c
-    u8 padding[3];
-    float animLength; //0x2490
-    MiiGroup miiGroup; //0x2494
-    u8 unknown_0x252c[0x2680 - 0x252c]; //0x252c
+    class FriendRoomMessages : public Page
+    { // ID 0x9e
+    public:
+        static const PageId id = PAGE_FRIEND_ROOM_MESSAGES;
+        FriendRoomMessages();                                                                      // 805dbd94
+        ~FriendRoomMessages() override;                                                            // 805dc034 vtable 808b8e5c
+        void OnInit() override;                                                                    // 0x28 805dc104
+        void OnActivate() override;                                                                // 0x30 805dc378
+        void OnDeactivate() override;                                                              // 0x34 805dc71c
+        void BeforeControlUpdate() override;                                                       // 0x48 805dc7b8
+        const ut::detail::RuntimeTypeInfo *GetRuntimeTypeInfo() const override;                    // 0x60 805de860
+        void UpdateMessages();                                                                     // 805dcab4
+        void OnMessageButtonClick(PushButton &button, u32 hudSlotId);                              // 805dcc70
+        void OnModeButtonClick(PushButton &button, u32 hudSlotId);                                 // 805dcd78
+        void OnAddFriendsButtonClick(PushButton &button, u32 hudSlotId);                           // 805dce80
+        void OnRightArrowPress(SheetSelectControlScaleFade *control, u32 hudSlotId);               // 805dd0c8
+        void OnLeftArrowPress(SheetSelectControlScaleFade *control, u32 hudSlotId);                // 805dd1d4
+        void OnBackButtonClick(CtrlMenuBackButton *backButton, u32 hudSlotId);                     // 805dd2dc
+        void OnBackPress(u32 hudSlotId);                                                           // 805dd318
+        void End();                                                                                // 805dca9c sets animLength and isEnding
+        PtmfHolder_2A<FriendRoomMessages, void, PushButton &, u32> onMessageButtonClickHandler;    // 0x44 805dcc70
+        PtmfHolder_2A<FriendRoomMessages, void, PushButton &, u32> onModeButtonClickHandler;       // 0x58 805dcd78
+        PtmfHolder_2A<FriendRoomMessages, void, PushButton &, u32> onAddFriendsButtonClickHandler; // 0x6c 805dce80
+        PtmfHolder_2A<Page, void, SheetSelectControlScaleFade &, u32> onRightArrowPressHandler;    // 0x80 805dd0c8
+        PtmfHolder_2A<Page, void, SheetSelectControlScaleFade &, u32> onLeftArrowPressHandler;     // 0x94 805dd1d4
+        PtmfHolder_2A<FriendRoomMessages, void, CtrlMenuBackButton &, u32> onBackButtonClick;      // 0xa8 805dd2dc
+        PtmfHolder_1A<Page, void, u32> onBackPress;                                                // 0xbc 805dd318
+        ControlsManipulatorManager manipulatorManager;                                             // 0xd0
+        LayoutUIControlScaleFade messageBase;                                                      // 0x2f4
+        MessageSelectControl messages[2];                                                          // 0x468 one for the purple, the other the blue?
+        SheetSelectControlScaleFade sheetSelect;                                                   // 0x19f0
+        LayoutUIControlScaleFade pageNumber;                                                       // 0x1f28
+        LayoutUIControl obiBottom;                                                                 // 0x209c
+        CtrlMenuBackButton backButton;                                                             // 0x2210
+        MessageSelectControl *messagesPtrs[2];                                                     // 0x2474
+        u32 location;                                                                              // 0x247c messages = 0, mode selection = 1, add friends = 2
+        u32 msgCount;                                                                              // 0x2480
+        u32 pageCount;                                                                             // 0x2484
+        u32 curPageIdx;                                                                            // 0x2488
+        bool isEnding;                                                                             // 0x248c
+        u8 padding[3];
+        float animLength;                   // 0x2490
+        MiiGroup miiGroup;                  // 0x2494
+        u8 unknown_0x252c[0x2680 - 0x252c]; // 0x252c
 
-}; //total size 0x2680
-size_assert(FriendRoomMessages, 0x2680);
-}//namespace Pages
+    }; // total size 0x2680
+    size_assert(FriendRoomMessages, 0x2680);
+} // namespace Pages
 #endif

--- a/GameSource/MarioKartWii/UI/Section/SectionParams.hpp
+++ b/GameSource/MarioKartWii/UI/Section/SectionParams.hpp
@@ -2,7 +2,7 @@
 #define _SECTIONPARAMS_
 #include <kamek.hpp>
 #include <MarioKartWii/System/Identifiers.hpp>
-#include <MarioKartWii/MII/MiiGroup.hpp>
+#include <MarioKartWii/Mii/MiiGroup.hpp>
 
 struct PlayerCombo {
     CharacterId selCharacter;

--- a/GameSource/core/egg/Audio/ArcPlayer.hpp
+++ b/GameSource/core/egg/Audio/ArcPlayer.hpp
@@ -3,57 +3,58 @@
 
 #include <types.hpp>
 #include <core/nw4r/snd.hpp>
-#include <core/rvl/os/OSthread.hpp>
-#include <core/rvl/os/OSmessage.hpp>
+#include <core/rvl/OS/OSthread.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
 #include <core/rvl/arc/arc.hpp>
 #include <core/egg/mem/Heap.hpp>
 
+namespace EGG
+{
+    using namespace nw4r;
 
-namespace EGG {
-using namespace nw4r;
+    class ArcPlayer
+    {
+    public:
+        ArcPlayer(snd::SoundArchivePlayer *soundArchivePlayer, snd::SoundHeap *heap);                         // 80210590
+        virtual ~ArcPlayer();                                                                                 // 0x8 80210624 vtable 802a2730
+        virtual void *OpenArchive(const char *filePath, snd::SoundHeap *heap, u32 type, ARC::Handle *handle); // 0xc 802106b8 type 0 = dvd, 1 nand, 2 memory
+        virtual void *OpenDVDArchive(const char *filePath, snd::SoundHeap *heap);                             // 0x10 80210748
+        virtual void *OpenNANDArchive(const char *filePath, snd::SoundHeap *heap);                            // 0x14 802108bc
+        virtual void *OpenMemoryArchive(const char *filePath, ARC::Handle *handle, snd::SoundHeap *heap);     // 0x18 80210a30
+        virtual int SetupMemoryArchive(const void *soundArchiveData, snd::SoundHeap *heap);                   // 0x1c 80210bd8
+        virtual int SetupMemoryArchive(const void *soundArchiveData, snd::SoundHeap *heap, s32 r6);           // 0x20 80211048
+        virtual void CloseArchive();                                                                          // 0x24 80210ce4
+        virtual bool LoadGroup(u32 groupId, snd::SoundHeap *heap, u32 loadBlockSize);                         // 0x28 80210d70
+        virtual bool LoadGroup(int groupId, snd::SoundHeap *heap, u32 loadBlockSize);                         // 0x2c 80210e3c
+        virtual bool LoadGroup(const char *groupName, snd::SoundHeap *heap, u32 loadBlockSize);               // 0x30 80210f08
+        virtual void Calc();                                                                                  // 80210fd4
+        virtual bool StartSound(snd::SoundHandle *handle, u32 soundId);                                       // 802110fc
+        virtual bool StartSound(snd::SoundHandle *handle, ul soundId);                                        // 802110c8
+        virtual bool StartSound(snd::SoundHandle *handle, const char *string);                                // 80211058
+        virtual bool PrepareSound(snd::SoundHandle *handle, u32);                                             // 802111d4
+        virtual bool PrepareSound(snd::SoundHandle *handle, ul);                                              // 802111a0
+        virtual bool PrepareSound(snd::SoundHandle *handle, const char *string);                              // 80211130
+        virtual bool HoldSound(snd::SoundHandle *handle, u32);                                                // 802112ac
+        virtual bool HoldSound(snd::SoundHandle *handle, ul);                                                 // 80211278
+        virtual bool HoldSound(snd::SoundHandle *handle, const char *string);                                 // 80211208
+        bool SetStreamBlocks(u32 count);                                                                      // 80210698
+        void StopAllSound();                                                                                  // 80210fec
 
-class ArcPlayer {
-public:
-    ArcPlayer(snd::SoundArchivePlayer* soundArchivePlayer, snd::SoundHeap* heap); //80210590
-    virtual ~ArcPlayer(); //0x8 80210624 vtable 802a2730
-    virtual void* OpenArchive(const char* filePath, snd::SoundHeap* heap, u32 type, ARC::Handle* handle); //0xc 802106b8 type 0 = dvd, 1 nand, 2 memory
-    virtual void* OpenDVDArchive(const char* filePath, snd::SoundHeap* heap); //0x10 80210748
-    virtual void* OpenNANDArchive(const char* filePath, snd::SoundHeap* heap); //0x14 802108bc
-    virtual void* OpenMemoryArchive(const char* filePath, ARC::Handle* handle, snd::SoundHeap* heap); //0x18 80210a30
-    virtual int SetupMemoryArchive(const void* soundArchiveData, snd::SoundHeap* heap); //0x1c 80210bd8
-    virtual int SetupMemoryArchive(const void* soundArchiveData, snd::SoundHeap* heap, s32 r6); //0x20 80211048
-    virtual void CloseArchive(); //0x24 80210ce4
-    virtual bool LoadGroup(u32 groupId, snd::SoundHeap* heap, u32 loadBlockSize); //0x28 80210d70
-    virtual bool LoadGroup(int groupId, snd::SoundHeap* heap, u32 loadBlockSize); //0x2c 80210e3c
-    virtual bool LoadGroup(const char* groupName, snd::SoundHeap* heap, u32 loadBlockSize); //0x30 80210f08
-    virtual void Calc(); //80210fd4
-    virtual bool StartSound(snd::SoundHandle* handle, u32 soundId); //802110fc
-    virtual bool StartSound(snd::SoundHandle* handle, ul  soundId); //802110c8
-    virtual bool StartSound(snd::SoundHandle* handle, const char* string); //80211058
-    virtual bool PrepareSound(snd::SoundHandle* handle, u32); //802111d4
-    virtual bool PrepareSound(snd::SoundHandle* handle, ul); //802111a0
-    virtual bool PrepareSound(snd::SoundHandle* handle, const char* string); //80211130
-    virtual bool HoldSound(snd::SoundHandle* handle, u32); //802112ac
-    virtual bool HoldSound(snd::SoundHandle* handle, ul); //80211278
-    virtual bool HoldSound(snd::SoundHandle* handle, const char* string); //80211208
-    bool SetStreamBlocks(u32 count); //80210698
-    void StopAllSound(); //80210fec
+        bool isOpen;
+        u8 unknown_0x5;
+        u8 unknown_0x6[2];
+        snd::DVDSoundArchive *dvdSoundArchiveptr; // ptr to the instance right below
+        snd::DVDSoundArchive dvdSoundArchive;
+        snd::NandSoundArchive nandSoundArchive;      // 0x198
+        snd::MemorySoundArchive memorySoundArchive;  // 0x374
+        snd::SoundArchivePlayer *soundArchivePlayer; // 0x4c4 + f8 (offset in simpleadioMgr) = 5bc
+        snd::SoundHeap *heap;
+        u32 unknown_0x4C;
+        u32 streamBlocks;
+        void *brsarINFO; // 0x4d4
+    }; // total size 0x4D8
+    size_assert(ArcPlayer, 0x4D8);
 
-    bool isOpen;
-    u8 unknown_0x5;
-    u8 unknown_0x6[2];
-    snd::DVDSoundArchive* dvdSoundArchiveptr; //ptr to the instance right below
-    snd::DVDSoundArchive dvdSoundArchive;
-    snd::NandSoundArchive nandSoundArchive; //0x198
-    snd::MemorySoundArchive memorySoundArchive; //0x374
-    snd::SoundArchivePlayer* soundArchivePlayer; //0x4c4 + f8 (offset in simpleadioMgr) = 5bc
-    snd::SoundHeap* heap;
-    u32 unknown_0x4C;
-    u32 streamBlocks;
-    void* brsarINFO; //0x4d4
-}; //total size 0x4D8
-size_assert(ArcPlayer, 0x4D8);
-
-}//namespace EGG
+} // namespace EGG
 
 #endif

--- a/GameSource/core/egg/Audio/Audio3DActor.hpp
+++ b/GameSource/core/egg/Audio/Audio3DActor.hpp
@@ -3,24 +3,25 @@
 
 #include <types.hpp>
 #include <core/nw4r/snd.hpp>
-#include <core/rvl/os/OSthread.hpp>
-#include <core/rvl/os/OSmessage.hpp>
+#include <core/rvl/OS/OSthread.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
 #include <core/rvl/arc/arc.hpp>
 #include <core/egg/mem/Heap.hpp>
 
+namespace EGG
+{
+    using namespace nw4r;
 
-namespace EGG {
-using namespace nw4r;
+    class Audio3DActor : public snd::Sound3DActor
+    { // unsure what the point of this is, it doesn't seem to add anything to 3DActors
+    public:
+        Audio3DActor(snd::SoundArchivePlayer &soundArchivePlayer, snd::Sound3DManager &sound3DManager); // 802104ec
+        // SoundActor vtable 802a2700
+        ~Audio3DActor() override; // 80210530
+        // AmbientArgUpdateCallback vtable 802a271c
+        //~Audio3DActor thunk 80210588 func 8021053
+    }; // total size 0x80
 
-class Audio3DActor : public snd::Sound3DActor { //unsure what the point of this is, it doesn't seem to add anything to 3DActors
-public:
-    Audio3DActor(snd::SoundArchivePlayer& soundArchivePlayer, snd::Sound3DManager& sound3DManager); //802104ec
-    //SoundActor vtable 802a2700
-    ~Audio3DActor() override; //80210530
-    //AmbientArgUpdateCallback vtable 802a271c
-    //~Audio3DActor thunk 80210588 func 8021053
-}; //total size 0x80
-
-}//namespace EGG
+} // namespace EGG
 
 #endif

--- a/GameSource/core/egg/Audio/AudioFx.hpp
+++ b/GameSource/core/egg/Audio/AudioFx.hpp
@@ -3,39 +3,41 @@
 
 #include <types.hpp>
 #include <core/nw4r/snd.hpp>
-#include <core/rvl/os/OSthread.hpp>
-#include <core/rvl/os/OSmessage.hpp>
+#include <core/rvl/OS/OSthread.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
 #include <core/rvl/arc/arc.hpp>
 #include <core/egg/mem/Heap.hpp>
 
+namespace EGG
+{
+    using namespace nw4r;
 
-namespace EGG {
-using namespace nw4r;
+    class AudioFx
+    {
+    public:
+        AudioFx();                                                                  // 80211a14
+        ~AudioFx();                                                                 // 80211a28
+        bool CreateFxReverb(u32 r4, nw4r::snd::detail::FxReverbStdParam, u32 type); // 80212748
+        bool CreateFx(u32 type, void *fxParam);                                     // 80211a94
+        snd::FxReverbStdDpl2 *fxReverb;
+        u32 unknown_0x4;
+        nw4r::snd::detail::FxReverbStdParam *reverbHiParam;
+        u32 type;
+        Heap *heap;
+        UnkType *array_0x14;
+    }; // total size 0x18
 
-class AudioFx {
-public:
-    AudioFx(); //80211a14
-    ~AudioFx(); //80211a28
-    bool CreateFxReverb(u32 r4, nw4r::snd::detail::FxReverbStdParam, u32 type); //80212748
-    bool CreateFx(u32 type, void* fxParam); //80211a94
-    snd::FxReverbStdDpl2* fxReverb;
-    u32 unknown_0x4;
-    nw4r::snd::detail::FxReverbStdParam* reverbHiParam;
-    u32 type;
-    Heap* heap;
-    UnkType* array_0x14;
-}; //total size 0x18
+    class AudioFxMgr
+    {
+    public:
+        AudioFxMgr();                                           // 80211c14
+        ~AudioFxMgr();                                          // 80211c74
+        bool InitalizeFx(snd::SoundHeap *heap, u32 *sizeArray); // 80211cd8
+        bool CreateFxReverb(snd::AuxBus bus);                   // 80211d84
+        void ClearFx(snd::AuxBus bus, int fadeOutFrames);       // 80211d94
+        AudioFx array[3];
+    }; // total size 0x48
 
-class AudioFxMgr {
-public:
-    AudioFxMgr(); //80211c14
-    ~AudioFxMgr(); //80211c74
-    bool InitalizeFx(snd::SoundHeap* heap, u32* sizeArray); //80211cd8
-    bool CreateFxReverb(snd::AuxBus bus); //80211d84
-    void ClearFx(snd::AuxBus bus, int fadeOutFrames); //80211d94
-    AudioFx array[3];
-}; //total size 0x48
-
-}//namespace EGG
+} // namespace EGG
 
 #endif

--- a/GameSource/core/egg/Audio/AudioHeap.hpp
+++ b/GameSource/core/egg/Audio/AudioHeap.hpp
@@ -3,37 +3,37 @@
 
 #include <types.hpp>
 #include <core/nw4r/snd.hpp>
-#include <core/rvl/os/OSthread.hpp>
-#include <core/rvl/os/OSmessage.hpp>
+#include <core/rvl/OS/OSthread.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
 #include <core/rvl/arc/arc.hpp>
 #include <core/egg/mem/Heap.hpp>
 
+namespace EGG
+{
+    using namespace nw4r;
 
-namespace EGG {
-using namespace nw4r;
+    class SoundMessages
+    {
+        OS::MessageQueue messageQueue;
+        OS::Message msgBuffer[4]; // similar to snd::SoundThread
+    }; // 0x30
+    size_assert(SoundMessages, 0x30);
 
-class SoundMessages {
-    OS::MessageQueue messageQueue;
-    OS::Message msgBuffer[4]; //similar to snd::SoundThread
-}; //0x30
-size_assert(SoundMessages, 0x30);
+    class SoundHeapMgr
+    {
+    public:
+        virtual bool LoadState(u32 level);                         // 80211874 vtable 802a2950
+        virtual int GetCurrentLevel();                             // 8021174c
+        virtual void SaveState();                                  // 802117a0
+        void Initialize(EGG::Heap *heap, u32 heapSize);            // 8021318c
+        void CreateSoundHeap(EGG::Allocator *allocator, u32 size); // 802131e8
+        void DestroySoundHeap();                                   // 80213258
+        snd::SoundHeap heap;                                       // 0x4
+        u8 unknown_0x30[0x60 - 0x30];
+        SoundMessages messages[3]; // 0x60
+    };
+    size_assert(SoundHeapMgr, 0xF0);
 
-class SoundHeapMgr {
-public:
-    virtual bool LoadState(u32 level); //80211874 vtable 802a2950
-    virtual int GetCurrentLevel(); //8021174c
-    virtual void SaveState(); //802117a0
-    void Initialize(EGG::Heap* heap, u32 heapSize); //8021318c
-    void CreateSoundHeap(EGG::Allocator* allocator, u32 size); //802131e8
-    void DestroySoundHeap(); //80213258
-    snd::SoundHeap heap; //0x4
-    u8 unknown_0x30[0x60 - 0x30];
-    SoundMessages messages[3]; //0x60
-};
-size_assert(SoundHeapMgr, 0xF0);
-
-
-
-}//namespace EGG
+} // namespace EGG
 
 #endif

--- a/GameSource/core/egg/Audio/AudioMgr.hpp
+++ b/GameSource/core/egg/Audio/AudioMgr.hpp
@@ -3,116 +3,125 @@
 
 #include <types.hpp>
 #include <core/nw4r/snd.hpp>
-#include <core/rvl/os/OSthread.hpp>
-#include <core/rvl/os/OSmessage.hpp>
+#include <core/rvl/OS/OSthread.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
 #include <core/rvl/arc/arc.hpp>
 #include <core/egg/mem/Heap.hpp>
 #include <core/egg/Audio/ArcPlayer.hpp>
 #include <core/egg/Audio/AudioHeap.hpp>
 #include <core/egg/Audio/AudioFx.hpp>
 
-namespace EGG {
-using namespace nw4r;
+namespace EGG
+{
+    using namespace nw4r;
 
-class AudioSystem {
-public:
-    AudioSystem(); //80213cc8
-    ~AudioSystem(); //80213ce4
-    void Calc(); //80213d24
-    float unknown_0x0;
-    u32 unknown_0x4[2];
-}; //total size 0xC
-size_assert(AudioSystem, 0xC);
-
-class IAudioMgr {
-public:
-    class Arg {
+    class AudioSystem
+    {
     public:
-    };
-    virtual void Initialize(Arg* args); //80213690 vtable 802a2910
-    virtual void Calc() = 0;
-    bool isInitialized;
-    u8 padding[3];
-};
+        AudioSystem();  // 80213cc8
+        ~AudioSystem(); // 80213ce4
+        void Calc();    // 80213d24
+        float unknown_0x0;
+        u32 unknown_0x4[2];
+    }; // total size 0xC
+    size_assert(AudioSystem, 0xC);
 
-class SoundArchivePlayerEGG : public snd::SoundArchivePlayer { //yes, that's the official name
-public:
-    //SoundArchivePlayer
-    //callback vtable 802a2920
-    ~SoundArchivePlayerEGG() override; //8021337c
-    //soundstartable vtable 802a2934
-    //~SoundArchivePlayerEGG() override; //thunk 8021369c func 8021337c
-    StartResult detail_SetupSound(snd::SoundHandle* handle, u32 id, bool r6, snd::SoundArchive::SoundInfo* soundInfo) override; //thunk 80213694 func 8021365c
-};
-size_assert(SoundArchivePlayerEGG, 0xe0);
-
-class SimpleAudioMgr : public IAudioMgr, public SoundHeapMgr, public ArcPlayer {
-public:
-    class SimpleAudioMgrArg : public Arg {
+    class IAudioMgr
+    {
     public:
-        SimpleAudioMgrArg(); //80213260
-        Heap* heap;
-        u32 unknown_0x4;
-        snd::SoundSystem::SoundSystemParam params; //0x8
-        u32 heapSize;
-        u32 streamBlocksCount; //0x1c
+        class Arg
+        {
+        public:
+        };
+        virtual void Initialize(Arg *args); // 80213690 vtable 802a2910
+        virtual void Calc() = 0;
+        bool isInitialized;
+        u8 padding[3];
     };
 
-    SimpleAudioMgr(); //8021329c
-    //IAudioMgr vtable 802a2868
-    void Initialize(Arg* args) override; //8021347c 
-    void Calc() override; //802135d0
-    //snd::SoundHeapMgr vtable 802a2878
-    //ArcPlayer vtable 802a288c at 0xf8
-    ~SimpleAudioMgr() override; //thunk 802136a4 function 802133d4
-    void* OpenDVDArchive(const char* filePath, snd::SoundHeap* heap) override; //thunk 802119fc function 8021361c
-    void* OpenNANDArchive(const char* filePath, snd::SoundHeap* heap) override; //thunk 802119f4 function 80213624
-    void* OpenMemoryArchive(const char* filePath, ARC::Handle* handle, snd::SoundHeap* heap) override; //thunk 802119ec function 8021362c
-    int SetupMemoryArchive(const void* soundArchiveData, snd::SoundHeap* heap) override; //thunk 802119a4 function 80213634
-    void CloseArchive() override; //thunk 8021199c function 8021363c
-    //void Calc() override; //thunk 802119b4 func 802135d0
-    AudioSystem audioSystem; //0x5d0
-    SoundArchivePlayerEGG archivePlayer; //0x5dc 
+    class SoundArchivePlayerEGG : public snd::SoundArchivePlayer
+    { // yes, that's the official name
+    public:
+        // SoundArchivePlayer
+        // callback vtable 802a2920
+        ~SoundArchivePlayerEGG() override; // 8021337c
+        // soundstartable vtable 802a2934
+        //~SoundArchivePlayerEGG() override; //thunk 8021369c func 8021337c
+        StartResult detail_SetupSound(snd::SoundHandle *handle, u32 id, bool r6, snd::SoundArchive::SoundInfo *soundInfo) override; // thunk 80213694 func 8021365c
+    };
+    size_assert(SoundArchivePlayerEGG, 0xe0);
 
-}; //total size 0x6bc
-size_assert(SimpleAudioMgr, 0x6bc);
+    class SimpleAudioMgr : public IAudioMgr, public SoundHeapMgr, public ArcPlayer
+    {
+    public:
+        class SimpleAudioMgrArg : public Arg
+        {
+        public:
+            SimpleAudioMgrArg(); // 80213260
+            Heap *heap;
+            u32 unknown_0x4;
+            snd::SoundSystem::SoundSystemParam params; // 0x8
+            u32 heapSize;
+            u32 streamBlocksCount; // 0x1c
+        };
 
-class ExpAudioMgr : public SimpleAudioMgr {
-public:
-    static SoundArchivePlayerEGG* audioArchivePlayer; //80386d98
-    static snd::Sound3DManager* sound3DManagerInstance; //80386d9c
-    class ExpAudioMgrArg : public SimpleAudioMgrArg {
-        ExpAudioMgrArg();  //80211460
-        u32 maxPriorityReduction;
-        float interiorSizes[4]; //0x24
-        float maxVolumeDistances[4]; //0x34
-        float unitDistances[4]; //0x44
-        float panRange; //0x54
-        float sonicVelocity; //0x58
-        u32 fxSizeArray[3]; //0x5c
-    }; //0x68
-    ExpAudioMgr(); //80211320
-    //IAudioMgr vtable 802a2790
-    void Initialize(IAudioMgr::Arg* args) override; //802114f0
-    //snd::SoundHeap vtable 802a27a0
-    bool LoadState(u32 level) override; //thunk 802119ac func 80211900
-    //ArcPlayer vtable 802a27b4
-    ~ExpAudioMgr() override; //thunk 80211a0c func 802113b8
-    void* OpenArchive(const char* filePath, snd::SoundHeap* heap, u32 type, ARC::Handle* handle) override; //thunk 80211a04 func 802115dc
-    int SetupMemoryArchive(const void* soundArchiveData, snd::SoundHeap* heap) override; //thunk 802119dc 8021167c
-    int SetupMemoryArchive(const void* soundArchiveData, snd::SoundHeap* heap, s32 r6) override; //thunk 802119e4 func 8021198c
-    void CloseArchive() override; //thunk 802119d4 func 80211718
+        SimpleAudioMgr(); // 8021329c
+        // IAudioMgr vtable 802a2868
+        void Initialize(Arg *args) override; // 8021347c
+        void Calc() override;                // 802135d0
+        // snd::SoundHeapMgr vtable 802a2878
+        // ArcPlayer vtable 802a288c at 0xf8
+        ~SimpleAudioMgr() override;                                                                        // thunk 802136a4 function 802133d4
+        void *OpenDVDArchive(const char *filePath, snd::SoundHeap *heap) override;                         // thunk 802119fc function 8021361c
+        void *OpenNANDArchive(const char *filePath, snd::SoundHeap *heap) override;                        // thunk 802119f4 function 80213624
+        void *OpenMemoryArchive(const char *filePath, ARC::Handle *handle, snd::SoundHeap *heap) override; // thunk 802119ec function 8021362c
+        int SetupMemoryArchive(const void *soundArchiveData, snd::SoundHeap *heap) override;               // thunk 802119a4 function 80213634
+        void CloseArchive() override;                                                                      // thunk 8021199c function 8021363c
+        // void Calc() override; //thunk 802119b4 func 802135d0
+        AudioSystem audioSystem;             // 0x5d0
+        SoundArchivePlayerEGG archivePlayer; // 0x5dc
 
-    //substruct from here, evidence at 8021133c
-    snd::Sound3DManager sound3DManager; //0x6bc
-    snd::Sound3DListener sound3DListener[4]; //0x6e4 one per player?
-    snd::DVDSoundArchive* dvdSoundArchive; //0x844
-    u32 unknown_0x848;
-    //end of substruct
+    }; // total size 0x6bc
+    size_assert(SimpleAudioMgr, 0x6bc);
 
-    AudioFxMgr audioFxMgr; //0x84c
-}; //total size 0x894
+    class ExpAudioMgr : public SimpleAudioMgr
+    {
+    public:
+        static SoundArchivePlayerEGG *audioArchivePlayer;   // 80386d98
+        static snd::Sound3DManager *sound3DManagerInstance; // 80386d9c
+        class ExpAudioMgrArg : public SimpleAudioMgrArg
+        {
+            ExpAudioMgrArg(); // 80211460
+            u32 maxPriorityReduction;
+            float interiorSizes[4];      // 0x24
+            float maxVolumeDistances[4]; // 0x34
+            float unitDistances[4];      // 0x44
+            float panRange;              // 0x54
+            float sonicVelocity;         // 0x58
+            u32 fxSizeArray[3];          // 0x5c
+        }; // 0x68
+        ExpAudioMgr(); // 80211320
+        // IAudioMgr vtable 802a2790
+        void Initialize(IAudioMgr::Arg *args) override; // 802114f0
+        // snd::SoundHeap vtable 802a27a0
+        bool LoadState(u32 level) override; // thunk 802119ac func 80211900
+        // ArcPlayer vtable 802a27b4
+        ~ExpAudioMgr() override;                                                                               // thunk 80211a0c func 802113b8
+        void *OpenArchive(const char *filePath, snd::SoundHeap *heap, u32 type, ARC::Handle *handle) override; // thunk 80211a04 func 802115dc
+        int SetupMemoryArchive(const void *soundArchiveData, snd::SoundHeap *heap) override;                   // thunk 802119dc 8021167c
+        int SetupMemoryArchive(const void *soundArchiveData, snd::SoundHeap *heap, s32 r6) override;           // thunk 802119e4 func 8021198c
+        void CloseArchive() override;                                                                          // thunk 802119d4 func 80211718
 
-}//namespace EGG
+        // substruct from here, evidence at 8021133c
+        snd::Sound3DManager sound3DManager;      // 0x6bc
+        snd::Sound3DListener sound3DListener[4]; // 0x6e4 one per player?
+        snd::DVDSoundArchive *dvdSoundArchive;   // 0x844
+        u32 unknown_0x848;
+        // end of substruct
+
+        AudioFxMgr audioFxMgr; // 0x84c
+    }; // total size 0x894
+
+} // namespace EGG
 
 #endif

--- a/GameSource/core/egg/Audio/AudioTrack.hpp
+++ b/GameSource/core/egg/Audio/AudioTrack.hpp
@@ -3,45 +3,48 @@
 
 #include <types.hpp>
 #include <core/nw4r/snd.hpp>
-#include <core/rvl/os/OSthread.hpp>
-#include <core/rvl/os/OSmessage.hpp>
+#include <core/rvl/OS/OSthread.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
 #include <core/rvl/arc/arc.hpp>
 #include <core/egg/mem/Heap.hpp>
 
+namespace EGG
+{
+    using namespace nw4r;
 
-namespace EGG {
-using namespace nw4r;
+    class AudioTrack;
+    struct AudioTrackCallback
+    {
+        void(*callbackFunc);
+        AudioTrack *ptr;
+    };
 
-class AudioTrack;
-struct AudioTrackCallback {
-    void(*callbackFunc);
-    AudioTrack* ptr;
-};
+    class AudioTrack
+    {
+    public:
+        AudioTrack(); // 80213e1c
+        AudioTrackCallback callback;
+        virtual void Reset();                                 // at 0x8 80213e48 vtable 802a2980
+        virtual bool Calc();                                  // 80213edc
+        void ApplyValueChange(u32 stepCount, float maxValue); // 80213e5c
+        bool ClampValue(float minValue, float maxValue);      // 80213f54
+        u32 delay;                                            // 0xC number of steps in frames
+        float maxValue;                                       // 0x10
+        float curValue;                                       // 0x14
+        float step;                                           // how much value decreases every frame
+    };
 
-class AudioTrack {
-public:
-    AudioTrack(); //80213e1c
-    AudioTrackCallback callback;
-    virtual void Reset(); //at 0x8 80213e48 vtable 802a2980
-    virtual bool Calc(); //80213edc
-    void ApplyValueChange(u32 stepCount, float maxValue); //80213e5c
-    bool ClampValue(float minValue, float maxValue); //80213f54
-    u32 delay; //0xC number of steps in frames
-    float maxValue; //0x10
-    float curValue; //0x14
-    float step; //how much value decreases every frame
-};
+    class SimpleAudioTrack : public AudioTrack
+    {
+        SimpleAudioTrack(u32 r4, snd::SoundHandle *handle);             // 80213f88
+        void Reset() override;                                          // 80213ffc vtable 802a2968
+        bool Calc() override;                                           // 802141c0
+        virtual void SetValueSmooth(u32 r4, u32 delay, float maxValue); // 80214058
+        virtual void SetValueSmoothAsync(u32 delay, float maxValue);    // 8021410c
+        snd::SoundHandle *handle;
+        u32 unknown_0x20;
+    };
 
-class SimpleAudioTrack : public AudioTrack {
-    SimpleAudioTrack(u32 r4, snd::SoundHandle* handle); //80213f88
-    void Reset() override; //80213ffc vtable 802a2968
-    bool Calc() override; //802141c0
-    virtual void SetValueSmooth(u32 r4, u32 delay, float maxValue); //80214058
-    virtual void SetValueSmoothAsync(u32 delay, float maxValue); //8021410c
-    snd::SoundHandle* handle;
-    u32 unknown_0x20;
-};
-
-}//namespace EGG
+} // namespace EGG
 
 #endif

--- a/GameSource/core/egg/Audio/AudioUtility.hpp
+++ b/GameSource/core/egg/Audio/AudioUtility.hpp
@@ -3,28 +3,31 @@
 
 #include <types.hpp>
 #include <core/nw4r/snd.hpp>
-#include <core/rvl/os/OSthread.hpp>
-#include <core/rvl/os/OSmessage.hpp>
+#include <core/rvl/OS/OSthread.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
 #include <core/rvl/arc/arc.hpp>
 #include <core/egg/mem/Heap.hpp>
 #include <core/egg/Audio/AudioMgr.hpp>
 
 using namespace nw4r;
-namespace EGG {
-namespace AudioUtility {
-namespace HBM {
+namespace EGG
+{
+    namespace AudioUtility
+    {
+        namespace HBM
+        {
 
-typedef void(*Callback)(bool); //called by enter with bool = 0, by exit with bool = 1
-extern SimpleAudioMgr* simpleAudioMgr; //80386DBC
-extern Callback cb; //80386DC4
-extern int fadeFrames; //80385F68
+            typedef void (*Callback)(bool);        // called by enter with bool = 0, by exit with bool = 1
+            extern SimpleAudioMgr *simpleAudioMgr; // 80386DBC
+            extern Callback cb;                    // 80386DC4
+            extern int fadeFrames;                 // 80385F68
 
-void init(SimpleAudioMgr* mgr, Callback cb, int fadeFrames); //80214350
-void enter(); //80214360
-void exit(bool r3); //80214490
+            void init(SimpleAudioMgr *mgr, Callback cb, int fadeFrames); // 80214350
+            void enter();                                                // 80214360
+            void exit(bool r3);                                          // 80214490
 
-}//namespace HBM
-}//namespace AudioUtility
-}//namespace EGG
+        } // namespace HBM
+    } // namespace AudioUtility
+} // namespace EGG
 
 #endif

--- a/GameSource/core/egg/DVD/DvdFile.hpp
+++ b/GameSource/core/egg/DVD/DvdFile.hpp
@@ -1,39 +1,41 @@
 #ifndef _EGGDVDFILE_
 #define _EGGDVDFILE_
 #include <types.hpp>
-#include <core/rvl/os/OSMutex.hpp>
-#include <core/rvl/os/OSMessage.hpp>
+#include <core/rvl/OS/OSMutex.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
 #include <core/rvl/dvd/dvd.hpp>
 #include <core/nw4r/ut/List.hpp>
 
-namespace EGG {
-class DvdFile {
-    static nw4r::ut::List openDvdFiles; //80384190
-    virtual ~DvdFile(); //0x8 802223a0 vtable 802a2da0
-    virtual bool open(const char* path); //0x8 802224e8
-    virtual void close(); //0x10 80222540
-    virtual void readData(void* dest, s32 length, s32 offset); //0x14 8022259c
-    virtual void writeData(const void* src, s32 length, s32 offset); //0x18 80222660
-    virtual int getFileSize() const; //0x1c 802226d0
-    virtual bool open(s32 entryNum); //0x20 80222470
-    virtual bool open2(const char* path); //80222530 calls open so idk
+namespace EGG
+{
+    class DvdFile
+    {
+        static nw4r::ut::List openDvdFiles;                              // 80384190
+        virtual ~DvdFile();                                              // 0x8 802223a0 vtable 802a2da0
+        virtual bool open(const char *path);                             // 0x8 802224e8
+        virtual void close();                                            // 0x10 80222540
+        virtual void readData(void *dest, s32 length, s32 offset);       // 0x14 8022259c
+        virtual void writeData(const void *src, s32 length, s32 offset); // 0x18 80222660
+        virtual int getFileSize() const;                                 // 0x1c 802226d0
+        virtual bool open(s32 entryNum);                                 // 0x20 80222470
+        virtual bool open2(const char *path);                            // 80222530 calls open so idk
 
-    void Initiate(); //80222408
-    void doneProcess(u32 r3, DVD::FileInfo* fileInfo); //802226bc
-    static void initialize(); //8022231c
+        void Initiate();                                   // 80222408
+        void doneProcess(u32 r3, DVD::FileInfo *fileInfo); // 802226bc
+        static void initialize();                          // 8022231c
 
-    bool isBusy; //0x4
-    u8 padding[3];
-    OS::Mutex mutex; //0x8
-    OS::Mutex mutex2; //0x20
-    u32 unknown_0x38;
-    DVD::FileInfo fileInfo; //0x3c might be file info
-    u32 unknown_0x78;
-    OS::MessageQueue msgqueue; //0x7c
-    OS::Message msg; //0x9c idk the exact type
-    u8 unknown_0xa0[0xc8 - 0xa0];
-    nw4r::ut::Link link; //0xc8
-};
-size_assert(DvdFile, 0xd0);
-}//namespace EGG
+        bool isBusy; // 0x4
+        u8 padding[3];
+        OS::Mutex mutex;  // 0x8
+        OS::Mutex mutex2; // 0x20
+        u32 unknown_0x38;
+        DVD::FileInfo fileInfo; // 0x3c might be file info
+        u32 unknown_0x78;
+        OS::MessageQueue msgqueue; // 0x7c
+        OS::Message msg;           // 0x9c idk the exact type
+        u8 unknown_0xa0[0xc8 - 0xa0];
+        nw4r::ut::Link link; // 0xc8
+    };
+    size_assert(DvdFile, 0xd0);
+} // namespace EGG
 #endif

--- a/GameSource/core/egg/System.hpp
+++ b/GameSource/core/egg/System.hpp
@@ -1,8 +1,8 @@
 #ifndef _EGGSYSTEM_
 #define _EGGSYSTEM_
 #include <types.hpp>
-#include <core/rvl/os/OSContext.hpp>
-#include <core/rvl/os/OSAlarm.hpp>
+#include <core/rvl/OS/OSContext.hpp>
+#include <core/rvl/OS/OSAlarm.hpp>
 #include <core/egg/mem/ExpHeap.hpp>
 #include <core/egg/Audio/AudioMgr.hpp>
 #include <core/egg/3D/XFB.hpp>
@@ -11,52 +11,53 @@
 #include <core/RK/RKSceneManager.hpp>
 #include <core/rvl/gx/GXStruct.hpp>
 
-namespace EGG {
+namespace EGG
+{
 
-void AlarmHandler(OS::Alarm* alarm, OS::Context* context); //8020fd10
+    void AlarmHandler(OS::Alarm *alarm, OS::Context *context); // 8020fd10
 
-class TSystem { //names obtained from BBA
-public:
-    static TSystem mInstance; //802a4080
-    static TSystem* sInstance; //80385fc8
-    static TSystem* sInstance2; //80386F60
-    virtual Video* GetVideo(); //0x8 800099ac vtable 80270c2c
-    virtual Heap* GetSystemHeap(); //0xC 800099b4
-    virtual Display* GetDisplay(); //0x10 80009818
-    virtual XfbManager* GetXFBMgr(); //0x14 800099bc
-    virtual PerformanceView* GetPerfView(); //0x18 80009830
-    virtual SceneManager* GetSceneMgr(); //0x1C 80009828
-    virtual ExpAudioMgr* GetAudioMgr(); //0x20 800099c4
-    virtual void OnBeginFrame(); //0x24 80009820
-    virtual void OnEndFrame(); //0x28 80009824
-    virtual void InitRenderMode(); //0x2c 80009190
-    virtual void InitMemory(); //0x30 80242504
-    virtual void Run(); //0x34 8024269c
-    virtual void Initialize(); //0x38 80008fb4
+    class TSystem
+    { // names obtained from BBA
+    public:
+        static TSystem mInstance;               // 802a4080
+        static TSystem *sInstance;              // 80385fc8
+        static TSystem *sInstance2;             // 80386F60
+        virtual Video *GetVideo();              // 0x8 800099ac vtable 80270c2c
+        virtual Heap *GetSystemHeap();          // 0xC 800099b4
+        virtual Display *GetDisplay();          // 0x10 80009818
+        virtual XfbManager *GetXFBMgr();        // 0x14 800099bc
+        virtual PerformanceView *GetPerfView(); // 0x18 80009830
+        virtual SceneManager *GetSceneMgr();    // 0x1C 80009828
+        virtual ExpAudioMgr *GetAudioMgr();     // 0x20 800099c4
+        virtual void OnBeginFrame();            // 0x24 80009820
+        virtual void OnEndFrame();              // 0x28 80009824
+        virtual void InitRenderMode();          // 0x2c 80009190
+        virtual void InitMemory();              // 0x30 80242504
+        virtual void Run();                     // 0x34 8024269c
+        virtual void Initialize();              // 0x38 80008fb4
 
-    void* MEM1ArenaLo;
-    void* MEM1ArenaHi;
-    void* MEM2ArenaLo;
-    void* MEM2ArenaHi;
-    u32 memorySize; //0x14
-    ExpHeap* EGGRootMEM1; //0x18
-    ExpHeap* EGGRootMEM2;  //0x1C
-    ExpHeap* EGGRootDebug; //0x20
-    ExpHeap* EGGSystem;  //0x24
-    void* heapSystem; //thread
-    u32 unknown_0x2C; //just the start of mem1?
-    u32 unknown_0x30; //idk
-    u32 sysHeapSize;
-    u32 gxFifoBufSize;
-    GX::RenderModeObj* mode;
-    ExpAudioMgr* audioManager; //0x40
-    Video* video; //0x44
-    void* xfbManager; //0x48
-    AsyncDisplay* asyncDisplay; //0x4c
-    ProcessMeter* processMeter; //0x50
-    SceneManager* sceneManager; //0x54 //actually a RKSceneManager
-};
-}//namespace EGG
-
+        void *MEM1ArenaLo;
+        void *MEM1ArenaHi;
+        void *MEM2ArenaLo;
+        void *MEM2ArenaHi;
+        u32 memorySize;        // 0x14
+        ExpHeap *EGGRootMEM1;  // 0x18
+        ExpHeap *EGGRootMEM2;  // 0x1C
+        ExpHeap *EGGRootDebug; // 0x20
+        ExpHeap *EGGSystem;    // 0x24
+        void *heapSystem;      // thread
+        u32 unknown_0x2C;      // just the start of mem1?
+        u32 unknown_0x30;      // idk
+        u32 sysHeapSize;
+        u32 gxFifoBufSize;
+        GX::RenderModeObj *mode;
+        ExpAudioMgr *audioManager;  // 0x40
+        Video *video;               // 0x44
+        void *xfbManager;           // 0x48
+        AsyncDisplay *asyncDisplay; // 0x4c
+        ProcessMeter *processMeter; // 0x50
+        SceneManager *sceneManager; // 0x54 //actually a RKSceneManager
+    };
+} // namespace EGG
 
 #endif

--- a/GameSource/core/egg/Thread.hpp
+++ b/GameSource/core/egg/Thread.hpp
@@ -1,8 +1,8 @@
 #ifndef _EGG_THREAD_
 #define _EGG_THREAD_
 #include <types.hpp>
-#include <core/rvl/os/OSthread.hpp>
-#include <core/rvl/os/OSmessage.hpp>
+#include <core/rvl/OS/OSthread.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
 #include <core/rvl/mtx/mtx.hpp>
 #include <core/nw4r/ut/LinkList.hpp>
 #include <core/nw4r/ut/List.hpp>

--- a/GameSource/core/nw4r/db/Exception.hpp
+++ b/GameSource/core/nw4r/db/Exception.hpp
@@ -1,52 +1,54 @@
 #ifndef _NW4R_DB_EXCEPTION_
 #define _NW4R_DB_EXCEPTION_
 #include <types.hpp>
-#include <core/rvl/os/OSMessage.hpp>
-#include <core/rvl/os/OSthread.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
+#include <core/rvl/OS/OSthread.hpp>
 #include <core/rvl/gx/GX.hpp>
 #include <core/nw4r/db/Console.hpp>
 
-namespace nw4r {
-namespace db {
-typedef bool (*ExceptionUserCallback)(detail::ConsoleHead* console, void* arg);
+namespace nw4r
+{
+    namespace db
+    {
+        typedef bool (*ExceptionUserCallback)(detail::ConsoleHead *console, void *arg);
 
-struct ExceptionHead {
-    static ExceptionHead mInstance; //802a70b8
-    static void Init(); //800023150
-    OS::Thread exceptionThread; //0x0
-    OS::MessageQueue msgQueue; //0x318
-    void* frameBuffer; //0x338
-    u32 sp; //0x33c
-    detail::ConsoleHead* console; //0x340
-    const void* render; //0x344
-    ExceptionUserCallback callback; //0x348
-    void* callbackArgs; //0x34c
-    u32 msr; //0x350
-    u32 fpscr; //0x354 
-    u16 displayedInfo; //0x358
-    u8 padding[6];
-}; //total size 0x360
-size_assert(ExceptionHead, 0x360);
+        struct ExceptionHead
+        {
+            static ExceptionHead mInstance; // 802a70b8
+            static void Init();             // 800023150
+            OS::Thread exceptionThread;     // 0x0
+            OS::MessageQueue msgQueue;      // 0x318
+            void *frameBuffer;              // 0x338
+            u32 sp;                         // 0x33c
+            detail::ConsoleHead *console;   // 0x340
+            const void *render;             // 0x344
+            ExceptionUserCallback callback; // 0x348
+            void *callbackArgs;             // 0x34c
+            u32 msr;                        // 0x350
+            u32 fpscr;                      // 0x354
+            u16 displayedInfo;              // 0x358
+            u8 padding[6];
+        }; // total size 0x360
+        size_assert(ExceptionHead, 0x360);
 
-struct ExceptionCallbackParam {
-    u16 error; //see OS::Error
-    u8 padding[2];
-    OS::Context* context;
-    u32 dsisr;
-    u32 dar;
-};
+        struct ExceptionCallbackParam
+        {
+            u16 error; // see OS::Error
+            u8 padding[2];
+            OS::Context *context;
+            u32 dsisr;
+            u32 dar;
+        };
 
+        // prints message to NW4R console
+        void DirectPrint_ChangeXfb(void *frameBuffer, u16 width, u16 height);                      // 80021e30
+        void DirectPrint_DrawString(u32 xCoord, u32 yCoord, bool hasWrapping, const char *string); // 80021e90
+        void DirectPrint_StoreCache();                                                             // 80021e70
+        void Exception_Printf_(const char *, ...);                                                 // 800235a0
+        void PrintContext_(u16 error, const OS::Context *context, u32 dsisr, u32 dar);             // 80023680
+        void Exception_SetUserCallback(ExceptionUserCallback callback, void *args);                // 800240a0
+        void DumpException_(const ExceptionCallbackParam *param);                                  // 80023410
 
-
-// prints message to NW4R console
-void DirectPrint_ChangeXfb(void* frameBuffer, u16 width, u16 height); //80021e30
-void DirectPrint_DrawString(u32 xCoord, u32 yCoord, bool hasWrapping, const char* string); //80021e90
-void DirectPrint_StoreCache(); //80021e70
-void Exception_Printf_(const char*, ...); //800235a0
-void PrintContext_(u16 error, const OS::Context* context, u32 dsisr, u32 dar); //80023680
-void Exception_SetUserCallback(ExceptionUserCallback callback, void* args); //800240a0
-void DumpException_(const ExceptionCallbackParam* param); //80023410
-
-}//namespace db
-}//namespace nw4r
+    } // namespace db
+} // namespace nw4r
 #endif

--- a/GameSource/core/nw4r/lyt.hpp
+++ b/GameSource/core/nw4r/lyt.hpp
@@ -10,7 +10,7 @@
 #include <core/nw4r/lyt/lytTypes.hpp>
 #include <core/nw4r/lyt/Material.hpp>
 #include <core/nw4r/lyt/Pane.hpp>
-#include <core/nw4r/lyt/Textbox.hpp>
+#include <core/nw4r/lyt/TextBox.hpp>
 #include <core/nw4r/lyt/Picture.hpp>
 #include <core/nw4r/lyt/Window.hpp>
 #include <core/nw4r/lyt/ResourceAccessor.hpp>

--- a/GameSource/core/nw4r/lyt/Picture.hpp
+++ b/GameSource/core/nw4r/lyt/Picture.hpp
@@ -2,7 +2,7 @@
 #define _NW4R_LYTPICTURE_
 #include <types.hpp>
 #include <core/nw4r/lyt/Pane.hpp>
-#include <core/nw4r/lyt/Common.hpp>
+#include <core/nw4r/lyt/common.hpp>
 #include <core/nw4r/lyt/TexMap.hpp>
 
 namespace nw4r {

--- a/GameSource/core/nw4r/lyt/Window.hpp
+++ b/GameSource/core/nw4r/lyt/Window.hpp
@@ -2,7 +2,7 @@
 #define _NW4R_LYTWINDOW_
 #include <types.hpp>
 #include <core/nw4r/lyt/Pane.hpp>
-#include <core/nw4r/lyt/Common.hpp>
+#include <core/nw4r/lyt/common.hpp>
 #include <core/nw4r/lyt/TexMap.hpp>
 
 namespace nw4r {

--- a/GameSource/core/nw4r/snd/FrameHeap.hpp
+++ b/GameSource/core/nw4r/snd/FrameHeap.hpp
@@ -1,42 +1,47 @@
 #ifndef _NW4R_SNDFRAMEHEAP_
 #define _NW4R_SNDFRAMEHEAP_
 #include <types.hpp>
-#include <core/rvl/os/OSmutex.hpp>
+#include <core/rvl/OS/OSMutex.hpp>
 #include <core/nw4r/ut/LinkList.hpp>
 #include <core/nw4r/snd/DisposeCallbackManager.hpp>
 
-namespace nw4r {
-namespace snd {
-namespace detail {
-size_assert(void*, 0x4);
-class FrameHeap {
-    struct Block {
-    public:
-        ut::LinkListNode link;
-        void* buffer;
-        u32 size;
-        void* callbackFunc;
-        void* callbackArg;
-    };
-    class Section {
-    public:
-        ut::LinkListNode link;
-        ut::LinkList<Block, offsetof(Block, link)> blockList;
-    };
-    int SaveState(); //80092500
-    void LoadState(int level); //800925d0
-    int GetCurrentLevel() const; //80092800
-    bool Create(void* startAddress, u32 size); //80092090
-    void Destroy(); //80092230
-    void* Alloc(u32 size, void* callbackFunc, void* callbackArg); //80092450
-    u32 GetFreeSize() const; //80092810
-    void* MEMiHeapHead;
-    ut::LinkList<Section, offsetof(Section, Section::link)> sectionlist;
-};//total size 0x10
-size_assert(FrameHeap, 0x10);
+namespace nw4r
+{
+    namespace snd
+    {
+        namespace detail
+        {
+            size_assert(void *, 0x4);
+            class FrameHeap
+            {
+                struct Block
+                {
+                public:
+                    ut::LinkListNode link;
+                    void *buffer;
+                    u32 size;
+                    void *callbackFunc;
+                    void *callbackArg;
+                };
+                class Section
+                {
+                public:
+                    ut::LinkListNode link;
+                    ut::LinkList<Block, offsetof(Block, link)> blockList;
+                };
+                int SaveState();                                              // 80092500
+                void LoadState(int level);                                    // 800925d0
+                int GetCurrentLevel() const;                                  // 80092800
+                bool Create(void *startAddress, u32 size);                    // 80092090
+                void Destroy();                                               // 80092230
+                void *Alloc(u32 size, void *callbackFunc, void *callbackArg); // 80092450
+                u32 GetFreeSize() const;                                      // 80092810
+                void *MEMiHeapHead;
+                ut::LinkList<Section, offsetof(Section, Section::link)> sectionlist;
+            }; // total size 0x10
+            size_assert(FrameHeap, 0x10);
 
-
-}//namespace detail
-}//namespace snd
-}//namespace nw4r
-#endif	
+        } // namespace detail
+    } // namespace snd
+} // namespace nw4r
+#endif

--- a/GameSource/core/nw4r/snd/PlayerHeap.hpp
+++ b/GameSource/core/nw4r/snd/PlayerHeap.hpp
@@ -1,35 +1,39 @@
 #ifndef _NW4R_SNDPLAYERHEAP_
 #define _NW4R_SNDPLAYERHEAP_
 #include <types.hpp>
-#include <core/rvl/os/OSmutex.hpp>
+#include <core/rvl/OS/OSMutex.hpp>
 #include <core/nw4r/snd/FrameHeap.hpp>
 #include <core/nw4r/snd/SoundMemoryAllocatable.hpp>
-namespace nw4r {
-namespace snd {
-namespace detail {
-class BasicSound;
-class SoundPlayer;
-class PlayerHeap : public SoundMemoryAllocatable {
-public:
-    PlayerHeap(); //80097e00
-    ~PlayerHeap() override; //80097e30 vtable 80274828
-    void* Alloc(u32 size) override; //80097f30
+namespace nw4r
+{
+    namespace snd
+    {
+        namespace detail
+        {
+            class BasicSound;
+            class SoundPlayer;
+            class PlayerHeap : public SoundMemoryAllocatable
+            {
+            public:
+                PlayerHeap();                   // 80097e00
+                ~PlayerHeap() override;         // 80097e30 vtable 80274828
+                void *Alloc(u32 size) override; // 80097f30
 
-    bool PlayerHeap::Create(void* startAddress, u32 size); //80097f00
-    void PlayerHeap::Clear(); //80097f5c
-    u32 PlayerHeap::GetFreeSize() const; //80097ff0
-    void PlayerHeap::AttachSound(BasicSound* sound); //80098000
-    void PlayerHeap::DetachSound(BasicSound* sound); //80098010
+                bool PlayerHeap::Create(void *startAddress, u32 size); // 80097f00
+                void PlayerHeap::Clear();                              // 80097f5c
+                u32 PlayerHeap::GetFreeSize() const;                   // 80097ff0
+                void PlayerHeap::AttachSound(BasicSound *sound);       // 80098000
+                void PlayerHeap::DetachSound(BasicSound *sound);       // 80098010
 
-    BasicSound* mSound; //0x4
-    SoundPlayer* mPlayer; //0x8
-    void* startAddress; //0xc
-    void* endAddress; //0x10
-    void* allocAddress; //0x14
-    ut::LinkListNode link; //0x18
-}; //0x20
-}//namespace detail
-}//namespace snd
-}//namespace nw4r
+                BasicSound *mSound;    // 0x4
+                SoundPlayer *mPlayer;  // 0x8
+                void *startAddress;    // 0xc
+                void *endAddress;      // 0x10
+                void *allocAddress;    // 0x14
+                ut::LinkListNode link; // 0x18
+            }; // 0x20
+        } // namespace detail
+    } // namespace snd
+} // namespace nw4r
 
 #endif

--- a/GameSource/core/nw4r/snd/SoundArchiveFile.hpp
+++ b/GameSource/core/nw4r/snd/SoundArchiveFile.hpp
@@ -3,221 +3,238 @@
 #include <types.hpp>
 #include <core/nw4r/snd/SoundArchive.hpp>
 #include <core/nw4r/snd/Util.hpp>
-#include <core/rvl/nand.hpp>
+#include <core/rvl/NAND.hpp>
 
+// 8009ed80 read bank info
+namespace nw4r
+{
+    namespace snd
+    {
+        class Sound3DParam;
+        namespace detail
+        {
 
+            class SoundArchiveFile
+            { // https://wiki.tockdom.com/wiki/BRSAR_(File_Format)
+            public:
+                struct SeqSoundInfo
+                {
+                    u32 dataOffset;
+                    SoundArchive::BankId bankId;
+                    u32 allocTrack;
+                    u8 channelPriority;
+                    u8 releasePriorityFix;
+                    u8 padding[2];
+                    u32 reserved;
+                };
 
-//8009ed80 read bank info
-namespace nw4r {
-namespace snd {
-class Sound3DParam;
-namespace detail {
+                struct StrmSoundInfo
+                {
+                    u32 startPosition;
+                    u16 allocChannelCount;
+                    u16 allocTrackFlag;
+                    u32 reserved;
+                };
 
-class SoundArchiveFile {//https://wiki.tockdom.com/wiki/BRSAR_(File_Format)
-public:
-    struct SeqSoundInfo {
-        u32 dataOffset;
-        SoundArchive::BankId bankId;
-        u32 allocTrack;
-        u8 channelPriority;
-        u8 releasePriorityFix;
-        u8 padding[2];
-        u32 reserved;
-    };
+                struct WaveSoundInfo
+                { // for example title screen
+                    s32 subNo;
+                    u32 allocTrack;
+                    u8 channelPriority;
+                    u8 releasePriorityFix;
+                    u8 padding[2];
+                    u32 reserved;
+                };
 
-    struct StrmSoundInfo {
-        u32 startPosition;
-        u16 allocChannelCount;
-        u16 allocTrackFlag;
-        u32 reserved;
-    };
+                typedef detail::Util::DataRef<void, SeqSoundInfo, StrmSoundInfo, WaveSoundInfo> SoundInfoRef;
+                struct SoundCommonInfo
+                {
+                    u32 stringId;
+                    u32 fileId;
+                    u32 playerId;
+                    detail::Util::DataRef<Sound3DParam> param3dRef;
+                    u8 volume;
+                    u8 playerPriority;
+                    u8 soundType;
+                    u8 remoteFilter;
+                    SoundInfoRef soundInfoRef;
+                    u32 userParam[2];
+                    u8 panMode;
+                    u8 panCurve;
+                    u8 actorPlayerId;
+                    u8 reserved;
+                };
 
-    struct WaveSoundInfo { //for example title screen
-        s32 subNo;
-        u32 allocTrack;
-        u8 channelPriority;
-        u8 releasePriorityFix;
-        u8 padding[2];
-        u32 reserved;
-    };
+                struct BankInfo
+                {
+                    u32 stringId;
+                    u32 fileId;
+                    u32 reserved;
+                };
 
-    typedef detail::Util::DataRef<void, SeqSoundInfo, StrmSoundInfo, WaveSoundInfo> SoundInfoRef;
-    struct SoundCommonInfo {
-        u32 stringId;
-        u32 fileId;
-        u32 playerId;
-        detail::Util::DataRef<Sound3DParam> param3dRef;
-        u8 volume;
-        u8 playerPriority;
-        u8 soundType;
-        u8 remoteFilter;
-        SoundInfoRef soundInfoRef;
-        u32 userParam[2];
-        u8 panMode;
-        u8 panCurve;
-        u8 actorPlayerId;
-        u8 reserved;
-    };
+                struct PlayerInfo
+                {
+                    u32 stringId;
+                    u8 playableSoundCount;
+                    u8 padding;
+                    u16 padding2;
+                    u32 heapSize;
+                    u32 reserved;
+                };
 
-    struct BankInfo {
-        u32 stringId;
-        u32 fileId;
-        u32 reserved;
-    };
+                struct GroupItemInfo
+                {
+                    u32 fileId;
+                    u32 offset;
+                    u32 size;
+                    u32 waveDataOffset;
+                    u32 waveDataSize;
+                    u32 reserved;
+                };
 
-    struct PlayerInfo {
-        u32 stringId;
-        u8 playableSoundCount;
-        u8 padding;
-        u16 padding2;
-        u32 heapSize;
-        u32 reserved;
-    };
+                typedef detail::Util::Table<detail::Util::DataRef<SoundArchive::FilePos>> FilePosTable;
+                struct FileInfo
+                {
+                    u32 fileSize;
+                    u32 waveDataFileSize;
+                    s32 entryNum;
+                    detail::Util::DataRef<char> extFilePathRef;
+                    detail::Util::DataRef<FilePosTable> filePosTableRef;
+                };
 
-    struct GroupItemInfo {
-        u32 fileId;
-        u32 offset;
-        u32 size;
-        u32 waveDataOffset;
-        u32 waveDataSize;
-        u32 reserved;
-    };
+                struct SoundArchivePlayerInfo
+                {
+                    u16 seqSoundCount;
+                    u16 seqTrackCount;
+                    u16 strmSoundCount;
+                    u16 strmTrackCount;
+                    u16 strmChannelCount;
+                    u16 waveSoundCount;
+                    u16 waveTrackCount;
+                    u16 padding;
+                    u32 reserved;
+                };
 
-    typedef detail::Util::Table< detail::Util::DataRef<SoundArchive::FilePos> > FilePosTable;
-    struct FileInfo {
-        u32 fileSize;
-        u32 waveDataFileSize;
-        s32 entryNum;
-        detail::Util::DataRef<char> extFilePathRef;
-        detail::Util::DataRef<FilePosTable> filePosTableRef;
-    };
+                typedef detail::Util::Table<detail::Util::DataRef<GroupItemInfo>> GroupItemTable;
 
-    struct SoundArchivePlayerInfo {
-        u16 seqSoundCount;
-        u16 seqTrackCount;
-        u16 strmSoundCount;
-        u16 strmTrackCount;
-        u16 strmChannelCount;
-        u16 waveSoundCount;
-        u16 waveTrackCount;
-        u16 padding;
-        u32 reserved;
-    };
+                struct GroupInfo
+                {
+                    u32 stringId;
+                    s32 entryNum;
+                    detail::Util::DataRef<char> extFilePathRef;
+                    u32 offset;
+                    u32 size;
+                    u32 waveDataOffset;
+                    u32 waveDataSize;
+                    detail::Util::DataRef<GroupItemTable> itemTableRef;
+                };
 
-    typedef detail::Util::Table<detail::Util::DataRef<GroupItemInfo> > GroupItemTable;
+                typedef detail::Util::DataRef<SoundCommonInfo> SoundCommonInfoRef;
+                typedef detail::Util::Table<SoundCommonInfoRef> SoundInfoTable;
+                typedef detail::Util::Table<detail::Util::DataRef<BankInfo>> BankInfoTable;
+                typedef detail::Util::Table<detail::Util::DataRef<PlayerInfo>> PlayerInfoTable;
+                typedef detail::Util::Table<detail::Util::DataRef<FileInfo>> FileInfoTable;
+                typedef detail::Util::Table<detail::Util::DataRef<GroupInfo>> GroupInfoTable;
 
-    struct GroupInfo {
-        u32 stringId;
-        s32 entryNum;
-        detail::Util::DataRef<char> extFilePathRef;
-        u32 offset;
-        u32 size;
-        u32 waveDataOffset;
-        u32 waveDataSize;
-        detail::Util::DataRef<GroupItemTable> itemTableRef;
-    };
+                struct Info
+                {
+                    detail::Util::DataRef<detail::Util::Table<SoundCommonInfoRef>> soundTableRef;
+                    detail::Util::DataRef<BankInfoTable> bankTableRef;
+                    detail::Util::DataRef<PlayerInfoTable> playerTableRef;
+                    detail::Util::DataRef<FileInfoTable> fileTableRef;
+                    detail::Util::DataRef<GroupInfoTable> groupTableRef;
+                    detail::Util::DataRef<SoundArchivePlayerInfo> soundArchivePlayerInfoRef;
+                };
 
-    typedef detail::Util::DataRef<SoundCommonInfo> SoundCommonInfoRef;
-    typedef detail::Util::Table<SoundCommonInfoRef> SoundInfoTable;
-    typedef detail::Util::Table<detail::Util::DataRef<BankInfo> > BankInfoTable;
-    typedef detail::Util::Table<detail::Util::DataRef<PlayerInfo> > PlayerInfoTable;
-    typedef detail::Util::Table<detail::Util::DataRef<FileInfo> > FileInfoTable;
-    typedef detail::Util::Table<detail::Util::DataRef<GroupInfo> > GroupInfoTable;
+                struct Header
+                {
+                    ut::BinaryFileHeader fileHeader;
+                    u32 offsetSYMB; // 0x10
+                    u32 sizeSYMB;   // 0x14
+                    u32 offsetINFO; // 0x18
+                    u32 sizeINFO;   // 0x1c
+                    u32 offsetFILE; // 0x20
+                    u32 sizeFILE;   // 0x24
+                };
+            };
 
-    struct Info {
-        detail::Util::DataRef<detail::Util::Table<SoundCommonInfoRef>> soundTableRef;
-        detail::Util::DataRef<BankInfoTable> bankTableRef;
-        detail::Util::DataRef<PlayerInfoTable> playerTableRef;
-        detail::Util::DataRef<FileInfoTable> fileTableRef;
-        detail::Util::DataRef<GroupInfoTable> groupTableRef;
-        detail::Util::DataRef<SoundArchivePlayerInfo> soundArchivePlayerInfoRef;
-    };
+            class SoundArchiveFileReader
+            {
+            public:
+                SoundArchiveFileReader();                                          // 8009e690
+                void Init(const void *soundArchiveData);                           // 8009e6c0
+                void SetStringChunk(const void *stringChunk, u32 stringChunkSize); // 8009e770
+                void SetInfoChunk(const void *infoChunk, u32 infoChunkSize);       // 8009e820
 
-    struct Header {
-        ut::BinaryFileHeader fileHeader;
-        u32 offsetSYMB; //0x10
-        u32 sizeSYMB; //0x14
-        u32 offsetINFO; //0x18 
-        u32 sizeINFO; //0x1c
-        u32 offsetFILE; //0x20
-        u32 sizeFILE; //0x24
-    };
-};
+                SoundArchive::SoundType GetSoundType(SoundArchive::SoundId soundId) const;                                 // 8009e830
+                bool ReadSoundInfo(SoundArchive::SoundId soundId, SoundArchive::SoundInfo *info) const;                    // 8009e920
+                bool ReadSound3DParam(SoundArchive::SoundId soundId, SoundArchive::Sound3DParam *param) const;             // 8009ea50
+                bool ReadSeqSoundInfo(SoundArchive::SoundId soundId, SoundArchive::SeqSoundInfo *info) const;              // 8009eb60
+                bool ReadStrmSoundInfo(SoundArchive::SoundId soundId, SoundArchive::StrmSoundInfo *info) const;            // 8009ec10
+                bool ReadWaveSoundInfo(SoundArchive::SoundId soundId, SoundArchive::WaveSoundInfo *info) const;            // 8009ece0
+                bool ReadBankInfo(SoundArchive::BankId bankId, SoundArchive::BankInfo *info) const;                        // 8009ed80
+                bool ReadPlayerInfo(SoundArchive::PlayerId playerId, SoundArchive::PlayerInfo *info) const;                // 8009ee30
+                bool ReadGroupInfo(SoundArchive::GroupId groupId, SoundArchive::GroupInfo *info) const;                    // 8009eef0
+                bool ReadGroupItemInfo(SoundArchive::GroupId groupId, u32 index, SoundArchive::GroupItemInfo *info) const; // 8009f000
+                bool ReadSoundArchivePlayerInfo(SoundArchive::SoundArchivePlayerInfo *info) const;                         // 8009f138
+                u32 GetPlayerCount() const;                                                                                // 8009f1d0
+                u32 GetGroupCount() const;                                                                                 // 8009f210
+                const char *GetGroupLabelString(SoundArchive::GroupId groupId) const;                                      // 8009f260
+                const char *GetBankLabelString(SoundArchive::BankId bankId) const;                                         // 8009f340
+                u32 GetSoundUserParam(SoundArchive::SoundId soundId) const;                                                // 8009f420
+                u32 GetFileCount() const;                                                                                  // 8009f4e0
+                bool ReadFileInfo(SoundArchive::FileId fileId, SoundArchive::FileInfo *info) const;                        // 8009f520
+                bool ReadFilePos(SoundArchive::FileId fileId, u32 index, SoundArchive::FilePos *info) const;               // 8009f620
+                u32 ConvertLabelStringToId(const void *stringTree, const char *str) const;                                 // 8009f740
+                SoundArchiveFile::SoundInfoRef impl_GetSoundInfoOffset();                                                  // 8009f890
 
-class SoundArchiveFileReader {
-public:
-    SoundArchiveFileReader(); //8009e690
-    void Init(const void* soundArchiveData); //8009e6c0
-    void SetStringChunk(const void* stringChunk, u32 stringChunkSize); //8009e770
-    void SetInfoChunk(const void* infoChunk, u32 infoChunkSize); //8009e820
+                SoundArchiveFile::Header header;
+                SoundArchiveFile::Info *soundInfo; // 0x28
+                void *stringBase;                  // 0x2c
+                u8 *stringTable;                   // 0x30
+                u8 *soundStringTree;               // 0x34
+                u8 *playerStringTree;
+                u8 *groupStringTree;
+                u8 *bankStringTree;
+            }; // total size 0x44
+            size_assert(SoundArchiveFileReader, 0x44);
+        }
 
-    SoundArchive::SoundType GetSoundType(SoundArchive::SoundId soundId) const; //8009e830
-    bool ReadSoundInfo(SoundArchive::SoundId soundId, SoundArchive::SoundInfo* info) const; //8009e920
-    bool ReadSound3DParam(SoundArchive::SoundId soundId, SoundArchive::Sound3DParam* param) const; //8009ea50
-    bool ReadSeqSoundInfo(SoundArchive::SoundId soundId, SoundArchive::SeqSoundInfo* info) const; //8009eb60
-    bool ReadStrmSoundInfo(SoundArchive::SoundId soundId, SoundArchive::StrmSoundInfo* info) const; //8009ec10
-    bool ReadWaveSoundInfo(SoundArchive::SoundId soundId, SoundArchive::WaveSoundInfo* info) const; //8009ece0
-    bool ReadBankInfo(SoundArchive::BankId bankId, SoundArchive::BankInfo* info) const; //8009ed80
-    bool ReadPlayerInfo(SoundArchive::PlayerId playerId, SoundArchive::PlayerInfo* info) const; //8009ee30
-    bool ReadGroupInfo(SoundArchive::GroupId groupId, SoundArchive::GroupInfo* info) const; //8009eef0
-    bool ReadGroupItemInfo(SoundArchive::GroupId groupId, u32 index, SoundArchive::GroupItemInfo* info) const; //8009f000
-    bool ReadSoundArchivePlayerInfo(SoundArchive::SoundArchivePlayerInfo* info) const; //8009f138
-    u32 GetPlayerCount() const; //8009f1d0
-    u32 GetGroupCount() const; //8009f210
-    const char* GetGroupLabelString(SoundArchive::GroupId groupId) const; //8009f260
-    const char* GetBankLabelString(SoundArchive::BankId bankId) const; //8009f340
-    u32 GetSoundUserParam(SoundArchive::SoundId soundId) const; //8009f420
-    u32 GetFileCount() const; //8009f4e0
-    bool ReadFileInfo(SoundArchive::FileId fileId, SoundArchive::FileInfo* info) const; //8009f520
-    bool ReadFilePos(SoundArchive::FileId fileId, u32 index, SoundArchive::FilePos* info) const; //8009f620
-    u32 ConvertLabelStringToId(const void* stringTree, const char* str) const; //8009f740
-    SoundArchiveFile::SoundInfoRef impl_GetSoundInfoOffset(); //8009f890
+        class NandSoundArchive : public SoundArchive
+        {
+        public:
+            NandSoundArchive();                                                                                                   // 80097570
+            ~NandSoundArchive() override;                                                                                         // 800975c0 vtable 80274808
+            const void *detail_GetFileAddress(FileId fileId) const override;                                                      // 0xc 80097df0
+            const void *detail_GetWaveDataFileAddress(FileId fileId) const override;                                              // 0x10 80097de0
+            int detail_GetRequiredStreamBufferSize() const override;                                                              // 0x14 800979e0
+            ut::FileStream *OpenStream(void *buffer, int size, u32 begin, u32 length) const override;                             // 0x18 800977e0
+            ut::FileStream *OpenExtStream(void *buffer, int size, const char *extFilePath, u32 begin, u32 length) const override; // 0x1c 800978a0
 
-    SoundArchiveFile::Header header;
-    SoundArchiveFile::Info* soundInfo; //0x28
-    void* stringBase; //0x2c
-    u8* stringTable; //0x30
-    u8* soundStringTree; //0x34
-    u8* playerStringTree;
-    u8* groupStringTree;
-    u8* bankStringTree;
-}; //total size 0x44
-size_assert(SoundArchiveFileReader, 0x44);
-}
+            detail::SoundArchiveFileReader fileReader; // 0x108
+            NAND::FileInfo fileInfo;                   // 14c
+            bool isOpen;
+            u8 padding[3];
+        }; // total size 0x1DC
+        size_assert(NandSoundArchive, 0x1DC);
 
-class NandSoundArchive : public SoundArchive {
-public:
-    NandSoundArchive(); //80097570
-    ~NandSoundArchive() override; //800975c0 vtable 80274808
-    const void* detail_GetFileAddress(FileId fileId) const override; //0xc 80097df0
-    const void* detail_GetWaveDataFileAddress(FileId fileId) const override; //0x10 80097de0
-    int detail_GetRequiredStreamBufferSize() const override; //0x14 800979e0
-    ut::FileStream* OpenStream(void* buffer, int size, u32 begin, u32 length) const override; //0x18 800977e0
-    ut::FileStream* OpenExtStream(void* buffer, int size, const char* extFilePath, u32 begin, u32 length) const override; //0x1c 800978a0
+        class MemorySoundArchive : public SoundArchive
+        {
+        public:
+            MemorySoundArchive();                                                                                                 // 80095d80
+            ~MemorySoundArchive() override;                                                                                       // 80095dd0 vtable 802744d8
+            const void *detail_GetFileAddress(FileId fileId) const override;                                                      // 0xc 80095ec0
+            const void *detail_GetWaveDataFileAddress(FileId fileId) const override;                                              // 0x10 80095f70
+            int detail_GetRequiredStreamBufferSize() const override;                                                              // 0x14 80096090
+            ut::FileStream *OpenStream(void *buffer, int size, u32 begin, u32 length) const override;                             // 0x18 80096020
+            ut::FileStream *OpenExtStream(void *buffer, int size, const char *extFilePath, u32 begin, u32 length) const override; // 0x1c 80096080
 
-    detail::SoundArchiveFileReader fileReader; //0x108
-    NAND::FileInfo fileInfo; //14c
-    bool isOpen;
-    u8 padding[3];
-}; //total size 0x1DC
-size_assert(NandSoundArchive, 0x1DC);
-
-class MemorySoundArchive : public SoundArchive {
-public:
-    MemorySoundArchive(); //80095d80
-    ~MemorySoundArchive() override; //80095dd0 vtable 802744d8
-    const void* detail_GetFileAddress(FileId fileId) const override; //0xc 80095ec0
-    const void* detail_GetWaveDataFileAddress(FileId fileId) const override; //0x10 80095f70
-    int detail_GetRequiredStreamBufferSize() const override; //0x14 80096090
-    ut::FileStream* OpenStream(void* buffer, int size, u32 begin, u32 length) const override; //0x18 80096020
-    ut::FileStream* OpenExtStream(void* buffer, int size, const char* extFilePath, u32 begin, u32 length) const override; //0x1c 80096080
-
-    bool Setup(const void* soundArchiveData); //80095e30
-    const void* data;
-    detail::SoundArchiveFileReader fileReader;
-}; //total size 0x150
-size_assert(MemorySoundArchive, 0x150);
-}//namespace snd
-}//namespace nw4r
+            bool Setup(const void *soundArchiveData); // 80095e30
+            const void *data;
+            detail::SoundArchiveFileReader fileReader;
+        }; // total size 0x150
+        size_assert(MemorySoundArchive, 0x150);
+    } // namespace snd
+} // namespace nw4r
 
 #endif

--- a/GameSource/core/nw4r/snd/SoundArchiveLoader.hpp
+++ b/GameSource/core/nw4r/snd/SoundArchiveLoader.hpp
@@ -1,30 +1,34 @@
 #ifndef _NW4R_SNDSOUNDARCHIVELOADER_
 #define _NW4R_SNDSOUNDARCHIVELOADER_
 #include <types.hpp>
-#include <core/rvl/os/OSmutex.hpp>
+#include <core/rvl/OS/OSMutex.hpp>
 #include <core/nw4r/snd/SoundArchive.hpp>
 #include <core/nw4r/ut.hpp>
 #include <core/nw4r/snd/SoundHeap.hpp>
 
-namespace nw4r {
-namespace snd {
-namespace detail {
-class SoundArchiveLoader {
-public:
-    SoundArchiveLoader(const SoundArchive& archive); //8009f990
-    ~SoundArchiveLoader(); //8009f9d0
-    void* LoadFile(SoundArchive::FileId fileId, SoundMemoryAllocatable* allocater); //800a0180
-    s32 ReadWaveDataFile(SoundArchive::FileId fileId, void* buffer, s32 size, s32 offset); //800a0260 returns size
-    void* LoadWaveDataFile(SoundArchive::FileId fileId, SoundMemoryAllocatable* allocater); //800a0420
+namespace nw4r
+{
+    namespace snd
+    {
+        namespace detail
+        {
+            class SoundArchiveLoader
+            {
+            public:
+                SoundArchiveLoader(const SoundArchive &archive);                                        // 8009f990
+                ~SoundArchiveLoader();                                                                  // 8009f9d0
+                void *LoadFile(SoundArchive::FileId fileId, SoundMemoryAllocatable *allocater);         // 800a0180
+                s32 ReadWaveDataFile(SoundArchive::FileId fileId, void *buffer, s32 size, s32 offset);  // 800a0260 returns size
+                void *LoadWaveDataFile(SoundArchive::FileId fileId, SoundMemoryAllocatable *allocater); // 800a0420
 
-    void* LoadGroup(u32 groupId, SoundMemoryAllocatable* allocater, void** waveDataAddress, u32 loadBlockSize); //8009fa10
-    OS::Mutex mutex;
-    const SoundArchive& archive;
-    u32 streamArea[0x80];
-    ut::FileStream* stream;
-};
-}//namespace detail
-}//namespace snd
-}//namespace nw4r
+                void *LoadGroup(u32 groupId, SoundMemoryAllocatable *allocater, void **waveDataAddress, u32 loadBlockSize); // 8009fa10
+                OS::Mutex mutex;
+                const SoundArchive &archive;
+                u32 streamArea[0x80];
+                ut::FileStream *stream;
+            };
+        } // namespace detail
+    } // namespace snd
+} // namespace nw4r
 
 #endif

--- a/GameSource/core/nw4r/snd/SoundHeap.hpp
+++ b/GameSource/core/nw4r/snd/SoundHeap.hpp
@@ -1,26 +1,29 @@
 #ifndef _NW4R_SNDHEAP_
 #define _NW4R_SNDHEAP_
 #include <types.hpp>
-#include <core/rvl/os/OSmutex.hpp>
+#include <core/rvl/OS/OSMutex.hpp>
 #include <core/nw4r/snd/FrameHeap.hpp>
 #include <core/nw4r/snd/SoundMemoryAllocatable.hpp>
-namespace  nw4r {
-namespace snd {
-class SoundHeap : public SoundMemoryAllocatable {
-public:
-    SoundHeap(); //800a2ed0
-    ~SoundHeap() override; //800a2f20 vtable 80274a30
-    void* Alloc(u32 size) override; //800a2fb0
-    void* Alloc(u32 size, void* callBackFunc, void* callBackArg); //800a3020
-    bool Create(void* startAddr, u32 size); //800a2f90
-    void Destroy(); //800a2fa0
-    int SaveState(); //800a3100
-    void LoadState(int level); //800a3160
-    OS::Mutex mutex; //4
-    detail::FrameHeap frameHeap; //0x1C
-}; //total size 0x2C
-size_assert(SoundHeap, 0x2c);
-}//namespace snd
-}//namespace nw4r
+namespace nw4r
+{
+    namespace snd
+    {
+        class SoundHeap : public SoundMemoryAllocatable
+        {
+        public:
+            SoundHeap();                                                  // 800a2ed0
+            ~SoundHeap() override;                                        // 800a2f20 vtable 80274a30
+            void *Alloc(u32 size) override;                               // 800a2fb0
+            void *Alloc(u32 size, void *callBackFunc, void *callBackArg); // 800a3020
+            bool Create(void *startAddr, u32 size);                       // 800a2f90
+            void Destroy();                                               // 800a2fa0
+            int SaveState();                                              // 800a3100
+            void LoadState(int level);                                    // 800a3160
+            OS::Mutex mutex;                                              // 4
+            detail::FrameHeap frameHeap;                                  // 0x1C
+        }; // total size 0x2C
+        size_assert(SoundHeap, 0x2c);
+    } // namespace snd
+} // namespace nw4r
 
 #endif

--- a/GameSource/core/nw4r/snd/SoundInstanceManager.hpp
+++ b/GameSource/core/nw4r/snd/SoundInstanceManager.hpp
@@ -2,36 +2,36 @@
 #define _NW4R_SNDSOUNDINSTANCEMANAGER_
 #include <types.hpp>
 #include <core/nw4r/ut/LinkList.hpp>
-#include <core/rvl/os/OSmutex.hpp>
+#include <core/rvl/OS/OSMutex.hpp>
 #include <core/nw4r/snd/BasicSound.hpp>
 #include <core/nw4r/snd/InstancePool.hpp>
 
+namespace nw4r
+{
+    namespace snd
+    {
+        namespace detail
+        {
 
-namespace nw4r {
-namespace snd {
-namespace detail {
+            template <class T>
+            class SoundInstanceManager
+            {
+            public:
+                MemoryPool<T> pool;
+                ut::LinkList<T, offsetof(T, priorityLink)> priorityList;
+                OS::Mutex mutex; // 0x10
+            }; // total size 0x28
 
-template <class T>
-class SoundInstanceManager {
-public:
-    MemoryPool<T> pool;
-    ut::LinkList<T, offsetof(T, priorityLink)> priorityList;
-    OS::Mutex mutex; //0x10
-}; //total size 0x28
+            class SeqSound;
+            class StrmSound;
+            class WaveSound;
 
-class SeqSound;
-class StrmSound;
-class WaveSound;
+            typedef detail::SoundInstanceManager<detail::SeqSound> SeqSoundInstanceManager;
+            typedef detail::SoundInstanceManager<detail::StrmSound> StrmSoundInstanceManager;
+            typedef detail::SoundInstanceManager<detail::WaveSound> WaveSoundInstanceManager;
 
-typedef detail::SoundInstanceManager<detail::SeqSound> SeqSoundInstanceManager;
-typedef detail::SoundInstanceManager<detail::StrmSound> StrmSoundInstanceManager;
-typedef detail::SoundInstanceManager<detail::WaveSound> WaveSoundInstanceManager;
+        }
 
-
-}
-
-
-
-}//namespace snd
-}//namespace nw4r
+    } // namespace snd
+} // namespace nw4r
 #endif

--- a/GameSource/core/nw4r/snd/SoundSystem.hpp
+++ b/GameSource/core/nw4r/snd/SoundSystem.hpp
@@ -1,21 +1,24 @@
 #ifndef _NW4R_SND_SOUNDSYSTEM_
 #define _NW4R_SND_SOUNDSYSTEM_
 #include <types.hpp>
-#include <core/rvl/os/OSthread.hpp>
+#include <core/rvl/OS/OSthread.hpp>
 
-namespace nw4r {
-namespace snd {
-
-class SoundSystem
+namespace nw4r
 {
-public:
-    struct SoundSystemParam {
-        s32 soundThreadPriority;
-        u32 soundThreadStackSize;
-        s32 dvdThreadPriority;
-        u32 dvdThreadStackSize;
-    };
-};
-}//namespace snd
-}//namespace nw4r
+    namespace snd
+    {
+
+        class SoundSystem
+        {
+        public:
+            struct SoundSystemParam
+            {
+                s32 soundThreadPriority;
+                u32 soundThreadStackSize;
+                s32 dvdThreadPriority;
+                u32 dvdThreadStackSize;
+            };
+        };
+    } // namespace snd
+} // namespace nw4r
 #endif

--- a/GameSource/core/nw4r/snd/SoundThread.hpp
+++ b/GameSource/core/nw4r/snd/SoundThread.hpp
@@ -3,63 +3,69 @@
 #include <types.hpp>
 #include <core/nw4r/ut/LinkList.hpp>
 #include <core/nw4r/snd/AxManager.hpp>
-#include <core/rvl/os/OSthread.hpp>
-#include <core/rvl/os/OSMessage.hpp>
-#include <core/rvl/os/OSMutex.hpp>
+#include <core/rvl/OS/OSthread.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
+#include <core/rvl/OS/OSMutex.hpp>
 
-namespace nw4r {
-namespace snd {
-namespace detail {
-class SoundThread {
-public:
-    class SoundFrameCallback {
-    public:
-        ut::LinkListNode link;
-        virtual ~SoundFrameCallback();
-        virtual void OnBeginSoundFrame();
-        virtual void OnEndSoundFrame();
-    };
-    class PlayerCallback {
-    public:
-        ut::LinkListNode link;
-        virtual ~PlayerCallback();
-        virtual void OnUpdateFrameSoundThread();
-        virtual void OnUpdateVoiceSoundThread(); //80096260
-        virtual void OnShutdownSoundThread();
-    };
+namespace nw4r
+{
+    namespace snd
+    {
+        namespace detail
+        {
+            class SoundThread
+            {
+            public:
+                class SoundFrameCallback
+                {
+                public:
+                    ut::LinkListNode link;
+                    virtual ~SoundFrameCallback();
+                    virtual void OnBeginSoundFrame();
+                    virtual void OnEndSoundFrame();
+                };
+                class PlayerCallback
+                {
+                public:
+                    ut::LinkListNode link;
+                    virtual ~PlayerCallback();
+                    virtual void OnUpdateFrameSoundThread();
+                    virtual void OnUpdateVoiceSoundThread(); // 80096260
+                    virtual void OnShutdownSoundThread();
+                };
 
-    static SoundThread instance; //802dceb0
-    static SoundThread& GetInstance(); //800a4530
-    ~SoundThread(); //800a4600
-    bool Create(s32 priority, void* stack, u32 stackSize); //800a4670
-    void Shutdown(); //800a47b0
-    static void AxCallbackFunc(); //800a48b0 
-    static void* SoundThreadFunc(void* arg); //800a49c0 OsThread Run func
-    void RegisterPlayerCallback(PlayerCallback* callback); //800a4a20
-    void UnregisterPlayerCallback(PlayerCallback* callback); //800a4a90
-    void FrameProcess(); //800a4af0
+                static SoundThread instance;                             // 802dceb0
+                static SoundThread &GetInstance();                       // 800a4530
+                ~SoundThread();                                          // 800a4600
+                bool Create(s32 priority, void *stack, u32 stackSize);   // 800a4670
+                void Shutdown();                                         // 800a47b0
+                static void AxCallbackFunc();                            // 800a48b0
+                static void *SoundThreadFunc(void *arg);                 // 800a49c0 OsThread Run func
+                void RegisterPlayerCallback(PlayerCallback *callback);   // 800a4a20
+                void UnregisterPlayerCallback(PlayerCallback *callback); // 800a4a90
+                void FrameProcess();                                     // 800a4af0
 
-    OS::Thread thread;
-    OS::ThreadQueue threadQueue; //0x318
-    OS::MessageQueue msgQueue; //0x320
-    OS::Message msgBuffer[4]; //0x340
-    u32* stackEnd; //0x350
-    OS::Mutex mutex; //0x354
+                OS::Thread thread;
+                OS::ThreadQueue threadQueue; // 0x318
+                OS::MessageQueue msgQueue;   // 0x320
+                OS::Message msgBuffer[4];    // 0x340
+                u32 *stackEnd;               // 0x350
+                OS::Mutex mutex;             // 0x354
 
-    AxManager::CallbackListNode axCallbackNode; //0x36c
+                AxManager::CallbackListNode axCallbackNode; // 0x36c
 
-    ut::LinkList<SoundFrameCallback, offsetof(SoundFrameCallback, link)> soundFrameCallbackList; //0x378
-    ut::LinkList<PlayerCallback, offsetof(PlayerCallback, link)> playerCallbackList; //0x384
+                ut::LinkList<SoundFrameCallback, offsetof(SoundFrameCallback, link)> soundFrameCallbackList; // 0x378
+                ut::LinkList<PlayerCallback, offsetof(PlayerCallback, link)> playerCallbackList;             // 0x384
 
-    u32 processTick; //0x390
+                u32 processTick; // 0x390
 
-    bool createFlag; //0x394
-    bool pauseFlag; //0x395
-    u8 padding[2];
-}; //total size 0x2C
+                bool createFlag; // 0x394
+                bool pauseFlag;  // 0x395
+                u8 padding[2];
+            }; // total size 0x2C
 
-}//namespace detail
-}//namespace snd
-}//namespace nw4r
+        } // namespace detail
+    } // namespace snd
+} // namespace nw4r
 
 #endif

--- a/GameSource/core/nw4r/ut/Misc.hpp
+++ b/GameSource/core/nw4r/ut/Misc.hpp
@@ -1,8 +1,8 @@
 #ifndef _NW4R_UT_MISC_
 #define _NW4R_UT_MISC_
 #include <types.hpp>
-#include <core/rvl/os/OS.hpp>
-#include <core/rvl/os/OSMutex.hpp>
+#include <core/rvl/OS/OS.hpp>
+#include <core/rvl/OS/OSMutex.hpp>
 
 namespace nw4r {
 namespace ut {

--- a/GameSource/core/nw4r/ut/RomFont.hpp
+++ b/GameSource/core/nw4r/ut/RomFont.hpp
@@ -2,42 +2,44 @@
 #define _NW4R_UT_ROMFONT_
 #include <types.hpp>
 #include <core/nw4r/ut/Font.hpp>
-#include <core/rvl/os/OSfont.hpp>
+#include <core/rvl/OS/OSfont.hpp>
 
-namespace nw4r {
-namespace ut {
+namespace nw4r
+{
+    namespace ut
+    {
 
-class RomFont : public Font {
-public:
-    RomFont(); //800b1a20
-    ~RomFont() override; //800b1a80 vtable 80274dac
-    int GetWidth() const override; //0xc 800b1ae0
-    int GetHeight() const override; //0x10 800b1af0
-    int GetAscent() const override; //0x14 800b1b50
-    int GetDescent() const override; //0x18 800b1b60
-    int GetBaselinePos() const override; //0x1c 800b1b70
-    int GetCellHeight() const override; //0x20 800b1b80
-    int GetCellWidth() const override; //0x24 800b1b90
-    int GetMaxCharWidth() const override; //0x28 800b1ba0
-    Type GetType() const override; //0x2c 800b1bb0
-    GX::TexFmt GetTextureFormat() const override; //0x30 800b1bc0
-    int GetLineFeed() const override; //0x34 800b1bd0
-    const CharWidths GetDefaultCharWidths() const override; //0x38 800b1be0
-    void SetDefaultCharWidths(const CharWidths& widths) override; //0x3c 800b11c00
-    bool SetAlternateChar(u16 code) override; //0x40 800b11c20
-    void SetLineFeed(int linefeed) override; //0x44 800b11cb0
-    int GetCharWidth(u16 code) const override; //0x48 800b11cc0
-    const CharWidths GetCharWidths(u16 code) const override; //0x4c 800b1d50
-    void GetGlyph(Glyph* glyphPtr, u16 code) const override; //0x50 800b1da0
-    bool HasGlyph(u16 c) const override; //0x54 800b1ea0
-    FontEncoding GetEncoding() const override; //0x58 800b1f66
+        class RomFont : public Font
+        {
+        public:
+            RomFont();                                                    // 800b1a20
+            ~RomFont() override;                                          // 800b1a80 vtable 80274dac
+            int GetWidth() const override;                                // 0xc 800b1ae0
+            int GetHeight() const override;                               // 0x10 800b1af0
+            int GetAscent() const override;                               // 0x14 800b1b50
+            int GetDescent() const override;                              // 0x18 800b1b60
+            int GetBaselinePos() const override;                          // 0x1c 800b1b70
+            int GetCellHeight() const override;                           // 0x20 800b1b80
+            int GetCellWidth() const override;                            // 0x24 800b1b90
+            int GetMaxCharWidth() const override;                         // 0x28 800b1ba0
+            Type GetType() const override;                                // 0x2c 800b1bb0
+            GX::TexFmt GetTextureFormat() const override;                 // 0x30 800b1bc0
+            int GetLineFeed() const override;                             // 0x34 800b1bd0
+            const CharWidths GetDefaultCharWidths() const override;       // 0x38 800b1be0
+            void SetDefaultCharWidths(const CharWidths &widths) override; // 0x3c 800b11c00
+            bool SetAlternateChar(u16 code) override;                     // 0x40 800b11c20
+            void SetLineFeed(int linefeed) override;                      // 0x44 800b11cb0
+            int GetCharWidth(u16 code) const override;                    // 0x48 800b11cc0
+            const CharWidths GetCharWidths(u16 code) const override;      // 0x4c 800b1d50
+            void GetGlyph(Glyph *glyphPtr, u16 code) const override;      // 0x50 800b1da0
+            bool HasGlyph(u16 c) const override;                          // 0x54 800b1ea0
+            FontEncoding GetEncoding() const override;                    // 0x58 800b1f66
 
-    OS::FontHeader* fontHeader; //0x10
-    CharWidths defaultWidths;  //0x14
-    u16 altChar; //0x18
-}; //0x1c
+            OS::FontHeader *fontHeader; // 0x10
+            CharWidths defaultWidths;   // 0x14
+            u16 altChar;                // 0x18
+        }; // 0x1c
 
-
-}//namespace ut
-}//namespace nw4r
+    } // namespace ut
+} // namespace nw4r
 #endif

--- a/GameSource/core/nw4r/ut/RuntimeTypeInfo.hpp
+++ b/GameSource/core/nw4r/ut/RuntimeTypeInfo.hpp
@@ -2,7 +2,7 @@
 #define _NW4R_UT_RUNTIMETYPEINFO_
 #include <types.hpp>
 #include <core/nw4r/ut/Font.hpp>
-#include <core/rvl/os/OSfont.hpp>
+#include <core/rvl/OS/OSFont.hpp>
 
 namespace nw4r {
 namespace ut {

--- a/GameSource/core/rvl/DWC/DWCFriend.hpp
+++ b/GameSource/core/rvl/DWC/DWCFriend.hpp
@@ -1,90 +1,93 @@
-#ifndef _DWCFRIEND_ //to split into multiple files ultimately
+#ifndef _DWCFRIEND_ // to split into multiple files ultimately
 #define _DWCFRIEND_
 
 #include <types.hpp>
 #include <core/rvl/DWC/DWCAccount.hpp>
 #include <core/rvl/DWC/DWCError.hpp>
-#include <core/rvl/os/OS.hpp>
+#include <core/rvl/OS/OS.hpp>
 
-//Credit Seeky
+// Credit Seeky
 
-namespace DWC { //this is C, but don't care
-enum FriendState {
-    DWC_FRIEND_STATE_INIT = 0,      //Initial state
-    DWC_FRIEND_STATE_PERS_LOGIN,    //during persistent server login and friend list synchronization
-    DWC_FRIEND_STATE_LOGON,         //After Persistent server login
-    DWC_FRIEND_STATE_NUM
-};
+namespace DWC
+{ // this is C, but don't care
+    enum FriendState
+    {
+        DWC_FRIEND_STATE_INIT = 0,   // Initial state
+        DWC_FRIEND_STATE_PERS_LOGIN, // during persistent server login and friend list synchronization
+        DWC_FRIEND_STATE_LOGON,      // After Persistent server login
+        DWC_FRIEND_STATE_NUM
+    };
 
-enum FriendStatus {
-    DWC_FRIEND_STATUS_OFFLINE = 0,    //Offline
-    DWC_FRIEND_STATUS_ONLINE,         //Online (already logged onto GP server)
-    DWC_FRIEND_STATUS_PLAYING,        //During game play
-    DWC_FRIEND_STATUS_MATCH_ANYBODY,  //friend unspecified peer matchmaking in progress
-    DWC_FRIEND_STATUS_MATCH_FRIEND,   //friend specified peer matchmaking in progress
-    DWC_FRIEND_STATUS_MATCH_SC_CL,    //client during server-client matchmaking
-    DWC_FRIEND_STATUS_MATCH_SC_SV,    //server during server-client matchmaking
-    DWC_FRIEND_STATUS_NUM
-};
+    enum FriendStatus
+    {
+        DWC_FRIEND_STATUS_OFFLINE = 0,   // Offline
+        DWC_FRIEND_STATUS_ONLINE,        // Online (already logged onto GP server)
+        DWC_FRIEND_STATUS_PLAYING,       // During game play
+        DWC_FRIEND_STATUS_MATCH_ANYBODY, // friend unspecified peer matchmaking in progress
+        DWC_FRIEND_STATUS_MATCH_FRIEND,  // friend specified peer matchmaking in progress
+        DWC_FRIEND_STATUS_MATCH_SC_CL,   // client during server-client matchmaking
+        DWC_FRIEND_STATUS_MATCH_SC_SV,   // server during server-client matchmaking
+        DWC_FRIEND_STATUS_NUM
+    };
 
-//Friend List synchronisation cb
-typedef void (*UpdateServersCallback)(Error error, BOOL isChanged, void* param);
+    // Friend List synchronisation cb
+    typedef void (*UpdateServersCallback)(Error error, BOOL isChanged, void *param);
 
-//Notification of changes in friend status cb
-typedef void (*FriendStatusCallback)(int index, u8 status, const char* statusString, void* param);
+    // Notification of changes in friend status cb
+    typedef void (*FriendStatusCallback)(int index, u8 status, const char *statusString, void *param);
 
-//Friend roster delete cb
-typedef void (*DeleteFriendListCallback)(int deletedIndex, int srcIndex, void* param);
+    // Friend roster delete cb
+    typedef void (*DeleteFriendListCallback)(int deletedIndex, int srcIndex, void *param);
 
-//New friend established cb
-typedef void (*BuddyFriendCallback)(int index, void* param);
+    // New friend established cb
+    typedef void (*BuddyFriendCallback)(int index, void *param);
 
-//data storage server/login cb
-typedef void (*StorageLoginCallback)(Error error, void* param);
+    // data storage server/login cb
+    typedef void (*StorageLoginCallback)(Error error, void *param);
 
-//data storage server save complete cb
-typedef void (*SaveToServerCallback)(BOOL success, BOOL isPublic, void* param);
+    // data storage server save complete cb
+    typedef void (*SaveToServerCallback)(BOOL success, BOOL isPublic, void *param);
 
-//data storage server load complete cb
-typedef void (*LoadFromServerCallback)(BOOL success, int index, char* data, int len, void* param);
+    // data storage server load complete cb
+    typedef void (*LoadFromServerCallback)(BOOL success, int index, char *data, int len, void *param);
 
-struct FriendControl {
-    static FriendControl* sInstance; //803862D0
+    struct FriendControl
+    {
+        static FriendControl *sInstance; // 803862D0
 
-    FriendState state;    //0x0
-    GP::Connection** gpConnection;
-    u32 gpProcessCount; //0x8
-    u8 timeAlignementPadding[4];
-    OS::Time lastGpProcess; //0x10 time at which the last gpProcess was called
-    int friendListLen; //0x18
-    AccFriendData* friendList; //0x1c
+        FriendState state; // 0x0
+        GP::Connection **gpConnection;
+        u32 gpProcessCount; // 0x8
+        u8 timeAlignementPadding[4];
+        OS::Time lastGpProcess;    // 0x10 time at which the last gpProcess was called
+        int friendListLen;         // 0x18
+        AccFriendData *friendList; // 0x1c
 
-    u8  buddyUpdateIdx;      //0x20 Index during synchronous processing of the friend roster
-    bool  friendListChanged;   //1: There has been a change to the friend roster, 0: No change
-    u8  buddyUpdateState;    //Synchronous processing status of friend roster. Defined using DWC_BUDDY_UPDATE_STATE_* enumerator.
-    vu8 svUpdateComplete;    //friend list synchronization complete flag synchronization complete with 2
-    u32 persCallbackLevel;   //0x24 Number of callback waits for Persistent data save/load
-    int localProfileID;           //0x28 
-    const u16* playerName;   //0x2c
+        u8 buddyUpdateIdx;      // 0x20 Index during synchronous processing of the friend roster
+        bool friendListChanged; // 1: There has been a change to the friend roster, 0: No change
+        u8 buddyUpdateState;    // Synchronous processing status of friend roster. Defined using DWC_BUDDY_UPDATE_STATE_* enumerator.
+        vu8 svUpdateComplete;   // friend list synchronization complete flag synchronization complete with 2
+        u32 persCallbackLevel;  // 0x24 Number of callback waits for Persistent data save/load
+        int localProfileID;     // 0x28
+        const u16 *playerName;  // 0x2c
 
-    UpdateServersCallback updateCallback;     //0x30 friend list synchronization complete callback
-    void* updateParam;       //0x34
-    FriendStatusCallback statusCallback;      //0x38 Callback for notification of changes to friend status
-    void* statusParam; //RKNet::Controller in mkwii
-    DeleteFriendListCallback deleteCallback;  //0x40 Friend roster delete callback
-    void* deleteParam;
-    BuddyFriendCallback buddyCallback;        //0x48 Callback for establishing friendship
-    void* buddyParam; //RKNet::Controller in mkwii
-    StorageLoginCallback persLoginCallback;   //0x50 Persistent server login completion notification callback
-    void* persLoginParam;
-    SaveToServerCallback saveCallback;        //0x58 Persistent server save callback
-    LoadFromServerCallback loadCallback;      //0x5c Persistent server load callback
-}; //0x60
+        UpdateServersCallback updateCallback;    // 0x30 friend list synchronization complete callback
+        void *updateParam;                       // 0x34
+        FriendStatusCallback statusCallback;     // 0x38 Callback for notification of changes to friend status
+        void *statusParam;                       // RKNet::Controller in mkwii
+        DeleteFriendListCallback deleteCallback; // 0x40 Friend roster delete callback
+        void *deleteParam;
+        BuddyFriendCallback buddyCallback;      // 0x48 Callback for establishing friendship
+        void *buddyParam;                       // RKNet::Controller in mkwii
+        StorageLoginCallback persLoginCallback; // 0x50 Persistent server login completion notification callback
+        void *persLoginParam;
+        SaveToServerCallback saveCallback;   // 0x58 Persistent server save callback
+        LoadFromServerCallback loadCallback; // 0x5c Persistent server load callback
+    }; // 0x60
 
-void iFriendInit(FriendControl* control, GP::Connection* gpConnection, const u16* playerName, AccFriendData* friendList, int friendListLen); //800ce414
-BOOL CanChangeFriendList(); //800ce2e4 is FriendControl ready or busy
-void DeleteBuddyFriendData(AccFriendData* friendData); //800ce314
-}//namespace DWC
-
+    void iFriendInit(FriendControl *control, GP::Connection *gpConnection, const u16 *playerName, AccFriendData *friendList, int friendListLen); // 800ce414
+    BOOL CanChangeFriendList();                                                                                                                  // 800ce2e4 is FriendControl ready or busy
+    void DeleteBuddyFriendData(AccFriendData *friendData);                                                                                       // 800ce314
+} // namespace DWC
 
 #endif

--- a/GameSource/core/rvl/DWC/DWCLogin.hpp
+++ b/GameSource/core/rvl/DWC/DWCLogin.hpp
@@ -1,57 +1,59 @@
-#ifndef _DWCLOGIN_ //to split into multiple files ultimately
+#ifndef _DWCLOGIN_ // to split into multiple files ultimately
 #define _DWCLOGIN_
 
 #include <types.hpp>
 #include <core/rvl/DWC/DWCAccount.hpp>
 #include <core/rvl/DWC/DWCError.hpp>
-#include <core/rvl/os/OS.hpp>
+#include <core/rvl/OS/OS.hpp>
 
-//Credit Seeky
+// Credit Seeky
 
-namespace DWC { //this is C, but don't care
+namespace DWC
+{ // this is C, but don't care
 
-enum LoginState {
-    DWC_LOGIN_STATE_INIT,         //Initial state
-    DWC_LOGIN_STATE_REMOTE_AUTH,      //Currently performing remote authentication
-    DWC_LOGIN_STATE_CONNECTING,       //Connecting to GP server
-    DWC_LOGIN_STATE_GPGETINFO,        //When getting lastname upon login to GP
-    DWC_LOGIN_STATE_GPSETINFO,        //lastname setting upon the first login to GP
-    DWC_LOGIN_STATE_CONNECTED,        //Connected status
-    DWC_LOGIN_STATE_NUM
-};
+    enum LoginState
+    {
+        DWC_LOGIN_STATE_INIT,        // Initial state
+        DWC_LOGIN_STATE_REMOTE_AUTH, // Currently performing remote authentication
+        DWC_LOGIN_STATE_CONNECTING,  // Connecting to GP server
+        DWC_LOGIN_STATE_GPGETINFO,   // When getting lastname upon login to GP
+        DWC_LOGIN_STATE_GPSETINFO,   // lastname setting upon the first login to GP
+        DWC_LOGIN_STATE_CONNECTED,   // Connected status
+        DWC_LOGIN_STATE_NUM
+    };
 
-//Login complete callback
-typedef void (*LoginCallback)(Error error, int profileID, void* param);
+    // Login complete callback
+    typedef void (*LoginCallback)(Error error, int profileID, void *param);
 
-struct LoginControl {
-    static LoginControl* sInstance; //803862E8
-    GP::Connection** gpConnection;
-    LoginState state; //0x4
-    int  gameID; //gamespy
-    u32  gamecode; //nintendo
-    const u16* playerName; //0x10
-    LoginCallback callback; //0x14
-    void* param; //0x18
+    struct LoginControl
+    {
+        static LoginControl *sInstance; // 803862E8
+        GP::Connection **gpConnection;
+        LoginState state;       // 0x4
+        int gameID;             // gamespy
+        u32 gamecode;           // nintendo
+        const u16 *playerName;  // 0x10
+        LoginCallback callback; // 0x14
+        void *param;            // 0x18
 
-    AccUserData* userdata; //0x1c
-    u8 unknown_0x20[0x8];
-    //void* bmwork; //0x20
-    //void* http; //0x24
-    OS::Time startTime; //0x28
-    u32 connectFlag; //0x30
-    u8 timeAlignmentPadding[4];
-    OS::Time connectTime; //0x38
-    AccLoginId tempLoginId; //0x40
-    char authToken[256];  //0x4c Token for authentication
-    char partnerChallenge[256];  //0x14c Challenge value for authentication
-    char username[21]; //0x24c
-    u8 padding[3];
-}; //0x268
+        AccUserData *userdata; // 0x1c
+        u8 unknown_0x20[0x8];
+        // void* bmwork; //0x20
+        // void* http; //0x24
+        OS::Time startTime; // 0x28
+        u32 connectFlag;    // 0x30
+        u8 timeAlignmentPadding[4];
+        OS::Time connectTime;       // 0x38
+        AccLoginId tempLoginId;     // 0x40
+        char authToken[256];        // 0x4c Token for authentication
+        char partnerChallenge[256]; // 0x14c Challenge value for authentication
+        char username[21];          // 0x24c
+        u8 padding[3];
+    }; // 0x268
 
-void iLoginInit(LoginControl* control, AccUserData* userdata, GP::Connection** gpConnection, int productID, u32 gamecode, const u16* playerName, LoginCallback callback, void* param); //800cff58
-void iLoginAsync(void); //800d00ac
-AccUserData* iGetUserData(); //800d0274
-}//namespace DWC
-
+    void iLoginInit(LoginControl *control, AccUserData *userdata, GP::Connection **gpConnection, int productID, u32 gamecode, const u16 *playerName, LoginCallback callback, void *param); // 800cff58
+    void iLoginAsync(void);                                                                                                                                                                // 800d00ac
+    AccUserData *iGetUserData();                                                                                                                                                           // 800d0274
+} // namespace DWC
 
 #endif

--- a/GameSource/core/rvl/DWC/DWCMatch.hpp
+++ b/GameSource/core/rvl/DWC/DWCMatch.hpp
@@ -1,254 +1,264 @@
-#ifndef _DWC_MATCH_ //to split into multiple files ultimately
+#ifndef _DWC_MATCH_ // to split into multiple files ultimately
 #define _DWC_MATCH_
 #include <types.hpp>
 #include <core/GS/GT2/GT2.hpp>
 #include <core/GS/GP/GP.hpp>
 #include <core/rvl/DWC/DWCAccount.hpp>
 #include <core/rvl/DWC/DWCError.hpp>
-#include <core/rvl/os/OS.hpp>
+#include <core/rvl/OS/OS.hpp>
 
-//Credit Seeky
+// Credit Seeky
 
-namespace DWC { //this is probably C, but don't care
+namespace DWC
+{ // this is probably C, but don't care
 
-enum MatchState {
-    DWC_MATCH_STATE_INIT = 0,           //Initial state
+    enum MatchState
+    {
+        DWC_MATCH_STATE_INIT = 0, // Initial state
 
-    //Client Status
-    DWC_MATCH_STATE_CL_WAITING,         //Wait status
-    DWC_MATCH_STATE_CL_SEARCH_OWN,      //Searching for information on own host
-    DWC_MATCH_STATE_CL_SEARCH_HOST,     //Open host search status (only when not specifying friends)
-    DWC_MATCH_STATE_CL_WAIT_RESV,       //Waiting for response from server to be reserved
-    DWC_MATCH_STATE_CL_SEARCH_NN_HOST,  //Searching for partner host that has been reserved
-    DWC_MATCH_STATE_CL_NN,              //NAT negotiation in progress
-    DWC_MATCH_STATE_CL_GT2,             //Establishing GT2 connection
-    DWC_MATCH_STATE_CL_CANCEL_SYN,      //matchmaking cancellation synchronization adjustment underway for the server-client
-    DWC_MATCH_STATE_CL_SYN,             //matchmaking completion synchronization adjustment underway
+        // Client Status
+        DWC_MATCH_STATE_CL_WAITING,        // Wait status
+        DWC_MATCH_STATE_CL_SEARCH_OWN,     // Searching for information on own host
+        DWC_MATCH_STATE_CL_SEARCH_HOST,    // Open host search status (only when not specifying friends)
+        DWC_MATCH_STATE_CL_WAIT_RESV,      // Waiting for response from server to be reserved
+        DWC_MATCH_STATE_CL_SEARCH_NN_HOST, // Searching for partner host that has been reserved
+        DWC_MATCH_STATE_CL_NN,             // NAT negotiation in progress
+        DWC_MATCH_STATE_CL_GT2,            // Establishing GT2 connection
+        DWC_MATCH_STATE_CL_CANCEL_SYN,     // matchmaking cancellation synchronization adjustment underway for the server-client
+        DWC_MATCH_STATE_CL_SYN,            // matchmaking completion synchronization adjustment underway
 
-    //Client Status
-    DWC_MATCH_STATE_SV_WAITING,         //Wait status
-    DWC_MATCH_STATE_SV_OWN_NN,          //NAT negotiation with client in progress
-    DWC_MATCH_STATE_SV_OWN_GT2,         //Establishing GT2 connection with client
-    DWC_MATCH_STATE_SV_WAIT_CL_LINK,    //Waiting for connection between clients to complete
-    DWC_MATCH_STATE_SV_CANCEL_SYN,      //Waiting for SYN-ACK for server-client matchmaking cancellation synchronization adjustment
-    DWC_MATCH_STATE_SV_CANCEL_SYN_WAIT, //waiting on end to matchmaking cancellation synchronization adjustment for the server-client
-    DWC_MATCH_STATE_SV_SYN,             //Waiting for matchmaking completion synchronization adjustment SYN-ACK
-    DWC_MATCH_STATE_SV_SYN_WAIT,        //Waiting for matchmaking completion synchronization adjustment to complete
+        // Client Status
+        DWC_MATCH_STATE_SV_WAITING,         // Wait status
+        DWC_MATCH_STATE_SV_OWN_NN,          // NAT negotiation with client in progress
+        DWC_MATCH_STATE_SV_OWN_GT2,         // Establishing GT2 connection with client
+        DWC_MATCH_STATE_SV_WAIT_CL_LINK,    // Waiting for connection between clients to complete
+        DWC_MATCH_STATE_SV_CANCEL_SYN,      // Waiting for SYN-ACK for server-client matchmaking cancellation synchronization adjustment
+        DWC_MATCH_STATE_SV_CANCEL_SYN_WAIT, // waiting on end to matchmaking cancellation synchronization adjustment for the server-client
+        DWC_MATCH_STATE_SV_SYN,             // Waiting for matchmaking completion synchronization adjustment SYN-ACK
+        DWC_MATCH_STATE_SV_SYN_WAIT,        // Waiting for matchmaking completion synchronization adjustment to complete
 
-    //Common Status
-    DWC_MATCH_STATE_WAIT_CLOSE,         //Waiting for connection close to complete
+        // Common Status
+        DWC_MATCH_STATE_WAIT_CLOSE, // Waiting for connection close to complete
 
-    //Status only while using matchmaking option
-    DWC_MATCH_STATE_SV_POLL_TIMEOUT,    //Server is currently polling for OPTION_MIN_COMPLETE timeouts
+        // Status only while using matchmaking option
+        DWC_MATCH_STATE_SV_POLL_TIMEOUT, // Server is currently polling for OPTION_MIN_COMPLETE timeouts
 
-    DWC_MATCH_STATE_NUM
-};
+        DWC_MATCH_STATE_NUM
+    };
 
-enum MatchCommand {
-    MATCH_COMMAND_RESERVATION = 1,
-    MATCH_COMMAND_RESV_OK = 2,
-    MATCH_COMMAND_RESV_DENY = 3,
-    MATCH_COMMAND_RESV_WAIT = 4,
-    MATCH_COMMAND_RESV_CANCEL = 5,
-    MATCH_COMMAND_TELL_ADDR = 6,
-    MATCH_COMMAND_NEW_PID_AID = 7,
-    MATCH_COMMAND_CANCEL = 0xc,
-    MATCH_COMMAND_CANCEL_SYN = 0xd,
-    MATCH_COMMAND_CANCEL_SYN_ACK = 0xe,
-    MATCH_COMMAND_CANCEL_ACK = 0xf,
-    MATCH_COMMAND_SL_CLOSE_CL = 0x10,
-    MATCH_COMMAND_SVDOWNQUERY = 0x52,
-    MATCH_COMMAND_SVDOWN_ACK = 0x53,
-    MATCH_COMMAND_SVDOWN_NAK = 0x54,
-    MATCH_COMMAND_SVDOWN_KEEP = 0x55,
-    MATCH_COMMAND_SB_RETRY_SEARCH = 0x70,
-    MATCH_COMMAND_SUSPEND_MATCH = 0x82,
-    MATCH_COMMAND_SLOT_LIST = 0x83,
-    MATCH_COMMAND_DUMMY = 0xff,
-};
+    enum MatchCommand
+    {
+        MATCH_COMMAND_RESERVATION = 1,
+        MATCH_COMMAND_RESV_OK = 2,
+        MATCH_COMMAND_RESV_DENY = 3,
+        MATCH_COMMAND_RESV_WAIT = 4,
+        MATCH_COMMAND_RESV_CANCEL = 5,
+        MATCH_COMMAND_TELL_ADDR = 6,
+        MATCH_COMMAND_NEW_PID_AID = 7,
+        MATCH_COMMAND_CANCEL = 0xc,
+        MATCH_COMMAND_CANCEL_SYN = 0xd,
+        MATCH_COMMAND_CANCEL_SYN_ACK = 0xe,
+        MATCH_COMMAND_CANCEL_ACK = 0xf,
+        MATCH_COMMAND_SL_CLOSE_CL = 0x10,
+        MATCH_COMMAND_SVDOWNQUERY = 0x52,
+        MATCH_COMMAND_SVDOWN_ACK = 0x53,
+        MATCH_COMMAND_SVDOWN_NAK = 0x54,
+        MATCH_COMMAND_SVDOWN_KEEP = 0x55,
+        MATCH_COMMAND_SB_RETRY_SEARCH = 0x70,
+        MATCH_COMMAND_SUSPEND_MATCH = 0x82,
+        MATCH_COMMAND_SLOT_LIST = 0x83,
+        MATCH_COMMAND_DUMMY = 0xff,
+    };
 
-enum MatchType {
-    MATCH_TYPE_ANYBODY,
-    MATCH_TYPE_FRIEND,
-    MATCH_TYPE_SC_SV,
-    MATCH_TYPE_SV_CL
-};
+    enum MatchType
+    {
+        MATCH_TYPE_ANYBODY,
+        MATCH_TYPE_FRIEND,
+        MATCH_TYPE_SC_SV,
+        MATCH_TYPE_SV_CL
+    };
 
-//friend specified/unspecified peer matchmaking completion cb
-typedef void (*MatchedCallback)(Error error, BOOL cancel, void* param);
+    // friend specified/unspecified peer matchmaking completion cb
+    typedef void (*MatchedCallback)(Error error, BOOL cancel, void *param);
 
-//server-client matchmaking complete cb
-typedef void (*MatchedSCCallback)(Error error, BOOL cancel, BOOL self, BOOL isServer, int index, void* param);
+    // server-client matchmaking complete cb
+    typedef void (*MatchedSCCallback)(Error error, BOOL cancel, BOOL self, BOOL isServer, int index, void *param);
 
-//New connection client 
-typedef void (*NewClientCallback)(int index, void* param);
+    // New connection client
+    typedef void (*NewClientCallback)(int index, void *param);
 
-//player evaluation, negative ret = no matchmaking, positive = the higher the more likely to be selected
-typedef int (*EvalPlayerCallback)(int index, void* param);
+    // player evaluation, negative ret = no matchmaking, positive = the higher the more likely to be selected
+    typedef int (*EvalPlayerCallback)(int index, void *param);
 
-//server-client matchmaking cancellation complete cb
-typedef void (*StopSCCallback)(void* param);
+    // server-client matchmaking cancellation complete cb
+    typedef void (*StopSCCallback)(void *param);
 
-//connection attempt (non-official)
-typedef bool (*ConnectionAttemptCallback)(void* userData, void* param); //false = deny connection
+    // connection attempt (non-official)
+    typedef bool (*ConnectionAttemptCallback)(void *userData, void *param); // false = deny connection
 
-struct NNInfo {
-    u8  isQR2; //1: Retry unnecessary because QR2, 0: Retry required because SB
-    u8  retryCount; //Counter to measure retry attempts
-    u16 port; //NAT Negotiation destination port number
-    u32 ip; //0x4 NAT Negotiation destination IP
-    int cookie; //0x8 NAT Negotiation cookie value. 0 indicates no NN in progress
-}; //0xc
+    struct NNInfo
+    {
+        u8 isQR2;      // 1: Retry unnecessary because QR2, 0: Retry required because SB
+        u8 retryCount; // Counter to measure retry attempts
+        u16 port;      // NAT Negotiation destination port number
+        u32 ip;        // 0x4 NAT Negotiation destination IP
+        int cookie;    // 0x8 NAT Negotiation cookie value. 0 indicates no NN in progress
+    }; // 0xc
 
-struct MatchCommandControl {
-    u8  command; //Send command
-    u8  count; //Number of retries
-    u16 port; //Send destination QR2 public port number
-    u32 ip; //0x4 Send destination QR2 IP
-    u32 data[32]; //0x8 Added send data
-    int profileID; //0x88 Send destination profile ID
-    int len; //0x8c Added send data request count
-    OS::Time sendTime; //0x90 Send time
-}; //0x98
+    struct MatchCommandControl
+    {
+        u8 command;        // Send command
+        u8 count;          // Number of retries
+        u16 port;          // Send destination QR2 public port number
+        u32 ip;            // 0x4 Send destination QR2 IP
+        u32 data[32];      // 0x8 Added send data
+        int profileID;     // 0x88 Send destination profile ID
+        int len;           // 0x8c Added send data request count
+        OS::Time sendTime; // 0x90 Send time
+    }; // 0x98
 
-struct NodeInfo {
-    u32 pid;
-    u8 unknown[0x12];
-    u8 aid; // 0x16
-    u8 unknown_0x1b[0x30 - 0x17];
-}; //0x30
+    struct NodeInfo
+    {
+        u32 pid;
+        u8 unknown[0x12];
+        u8 aid; // 0x16
+        u8 unknown_0x1b[0x30 - 0x17];
+    }; // 0x30
 
-size_assert(NodeInfo, 0x30);
+    size_assert(NodeInfo, 0x30);
 
-struct MatchControl {
-    static MatchControl* sInstance; //8038630C
+    struct MatchControl
+    {
+        static MatchControl *sInstance; // 8038630C
 
-    GP::Connection** gpConnection;
-    GT2::Socket* gt2Socket; //0x4
-    GT2::ConnectionCallbacks* gt2Callbacks; //0x8
+        GP::Connection **gpConnection;
+        GT2::Socket *gt2Socket;                 // 0x4
+        GT2::ConnectionCallbacks *gt2Callbacks; // 0x8
 
-    u8 gt2ConnectCount; //0xc GT2 retry counter
-    u8 gt2NumConnection; //Number of established GT2 connections
-    u8 gt2NumValidConn; //Number of valid GT2 connections that have completed connection to all members
-    u8 padding;
+        u8 gt2ConnectCount;  // 0xc GT2 retry counter
+        u8 gt2NumConnection; // Number of established GT2 connections
+        u8 gt2NumValidConn;  // Number of valid GT2 connections that have completed connection to all members
+        u8 padding;
 
-    void* qr2; //0x10 Pointer to QR2 object
-    u8 unknown_0x14[2];
-    vu8  qr2MatchType; //0x16 Matchmaking type DWC_MATCH_TYPE_* enumerator
-    vu8  qr2NumEntry; //0x17 The maximum number to be gathered, excluding self
-    vu8  qr2IsReserved; //0x18 1: Completed NN Reservation to self, 0: No reservation
-    u8 unknown_0x19[0x30 - 0x19];
-    vu8  qr2NNFinishCount; //0x30 NAT negotiation completion counter
-    u8 padding2[3];
-    u32 _34; //0x34
-    NodeInfo nodes[32]; //0x38
-    u32 serverPid; //0x638
-    u8 unknown_0x63c[0x6d0 - 0x63c];
-    u16  qr2Port; //0x6d0
-    u8 padding3[2];
-    u32  qr2IP; //0x6d4
-    u8 unknown_0x6d8[4];
-    void* serverBrowser; //0x6dc
-    u8 unknown_0x6e0[0x6f8 - 0x6e0];
-    u8  nnRecvCount; //0x6f8 Count for receiving the same NAT negotiation
-    u8  nnFailureCount; //0x6f9 NN failure count
-    u16 nnCookieRand; //0x6fa Random number for cookies used in NAT negotiation
-    int nnLastCookie; //0x6fc Cookie for NN  received the time before
-    OS::Time nnFailedTime; //0x700 Time when NAT negotiation failed
-    OS::Time nnFinishTime; //0x708 Time when NAT negotiation terminated
-    NNInfo nnInfo; //0x710 NAT negotiation data structure
-    MatchState state; //0x71c Matchmaking progress status
+        void *qr2; // 0x10 Pointer to QR2 object
+        u8 unknown_0x14[2];
+        vu8 qr2MatchType;  // 0x16 Matchmaking type DWC_MATCH_TYPE_* enumerator
+        vu8 qr2NumEntry;   // 0x17 The maximum number to be gathered, excluding self
+        vu8 qr2IsReserved; // 0x18 1: Completed NN Reservation to self, 0: No reservation
+        u8 unknown_0x19[0x30 - 0x19];
+        vu8 qr2NNFinishCount; // 0x30 NAT negotiation completion counter
+        u8 padding2[3];
+        u32 _34;            // 0x34
+        NodeInfo nodes[32]; // 0x38
+        u32 serverPid;      // 0x638
+        u8 unknown_0x63c[0x6d0 - 0x63c];
+        u16 qr2Port; // 0x6d0
+        u8 padding3[2];
+        u32 qr2IP; // 0x6d4
+        u8 unknown_0x6d8[4];
+        void *serverBrowser; // 0x6dc
+        u8 unknown_0x6e0[0x6f8 - 0x6e0];
+        u8 nnRecvCount;        // 0x6f8 Count for receiving the same NAT negotiation
+        u8 nnFailureCount;     // 0x6f9 NN failure count
+        u16 nnCookieRand;      // 0x6fa Random number for cookies used in NAT negotiation
+        int nnLastCookie;      // 0x6fc Cookie for NN  received the time before
+        OS::Time nnFailedTime; // 0x700 Time when NAT negotiation failed
+        OS::Time nnFinishTime; // 0x708 Time when NAT negotiation terminated
+        NNInfo nnInfo;         // 0x710 NAT negotiation data structure
+        MatchState state;      // 0x71c Matchmaking progress status
 
-    u8 unknown_0x720[0x778 - 0x720];
-    volatile int profileID; //0x778 This players Profile ID
-    int reqProfileID; //0x77c Profile ID of partner that send NN request for friend specified peer matching
-    u8 unknown_0x780[4];
-    const char* gameName; //0x784 GameSpy
-    const char* secretKey; //0x788 GameSpy
-    const AccFriendData* friendList; //0x78c Pointer to Friend roster
-    int friendListLen; //0x790  Friend roster length
-    u8  friendIdxList[64]; //0x794 Matchmaking friend index list
-    int friendIdxListLen; //0x7d4 Matchmaking friend index list length
-    MatchCommandControl commandControl; //0x7d8 Matchmaking command control structure
-    MatchedSCCallback matchedCallback; //0x870
-    void* matchedParam;
-    NewClientCallback newClientCallback; //0x878
-    void* newClientParam;
-    EvalPlayerCallback evalCallback; //0x880
-    void* evalParam;
-    StopSCCallback stopSCCallback; //0x888 server-client matchmaking cancellation complete callback
-    void* stopSCParam; //0x88c RKNet::Controller in mkwii
+        u8 unknown_0x720[0x778 - 0x720];
+        volatile int profileID; // 0x778 This players Profile ID
+        int reqProfileID;       // 0x77c Profile ID of partner that send NN request for friend specified peer matching
+        u8 unknown_0x780[4];
+        const char *gameName;               // 0x784 GameSpy
+        const char *secretKey;              // 0x788 GameSpy
+        const AccFriendData *friendList;    // 0x78c Pointer to Friend roster
+        int friendListLen;                  // 0x790  Friend roster length
+        u8 friendIdxList[64];               // 0x794 Matchmaking friend index list
+        int friendIdxListLen;               // 0x7d4 Matchmaking friend index list length
+        MatchCommandControl commandControl; // 0x7d8 Matchmaking command control structure
+        MatchedSCCallback matchedCallback;  // 0x870
+        void *matchedParam;
+        NewClientCallback newClientCallback; // 0x878
+        void *newClientParam;
+        EvalPlayerCallback evalCallback; // 0x880
+        void *evalParam;
+        StopSCCallback stopSCCallback; // 0x888 server-client matchmaking cancellation complete callback
+        void *stopSCParam;             // 0x88c RKNet::Controller in mkwii
 
-    u8 unknown_0x890[0x8a4 - 0x890];
-    ConnectionAttemptCallback attemptCallback; //0x8a4
-    u32 userData; //0x8a8 RKNet::ConnectionUserData in mkwii
-    void* attemptCallbackParam; //0x8ac RKNet::Controller in mkwii
+        u8 unknown_0x890[0x8a4 - 0x890];
+        ConnectionAttemptCallback attemptCallback; // 0x8a4
+        u32 userData;                              // 0x8a8 RKNet::ConnectionUserData in mkwii
+        void *attemptCallbackParam;                // 0x8ac RKNet::Controller in mkwii
 
-    u8 unknown_0x8b0[0x10];
-}; //0x8c0
+        u8 unknown_0x8b0[0x10];
+    }; // 0x8c0
 
-size_assert(MatchControl, 0x8c0);
+    size_assert(MatchControl, 0x8c0);
 
-struct MatchCommandHeader {
-    u32 identifier; //magic
-    u32 version; //0x4
-    u8 type; //0x8 see enum
-    u8 sizeAppended; //0x9
-    u16 qr2port; //0xa
-    u32 qr2IP; //0xc
-    u32 pid; //0x10
-    //followed by data
-};
+    struct MatchCommandHeader
+    {
+        u32 identifier;  // magic
+        u32 version;     // 0x4
+        u8 type;         // 0x8 see enum
+        u8 sizeAppended; // 0x9
+        u16 qr2port;     // 0xa
+        u32 qr2IP;       // 0xc
+        u32 pid;         // 0x10
+        // followed by data
+    };
 
-struct Reservation { //little endian
-    MatchType type;
-    u32 publicIP; //0x4
-    u32 publicPort; //0x8
-    u32 localIP; //0xc
-    u32 localPort; //0x10
-    u32 unknown_0x14; //0x
-    u32 isFriend;
-    u32 localPlayerCount;
-    u32 resvCheckValue;
-}; //0x24
+    struct Reservation
+    { // little endian
+        MatchType type;
+        u32 publicIP;     // 0x4
+        u32 publicPort;   // 0x8
+        u32 localIP;      // 0xc
+        u32 localPort;    // 0x10
+        u32 unknown_0x14; // 0x
+        u32 isFriend;
+        u32 localPlayerCount;
+        u32 resvCheckValue;
+    }; // 0x24
 
-struct ResvOk {
-    u32 maxPlayers;
-    u32 clientSlotIndexSender;
-    u32 pid;
-    u32 publicIP;
-    u32 publicPort;
-    u32 localIP;
-    u32 localPort;
-    u32 unknown_0x1c;
-    u32 localPlayerCount;
-    u32 groupId;
-    u32 clientSlotIndexReceiver;
-    u32 consoleCountInRoom;
-    u32 resvCheckValue;
-}; //0x34
+    struct ResvOk
+    {
+        u32 maxPlayers;
+        u32 clientSlotIndexSender;
+        u32 pid;
+        u32 publicIP;
+        u32 publicPort;
+        u32 localIP;
+        u32 localPort;
+        u32 unknown_0x1c;
+        u32 localPlayerCount;
+        u32 groupId;
+        u32 clientSlotIndexReceiver;
+        u32 consoleCountInRoom;
+        u32 resvCheckValue;
+    }; // 0x34
 
-struct ResvDeny {
-    u32 errorId;
-    /* 0x10 = room is full (but not on suspend) (never seen in-game, but is implemented in the game code)
-       0x11 = Room has already started playing since you tried joining
-       0x12 = Room is on suspend.
-    */
-};
+    struct ResvDeny
+    {
+        u32 errorId;
+        /* 0x10 = room is full (but not on suspend) (never seen in-game, but is implemented in the game code)
+           0x11 = Room has already started playing since you tried joining
+           0x12 = Room is on suspend.
+        */
+    };
 
+    void iMatchInit(MatchControl *control, GP::Connection *gpConnection, GT2::Socket *gt2Socket, GT2::ConnectionCallbacks *gt2Callbacks,
+                    const char *gameName, const char *secretKey, const AccFriendData friendList[], int friendListLen); // 800d4bbc
 
-void iMatchInit(MatchControl* control, GP::Connection* gpConnection, GT2::Socket* gt2Socket, GT2::ConnectionCallbacks* gt2Callbacks,
-    const char* gameName, const char* secretKey, const AccFriendData friendList[], int  friendListLen); //800d4bbc
-
-void SendMatchCommand(MatchCommand type, u32 pid, u32 ip, u16 port, void* data, u32 dataSize); //800dbd38
-void SendResvCommand(u32 pid, u32 r4); //800deddc
-void ProcessRecvMatchCommand(MatchCommand type, u32 pid, u32 qr2IP, u32 qr2Port, void* data, u32 dataSize); //800dc234
-MatchCommand CheckResvCommand(u32 pid, u32 publicIP, u16 port, MatchType matchType, BOOL isPriorityNN, void* userdata); //800de6b8 userdata = RKNet::ConnectionUserData in mkwii
-u8  AddMatchKeyString(u8 keyID, const char* keyString, const char* valueSrc); //800d45f4
-u8  AddMatchKeyInt(u8 keyID, const char* keyString, const int* valueSrc); //800d4258
-BOOL ConnectToAnybodyAsync(u8  numEntry, const char* addFilter, MatchedCallback matchedCallback, void* matchedParam,
-    EvalPlayerCallback evalCallback, void* evalParam); //800d1840
-}//namespace DWC
-
+    void SendMatchCommand(MatchCommand type, u32 pid, u32 ip, u16 port, void *data, u32 dataSize);                          // 800dbd38
+    void SendResvCommand(u32 pid, u32 r4);                                                                                  // 800deddc
+    void ProcessRecvMatchCommand(MatchCommand type, u32 pid, u32 qr2IP, u32 qr2Port, void *data, u32 dataSize);             // 800dc234
+    MatchCommand CheckResvCommand(u32 pid, u32 publicIP, u16 port, MatchType matchType, BOOL isPriorityNN, void *userdata); // 800de6b8 userdata = RKNet::ConnectionUserData in mkwii
+    u8 AddMatchKeyString(u8 keyID, const char *keyString, const char *valueSrc);                                            // 800d45f4
+    u8 AddMatchKeyInt(u8 keyID, const char *keyString, const int *valueSrc);                                                // 800d4258
+    BOOL ConnectToAnybodyAsync(u8 numEntry, const char *addFilter, MatchedCallback matchedCallback, void *matchedParam,
+                               EvalPlayerCallback evalCallback, void *evalParam); // 800d1840
+} // namespace DWC
 
 #endif

--- a/GameSource/core/rvl/DWC/DWCTransport.hpp
+++ b/GameSource/core/rvl/DWC/DWCTransport.hpp
@@ -1,78 +1,78 @@
-#ifndef _DWC_TRANSPORT_ 
+#ifndef _DWC_TRANSPORT_
 #define _DWC_TRANSPORT_
 #include <types.hpp>
-#include <core/rvl/os/OS.hpp>
+#include <core/rvl/OS/OS.hpp>
 #include <core/GS/GT2/GT2.hpp>
 
+namespace DWC
+{ // this is C, but don't care
 
-namespace DWC { //this is C, but don't care
+    typedef void (*UserSendCallback)(int size, u8 aid);
+    typedef void (*UserRecvCallback)(u8 aid, u8 *buffer, int size);
+    typedef void (*UserRecvTimeoutCallback)(u8 aid);
+    typedef void (*UserPingCallback)(int latency, u8 aid);
 
-typedef void (*UserSendCallback)(int size, u8 aid);
-typedef void (*UserRecvCallback)(u8 aid, u8* buffer, int size);
-typedef void (*UserRecvTimeoutCallback)(u8 aid);
-typedef void (*UserPingCallback)(int latency, u8 aid);
+    enum ReceiveStatus
+    {
+        DWC_TRANSPORT_RECV_NOBUF,       // Receive buffer not set
+        DWC_TRANSPORT_RECV_HEADER,      // Wait to receive header
+        DWC_TRANSPORT_RECV_BODY,        // Wait for data
+        DWC_TRANSPORT_RECV_SYSTEM_DATA, // Wait for data used internally
+        DWC_TRANSPORT_RECV_ERROR,
+        DWC_TRANSPORT_RECV_LAST
+    };
 
-enum ReceiveStatus {
-    DWC_TRANSPORT_RECV_NOBUF,		//Receive buffer not set
-    DWC_TRANSPORT_RECV_HEADER,		//Wait to receive header
-    DWC_TRANSPORT_RECV_BODY,		//Wait for data
-    DWC_TRANSPORT_RECV_SYSTEM_DATA,	//Wait for data used internally
-    DWC_TRANSPORT_RECV_ERROR,
-    DWC_TRANSPORT_RECV_LAST
-};
+    enum SendStatus
+    {
+        DWC_SEND_TYPE_INVALID,
+        DWC_SEND_TYPE_USERDATA,      // User data
+        DWC_SEND_TYPE_MATCH_SYN,     // SYN used for matchmaking end sync
+        DWC_SEND_TYPE_MATCH_SYN_ACK, // SYN-ACK used for matchmaking end sync
+        DWC_SEND_TYPE_MATCH_ACK,     // ACK used for matchmaking end sync
+    };
 
-enum SendStatus {
-    DWC_SEND_TYPE_INVALID,
-    DWC_SEND_TYPE_USERDATA,							//User data
-    DWC_SEND_TYPE_MATCH_SYN,						//SYN used for matchmaking end sync
-    DWC_SEND_TYPE_MATCH_SYN_ACK,					//SYN-ACK used for matchmaking end sync
-    DWC_SEND_TYPE_MATCH_ACK,						//ACK used for matchmaking end sync
-};
+    struct TransportConnection
+    {
 
-struct TransportConnection {
+        const u8 *sendBuffer;
+        u8 *recvBuffer;            // 0x4 RACEPacket
+        int recvBufferSize;        // 0x8
+        int sendingSize;           // 0xc  Size of data being sent
+        int recvingSize;           // 0x10 Size of data being received
+        int requestSendSize;       // 0x14 Send request size
+        int requestRecvSize;       // 0x18 Receive request size
+        u8 sendState;              // 0x1c Send status enum
+        u8 recvState;              // 0x1d Receive status enum
+        u8 lastRecvState;          // 0x1e Last receive status before receiving header
+        u8 padding[3];             // 0x1f
+        u16 lastRecvType;          // 0x22Last header type received
+        OS::Tick previousRecvTick; // 0x24
+        u32 recvTimeoutTime;       // 0x28
+    }; // 0x2c
 
-    const u8* sendBuffer;
-    u8* recvBuffer;			    //0x4 RACEPacket
-    int	recvBufferSize;		    //0x8
-    int	sendingSize;		    //0xc  Size of data being sent
-    int	recvingSize;		    //0x10 Size of data being received
-    int	requestSendSize;	    //0x14 Send request size
-    int	requestRecvSize;	    //0x18 Receive request size
-    u8	sendState;			    //0x1c Send status enum
-    u8	recvState;			    //0x1d Receive status enum
-    u8	lastRecvState;		    //0x1e Last receive status before receiving header
-    u8	padding[3];             //0x1f
-    u16	lastRecvType;		    //0x22Last header type received
-    OS::Tick previousRecvTick;  //0x24
-    u32	recvTimeoutTime;        //0x28
-}; //0x2c
+    struct TransportInfo
+    {
+        static TransportInfo *sInstance; // 80386318
 
-struct TransportInfo {
-    static TransportInfo* sInstance; //80386318
+        TransportConnection connections[32]; // Data used to manage each connection
 
-    TransportConnection connections[32]; //Data used to manage each connection
+        UserSendCallback sendCb; // 0x800 A transmission completion cb
+        UserRecvCallback recvCb; // 0x804 Receive complete cb
+        u32 unknown_0x808;
+        UserPingCallback pingCb; // 0x80c Ping cb
 
-    UserSendCallback sendCb;			    //0x800 A transmission completion cb
-    UserRecvCallback recvCb;			    //0x804 Receive complete cb
-    u32 unknown_0x808;
-    UserPingCallback pingCb;			    //0x80c Ping cb
+        u16 sendSplitMax; // 0x814 Maximum split size for sending
+        u8 padding[2];
 
-    u16	sendSplitMax;			            //0x814 Maximum split size for sending
-    u8 padding[2];
+        // UserRecvTimeoutCallback	recvTimeoutCb;	//0x80c Receive timeout cb
 
+    }; // 0x818
 
-    //UserRecvTimeoutCallback	recvTimeoutCb;	//0x80c Receive timeout cb
-
-
-
-}; //0x818
-
-BOOL SetRecvBuffer(u8 aid, void* recvBuffer, int size); //800e8750
-void iInitTransport(TransportInfo* info); //800e87c8
-void iRecvCallback(GT2::Connection* connection, GT2::Byte* message, int size, GT2::Bool reliable); //800e8814
-void iPingCallback(GT2::Connection* connection, int latency); //800e88f8
-BOOL SendUnreliable(u8 aid, const void* buffer, int size); //800e8654
-}//namespace DWC
-
+    BOOL SetRecvBuffer(u8 aid, void *recvBuffer, int size);                                            // 800e8750
+    void iInitTransport(TransportInfo *info);                                                          // 800e87c8
+    void iRecvCallback(GT2::Connection *connection, GT2::Byte *message, int size, GT2::Bool reliable); // 800e8814
+    void iPingCallback(GT2::Connection *connection, int latency);                                      // 800e88f8
+    BOOL SendUnreliable(u8 aid, const void *buffer, int size);                                         // 800e8654
+} // namespace DWC
 
 #endif

--- a/GameSource/core/rvl/HBM/HBM.hpp
+++ b/GameSource/core/rvl/HBM/HBM.hpp
@@ -2,63 +2,65 @@
 #define _HBM_
 #include <types.hpp>
 #include <core/rvl/MEM/MEMallocator.hpp>
-#include <core/rvl/mtx/MTX.hpp>
+#include <core/rvl/mtx/mtx.hpp>
 #include <core/rvl/KPAD.hpp>
 
-namespace HBM {
+namespace HBM
+{
 
-typedef int (*SoundCallback)(int evt, int num);
+    typedef int (*SoundCallback)(int evt, int num);
 
-struct KPadData {
-    KPAD::Status* kpad;
-    Vec2D        pos;
-    u32         use_devtype;
-}; //0x10
+    struct KPadData
+    {
+        KPAD::Status *kpad;
+        Vec2D pos;
+        u32 use_devtype;
+    }; // 0x10
 
-struct ControllerData {
-    KPadData wiiCon[4];
-}; //0x40
+    struct ControllerData
+    {
+        KPadData wiiCon[4];
+    }; // 0x40
 
-enum SelectBtnNum { //decided upon button, as in the one that was ultimately selected
-    HBM_SELECT_NULL = -1,
-    HBM_SELECT_HOMEBTN = 0,
-    HBM_SELECT_BTN1,
-    HBM_SELECT_BTN2,
-    HBM_SELECT_BTN3,
-    HBM_SELECT_BTN4,
-    HBM_SELECT_MAX
-};
+    enum SelectBtnNum
+    { // decided upon button, as in the one that was ultimately selected
+        HBM_SELECT_NULL = -1,
+        HBM_SELECT_HOMEBTN = 0,
+        HBM_SELECT_BTN1,
+        HBM_SELECT_BTN2,
+        HBM_SELECT_BTN3,
+        HBM_SELECT_BTN4,
+        HBM_SELECT_MAX
+    };
 
-struct DataInfo {
-    void* layout;
-    void* spkSe;
-    void* msg;
-    void* config;
-    void* mem;  //0x10
-    SoundCallback soundCB;
-    int   backFlag;
-    int   region;
-    int   cursor; //0x20
-    int   messageFlag;
-    u32   configBufSize;
-    u32   memSize;
-    float   frameDelta; //0x30
-    Vec2D  adjust; //0x34
-    MEM::Allocator* pAllocator; //0x3c
-}; //0x40
+    struct DataInfo
+    {
+        void *layout;
+        void *spkSe;
+        void *msg;
+        void *config;
+        void *mem; // 0x10
+        SoundCallback soundCB;
+        int backFlag;
+        int region;
+        int cursor; // 0x20
+        int messageFlag;
+        u32 configBufSize;
+        u32 memSize;
+        float frameDelta;           // 0x30
+        Vec2D adjust;               // 0x34
+        MEM::Allocator *pAllocator; // 0x3c
+    }; // 0x40
 
-void Create(const DataInfo* dataInfo); //801773d0
-void Init(); //80177520
+    void Create(const DataInfo *dataInfo); // 801773d0
+    void Init();                           // 80177520
 
-void CreateSound(const void* soundData, void* memBuf, u32 memSize); //80177740
-SelectBtnNum Calc(const ControllerData* controller); //80177554
-void Draw(); //801775a4
-SelectBtnNum  GetSelectBtnNum(); //80177700
-void SetAdjustFlag(int flag); //80177724
-void UpdateSound(); //80177744
+    void CreateSound(const void *soundData, void *memBuf, u32 memSize); // 80177740
+    SelectBtnNum Calc(const ControllerData *controller);                // 80177554
+    void Draw();                                                        // 801775a4
+    SelectBtnNum GetSelectBtnNum();                                     // 80177700
+    void SetAdjustFlag(int flag);                                       // 80177724
+    void UpdateSound();                                                 // 80177744
 
-
-
-} //namespace HBM
+} // namespace HBM
 #endif
-

--- a/GameSource/core/rvl/KPAD.hpp
+++ b/GameSource/core/rvl/KPAD.hpp
@@ -1,7 +1,7 @@
 #ifndef _KPAD_
 #define _KPAD_
 #include <types.hpp>
-#include <core/rvl/wpad.hpp>
+#include <core/rvl/WPAD.hpp>
 #include <core/rvl/mtx/mtx.hpp>
 
 namespace KPAD { //KPAD, high-level wii remote library

--- a/GameSource/core/rvl/MEM/MEMheap.hpp
+++ b/GameSource/core/rvl/MEM/MEMheap.hpp
@@ -2,7 +2,7 @@
 #define _MEMHEAP_
 #include <types.hpp>
 #include <core/rvl/MEM/MEMlist.hpp>
-#include <core/rvl/os/OSmutex.hpp>
+#include <core/rvl/OS/OSMutex.hpp>
 namespace MEM {
 enum HeapType {
     HEAPTYPE_EXP,    //Expanded

--- a/GameSource/core/rvl/OS/OSAlarm.hpp
+++ b/GameSource/core/rvl/OS/OSAlarm.hpp
@@ -1,30 +1,33 @@
 #ifndef _OSALARM_
 #define _OSALARM_
 #include <types.hpp>
-#include <core/rvl/os/OSContext.hpp>
+#include <core/rvl/OS/OSContext.hpp>
 
-namespace OS {
+namespace OS
+{
 
-struct Alarm;
-typedef void  (*AlarmHandler)(Alarm* alarm, Context* context);
-struct Alarm { //either one-time or periodic handler calls
-    AlarmHandler handler; //0
-    u32 tag; //0x4
-    s64 fire; //0x8
-    Alarm* prev; //0x10
-    Alarm* next; //0x14
+    struct Alarm;
+    typedef void (*AlarmHandler)(Alarm *alarm, Context *context);
+    struct Alarm
+    {                         // either one-time or periodic handler calls
+        AlarmHandler handler; // 0
+        u32 tag;              // 0x4
+        s64 fire;             // 0x8
+        Alarm *prev;          // 0x10
+        Alarm *next;          // 0x14
 
-    //Periodic
-    s64 period; //0x18
-    s64 start; //0x20
-    void* userData; //0x28
-}; //0x2c
+        // Periodic
+        s64 period;     // 0x18
+        s64 start;      // 0x20
+        void *userData; // 0x28
+    }; // 0x2c
 
-struct AlarmQueue {
-    static AlarmQueue queue; //803868A0
-    Alarm* head;
-    Alarm* tail;
-};
+    struct AlarmQueue
+    {
+        static AlarmQueue queue; // 803868A0
+        Alarm *head;
+        Alarm *tail;
+    };
 
-} //namespace OS
+} // namespace OS
 #endif

--- a/GameSource/core/rvl/OS/OSBootInfo.hpp
+++ b/GameSource/core/rvl/OS/OSBootInfo.hpp
@@ -1,23 +1,24 @@
 #ifndef _OSBOOTINFO_
 #define _OSBOOTINFO_
 #include <types.hpp>
-#include <core/rvl/dvd/DVD.hpp>
+#include <core/rvl/dvd/dvd.hpp>
 
-
-namespace OS {
-struct BootInfo {
-    static BootInfo mInstance; //80000000
-    static BootInfo* sInstance; //80386890
-    DVD::DiskID diskID;
-    u32 magic;
-    u32 version;
-    u32 memorySize;
-    u32 consoleType;
-    void* arenaLo;
-    void* arenaHi;
-    void* FSTLocation;
-    u32 FSTMaxLength;
-};
-}//namespace OS
+namespace OS
+{
+    struct BootInfo
+    {
+        static BootInfo mInstance;  // 80000000
+        static BootInfo *sInstance; // 80386890
+        DVD::DiskID diskID;
+        u32 magic;
+        u32 version;
+        u32 memorySize;
+        u32 consoleType;
+        void *arenaLo;
+        void *arenaHi;
+        void *FSTLocation;
+        u32 FSTMaxLength;
+    };
+} // namespace OS
 
 #endif

--- a/GameSource/core/rvl/OS/OSMessage.hpp
+++ b/GameSource/core/rvl/OS/OSMessage.hpp
@@ -1,7 +1,7 @@
 #ifndef _OSMESSAGE_
 #define _OSMESSAGE_
 #include <types.hpp>
-#include <core/rvl/os/OSthread.hpp>
+#include <core/rvl/OS/OSthread.hpp>
 
 namespace OS {
 typedef void* Message;

--- a/GameSource/core/rvl/OS/OSMutex.hpp
+++ b/GameSource/core/rvl/OS/OSMutex.hpp
@@ -1,7 +1,7 @@
 #ifndef _MUTEX_
 #define _MUTEX_
 #include <types.hpp>
-#include <core/rvl/os/OSthread.hpp>
+#include <core/rvl/OS/OSthread.hpp>
 
 namespace OS {
 struct Mutex { //RVL mutexes are recursive

--- a/GameSource/core/rvl/OS/OSthread.hpp
+++ b/GameSource/core/rvl/OS/OSthread.hpp
@@ -1,7 +1,7 @@
 #ifndef _OSTHREAD_
 #define _OSTHREAD_
 #include <types.hpp>
-#include <core/rvl/os/OScontext.hpp>
+#include <core/rvl/OS/OSContext.hpp>
 
 namespace OS {
 class Thread;

--- a/GameSource/core/rvl/gx/GX.hpp
+++ b/GameSource/core/rvl/gx/GX.hpp
@@ -2,9 +2,9 @@
 #define _GX_
 
 #include <types.hpp>
-#include <core/rvl/GX/GXEnum.hpp>
-#include <core/rvl/GX/GXStruct.hpp>
-#include <core/rvl/os/OSthread.hpp>
+#include <core/rvl/gx/GXEnum.hpp>
+#include <core/rvl/gx/GXStruct.hpp>
+#include <core/rvl/OS/OSthread.hpp>
 
 namespace GX {
 

--- a/GameSource/core/rvl/nwc24/NWC24Msg.hpp
+++ b/GameSource/core/rvl/nwc24/NWC24Msg.hpp
@@ -2,52 +2,52 @@
 #define _NWC24MSG_
 #include <types.hpp>
 #include <core/rvl/nwc24/NWC24Types.hpp>
-#include <core/rvl/os/OS.hpp>
+#include <core/rvl/OS/OS.hpp>
 
-namespace NWC24 { //this is C, but don't care
+namespace NWC24
+{ // this is C, but don't care
 
-Error OpenLib(void* workMemory); //801dccfc
-Error CloseLib(); //801dcee8
-Error InitMsgObj(MsgObj* obj, MsgType type); //801dd818 game uses type 2 to publish on the msgboard (game to wii menu)
+    Error OpenLib(void *workMemory);             // 801dccfc
+    Error CloseLib();                            // 801dcee8
+    Error InitMsgObj(MsgObj *obj, MsgType type); // 801dd818 game uses type 2 to publish on the msgboard (game to wii menu)
 
-Error SetMsgToId(MsgObj* obj, u64 userId); //801dda08
-Error SetMsgToAddr(MsgObj* obj, const char* addr, u32 length); //801dda6c
-Error SetMsgSubject(MsgObj* obj, const char* subject, u32 size); //801DDB34
-Error SetMsgTag(MsgObj* obj, u16 tag); //801ddf44
-Error SetMsgLedPattern(MsgObj* obj, u16 pattern); //801de27c
-Error SetMsgAttached(MsgObj* obj, const char* data, u32 size, MIMEType type); //801ddcdc APP WII MSG BOARD, but also img and text used ingame
-Error SetMsgText(MsgObj* obj, const char* text, u32 size, Charset charset, Encoding encoding); //801ddba4
-Error SetMsgAltName(MsgObj* obj, const u16* name, u32 length); //801ddfe0
+    Error SetMsgToId(MsgObj *obj, u64 userId);                                                     // 801dda08
+    Error SetMsgToAddr(MsgObj *obj, const char *addr, u32 length);                                 // 801dda6c
+    Error SetMsgSubject(MsgObj *obj, const char *subject, u32 size);                               // 801DDB34
+    Error SetMsgTag(MsgObj *obj, u16 tag);                                                         // 801ddf44
+    Error SetMsgLedPattern(MsgObj *obj, u16 pattern);                                              // 801de27c
+    Error SetMsgAttached(MsgObj *obj, const char *data, u32 size, MIMEType type);                  // 801ddcdc APP WII MSG BOARD, but also img and text used ingame
+    Error SetMsgText(MsgObj *obj, const char *text, u32 size, Charset charset, Encoding encoding); // 801ddba4
+    Error SetMsgAltName(MsgObj *obj, const u16 *name, u32 length);                                 // 801ddfe0
 
-Error GetMsgType(const MsgObj* obj, MsgType* type); //801de3a8
-Error GetMsgFromId(const MsgObj* obj, u64* userId); //801de51c
-Error GetMsgNumTo(const MsgObj* obj, u32* numTo); //801de548
-Error GetMsgNumAttached(const MsgObj* obj, u32* numAttached); //801de420
-Error GetMsgAttachedSize(const MsgObj* obj, u32 index, u32* size); //801de43c
-Error GetMsgAttachedType(const MsgObj* obj, u32 index, MIMEType* type); //801de470
-Error GetMsgDate(const MsgObj* obj, OS::CalendarTime* time); //801de5a0
-Error GetMsgTag(const MsgObj* obj, u16* tag); //801de50c
-Error GetMsgId(const MsgObj* obj, u32* msgId); //801de4ec
-Error GetMsgAppId(const MsgObj* obj, u32* appId); //801de4fc
+    Error GetMsgType(const MsgObj *obj, MsgType *type);                     // 801de3a8
+    Error GetMsgFromId(const MsgObj *obj, u64 *userId);                     // 801de51c
+    Error GetMsgNumTo(const MsgObj *obj, u32 *numTo);                       // 801de548
+    Error GetMsgNumAttached(const MsgObj *obj, u32 *numAttached);           // 801de420
+    Error GetMsgAttachedSize(const MsgObj *obj, u32 index, u32 *size);      // 801de43c
+    Error GetMsgAttachedType(const MsgObj *obj, u32 index, MIMEType *type); // 801de470
+    Error GetMsgDate(const MsgObj *obj, OS::CalendarTime *time);            // 801de5a0
+    Error GetMsgTag(const MsgObj *obj, u16 *tag);                           // 801de50c
+    Error GetMsgId(const MsgObj *obj, u32 *msgId);                          // 801de4ec
+    Error GetMsgAppId(const MsgObj *obj, u32 *appId);                       // 801de4fc
 
-Error ReadMsgFromAddr(const MsgObj* obj, char* buffer, u32 bufSize); //801e4564
-Error ReadMsgToId(const MsgObj* obj, u32 index, u64* userId); //801e4778
-Error ReadMsgToAddr(const MsgObj* obj, u32 index, char* buffer, u32 bufSize); //801e46d4
-Error ReadMsgSubject(const MsgObj* obj, char* buffer, u32 bufSize); //801e4980
-Error ReadMsgText(const MsgObj* obj, char* buffer, u32 bufSize, Charset* charset, Encoding* encoding); //801e4ac8
-Error ReadMsgAttached(const MsgObj* obj, u32 index, char* buffer, u32 bufSize); //801e4dec
-Error ReadMsgAltName(const MsgObj* obj, u16* name, u32 length); //801e422c
+    Error ReadMsgFromAddr(const MsgObj *obj, char *buffer, u32 bufSize);                                   // 801e4564
+    Error ReadMsgToId(const MsgObj *obj, u32 index, u64 *userId);                                          // 801e4778
+    Error ReadMsgToAddr(const MsgObj *obj, u32 index, char *buffer, u32 bufSize);                          // 801e46d4
+    Error ReadMsgSubject(const MsgObj *obj, char *buffer, u32 bufSize);                                    // 801e4980
+    Error ReadMsgText(const MsgObj *obj, char *buffer, u32 bufSize, Charset *charset, Encoding *encoding); // 801e4ac8
+    Error ReadMsgAttached(const MsgObj *obj, u32 index, char *buffer, u32 bufSize);                        // 801e4dec
+    Error ReadMsgAltName(const MsgObj *obj, u16 *name, u32 length);                                        // 801e422c
 
-Error DeleteMsg(MsgBoxId mboxId, u32 msgId); //801dea58
+    Error DeleteMsg(MsgBoxId mboxId, u32 msgId); // 801dea58
 
-Error InitSearchConds(); //801e51c8
-Error SetSearchCondMsgBox(MsgBoxId mBoxId); //801e5240
-Error SearchMsgs(MsgObj* msgObjArray, u32 arraySize, u32* numStored, u32* numRemain); //801e52b0
+    Error InitSearchConds();                                                              // 801e51c8
+    Error SetSearchCondMsgBox(MsgBoxId mBoxId);                                           // 801e5240
+    Error SearchMsgs(MsgObj *msgObjArray, u32 arraySize, u32 *numStored, u32 *numRemain); // 801e52b0
 
-Error CommitMsg(MsgObj* obj); //801e1e5c
-Error GetMyUserId(u64* userId); //801dc2ec
-Error CheckUserId(u64 userId); //801e8290
-}//namespace NWC24
-
+    Error CommitMsg(MsgObj *obj);   // 801e1e5c
+    Error GetMyUserId(u64 *userId); // 801dc2ec
+    Error CheckUserId(u64 userId);  // 801e8290
+} // namespace NWC24
 
 #endif

--- a/PulsarEngine/AutoTrackSelect/ChooseNextTrack.cpp
+++ b/PulsarEngine/AutoTrackSelect/ChooseNextTrack.cpp
@@ -1,4 +1,4 @@
-#include <MarioKartWii/Race/Racedata.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
 #include <MarioKartWii/Audio/RSARPlayer.hpp>
 #include <PulsarSystem.hpp>
 #include <Network/PacketExpansion.hpp>
@@ -6,293 +6,347 @@
 #include <SlotExpansion/UI/ExpansionUIMisc.hpp>
 #include <AutoTrackSelect/ChooseNextTrack.hpp>
 
-namespace Pulsar {
-namespace UI {
-
-void RaceControlButtonInfo::Update(const Input::ControllerHolder* controllerHolder) {
-    Input::ControllerHolder* modHolder = const_cast<Input::ControllerHolder*>(controllerHolder);
-    bool isMirror = false;
-    //u16 oldActions;
-    if(modHolder != nullptr) {
-        //oldActions = modHolder->uiinputStates[0].buttonActions;
-        isMirror = Racedata::sInstance->racesScenario.settings.modeFlags & 1;
-        if(isMirror) {
-            modHolder->uiinputStates[0].stickX = -modHolder->uiinputStates[0].stickX;
-        }
-    }
-    ControlButtonInfo::Update(modHolder);
-    if(isMirror) {
-        //modHolder->uiinputStates[0].buttonActions = oldActions;
-        modHolder->uiinputStates[0].stickX = -modHolder->uiinputStates[0].stickX;
-    }
-}
-/*
-static void BuildChooseNextTrack(Section& section, PageId id) {
-    section.CreateAndInitPage(id);
-    if(Info::IsHAW(false)) {
-        ChooseNextTrack* choose = new(ChooseNextTrack);
-        section.Set(choose, ChooseNextTrack::fakeId);
-        choose->Init(ChooseNextTrack::fakeId);
-    }
-}
-kmCall(0x8062f020, BuildChooseNextTrack); //0x70
-kmCall(0x8062f08c, BuildChooseNextTrack); //0x71
-kmCall(0x8062f0f8, BuildChooseNextTrack); //0x72
-kmCall(0x8062f164, BuildChooseNextTrack); //0x73
-kmCall(0x8062f1d0, BuildChooseNextTrack); //0x74
-kmCall(0x8062f23c, BuildChooseNextTrack); //0x75
-kmCall(0x8062f2a8, BuildChooseNextTrack); //0x76
-kmCall(0x8062f314, BuildChooseNextTrack); //0x77
-*/
-
-ChooseNextTrack::ChooseNextTrack() :
-    isBattle(Racedata::sInstance->racesScenario.settings.gamemode == MODE_PRIVATE_BATTLE)
+namespace Pulsar
 {
-    const RKNet::Controller* controller = RKNet::Controller::sInstance;
-    const RKNet::ControllerSub& sub = controller->subs[controller->currentSub];
-    this->isHost = sub.hostAid == sub.localAid;
-    this->status = STATUS_NOTRACK;
-    //if(this->isHost) this->status = STATUS_NOTRACK;
-    //else this->status = STATUS_TRACK_SELECTED; //non-hosts never send a track
+    namespace UI
+    {
 
-    messageBMGId = BMG_CHOOSE_NEXT;
-    nextPage = PAGE_WWRACEEND_WAIT;
-    onRightArrowSelectHandler.subject = this;
-    onRightArrowSelectHandler.ptmf = &ChooseNextTrack::OnRightArrowSelect;
-    onLeftArrowSelectHandler.subject = this;
-    onLeftArrowSelectHandler.ptmf = &ChooseNextTrack::OnLeftArrowSelect;
-    onButtonClickHandler.ptmf = &ChooseNextTrack::OnButtonClick;
-    for(int i = 0; i < 6; ++i) new (&this->manipulatorManager.holders[0].info) RaceControlButtonInfo;
-    for(int i = 0; i < 12; ++i) hasReceivedHostTrack[i] = false;
-    CupsConfig* cupsConfig = CupsConfig::sInstance;
-    PulsarId lastTrack = cupsConfig->GetWinning();
-    if(!this->isBattle && cupsConfig->IsAlphabetical() && lastTrack >= PULSARID_FIRSTCT) lastTrack = static_cast<PulsarId>(cupsConfig->GetInvertedArray()[lastTrack - PULSARID_FIRSTCT] + PULSARID_FIRSTCT);
-    curPageIdx = CupsConfig::ConvertCup_PulsarTrackToCup(lastTrack);
-    cupsConfig->ToggleCTs(System::sInstance->IsContext(PULSAR_CT));
-
-}
-
-void ChooseNextTrack::OnActivate() {
-    this->pageId = PAGE_TT_PAUSE_MENU;
-    RaceMenu::OnActivate();
-    this->pageId = ChooseNextTrack::fakeId;
-    //this->buttons[3].SetMessage(BMG_RANDOM_TRACK);
-    this->UpdateButtonInfo(0); //to fix the bad IDs from the array
-    this->message->positionAndscale[1].position.y = 180.0f;
-    this->countdown.SetInitial(static_cast<float>(System::sInstance->GetInfo().GetChooseNextTrackTimer()));
-    this->countdown.isActive = true;
-    this->countdownControl.AnimateCurrentCountDown();
-}
-
-void ChooseNextTrack::OnUpdate() {
-    this->countdown.Update();
-    this->countdownControl.AnimateCurrentCountDown();
-    const CupsConfig* cupsConfig = CupsConfig::sInstance;
-    if(this->duration == System::sInstance->GetInfo().GetChooseNextTrackTimer() * 60) {
-        PulsarId lastTrack = cupsConfig->GetWinning();
-        if(this->isBattle && lastTrack == N64_SKYSCRAPER) lastTrack = static_cast<PulsarId>(DELFINO_PIER);
-        else {
-            const bool isAlphabetical = cupsConfig->IsAlphabetical();
-
-            if(isAlphabetical && lastTrack >= PULSARID_FIRSTCT) lastTrack = static_cast<PulsarId>(cupsConfig->GetInvertedArray()[lastTrack - PULSARID_FIRSTCT] + PULSARID_FIRSTCT);
-            u32 rowIdx = lastTrack % 4;
-            PulsarCupId cupId = CupsConfig::ConvertCup_PulsarTrackToCup(lastTrack);
-            if(rowIdx == 3) {
-                cupId = cupsConfig->GetNextCupId(cupId, 1);
-                rowIdx = -1;
-            }
-            lastTrack = cupsConfig->ConvertTrack_PulsarCupToTrack(cupId, rowIdx + 1);
-        }
-        this->buttons[0].buttonId = lastTrack;
-        this->OnButtonClick(this->buttons[0], 0);
-    }
-}
-
-
-int ChooseNextTrack::GetMessageBMG() const {
-    return this->messageBMGId;
-}
-u32 ChooseNextTrack::GetButtonCount() const {
-    return this->isBattle ? 4 : maxButtonCount;
-}
-const u32* ChooseNextTrack::GetVariantsIdxArray() const {
-    static const u32 array[maxButtonCount] ={ 0,1,2,4,5 }; //can't use 3 because 808da7a8 of variant names
-    return array;
-}
-
-bool ChooseNextTrack::IsPausePage() const {
-    return false;
-}
-const char* ChooseNextTrack::GetButtonsBRCTRName() const {
-    return "ChooseNext";
-}
-
-void ChooseNextTrack::OnRightArrowSelect(SheetSelectControl& control, u32 hudSlotId) {
-    this->UpdateButtonInfo(1);
-}
-void ChooseNextTrack::OnLeftArrowSelect(SheetSelectControl& control, u32 hudSlotId) {
-    this->UpdateButtonInfo(-1);
-}
-void ChooseNextTrack::UpdateButtonInfo(s32 direction) {
-
-    if(this->isBattle) {
-        this->curPageIdx = (this->curPageIdx + direction + 3) % 3;
-        bool isHidden = false;
-        if(this->curPageIdx == 2) isHidden = true;
-        this->buttons[2].isHidden = isHidden;
-        this->buttons[2].manipulator.inaccessible = isHidden;
-        this->buttons[3].isHidden = isHidden;
-        this->buttons[3].manipulator.inaccessible = isHidden;
-
-        for(int i = 0; i < 4; ++i) {
-            u32 curId = this->curPageIdx * 4 + i;
-            this->buttons[i].buttonId = curId + 0x20;
-            this->buttons[i].SetMessage(BMG_BATTLE + curId);
-        }
-    }
-    else {
-        const CupsConfig* cupsConfig = CupsConfig::sInstance;
-        int ret = cupsConfig->GetNextCupId(static_cast<PulsarCupId>(this->curPageIdx), direction);
-        const u32 count = cupsConfig->GetCtsTrackCount() / 4;
-        if(cupsConfig->HasOddCups() && ret == count - 1) {
-            if(direction == -1) ret = count - 2;
-            else ret = 0;
-        }
-        this->curPageIdx = ret;
-        for(int i = 0; i < 4; ++i) {
-            this->buttons[i].buttonId = cupsConfig->ConvertTrack_PulsarCupToTrack(static_cast<PulsarCupId>(this->curPageIdx), i);
-            this->buttons[i].SetMessage(UI::GetTrackBMGId(static_cast<PulsarId>(this->buttons[i].buttonId), true));
-        }
-    }
-    this->buttons[4].buttonId = -1;
-}
-
-void ChooseNextTrack::OnButtonClick(PushButton& button, u32 hudSlotId) {
-    CupsConfig* cupsConfig = CupsConfig::sInstance;
-    PulsarId next;
-    if(button.buttonId == -1) {
-        next = cupsConfig->RandomizeTrack();
-        if(cupsConfig->GetWinning() == next) next = cupsConfig->RandomizeTrack();
-    }
-    else next = static_cast<PulsarId>(button.buttonId);
-    cupsConfig->SetWinning(next);
-    cupsConfig->SetSelected(next);
-    this->status = STATUS_TRACK;
-    this->EndStateAnimated(0, button.GetAnimationFrameSize());
-    Racedata::sInstance->menusScenario.settings.courseId = cupsConfig->GetCorrectTrackSlot();
-    Audio::RaceRSARPlayer* rsarPlayer = static_cast<Audio::RaceRSARPlayer*>(Audio::RSARPlayer::sInstance);
-    rsarPlayer->PlayEndRaceMenuButtonClickSound();
-}
-
-void ChooseNextTrack::InitExtraControls(u32 gameControlCount) {
-    this->InitControlGroup(gameControlCount + 2);
-    this->AddControl(gameControlCount, this->arrows, 0);
-    this->arrows.SetRightArrowHandler(this->onRightArrowSelectHandler);
-    this->arrows.SetLeftArrowHandler(this->onLeftArrowSelectHandler);
-    this->arrows.Load("button", "RaceArrowRight", "ButtonArrowRight",
-        "RaceArrowLeft", "ButtonArrowLeft", 1, 0, false);
-
-    this->AddControl(gameControlCount + 1, this->countdownControl, 0);
-    this->countdownControl.Load(this->countdown);
-
-}
-
-
-void ChooseNextTrack::UpdateRH1() {
-    RKNet::Controller* controller = RKNet::Controller::sInstance;
-    RKNet::ControllerSub& sub = controller->subs[controller->currentSub];
-    for(int aid = 0; aid < 12; ++aid) {
-        if((1 << aid & sub.availableAids) == 0) continue;
-        if(aid == sub.localAid) continue;
-        for(int i = 0; i < 2; ++i) {
-            RKNet::PacketHolder<Network::PulRH1>* holder = controller->splitToSendRACEPackets[i][aid]->GetPacketHolder<Network::PulRH1>();
-            /*
-            this shouldn't be needed because the "ExportRH1ToPulRH1" always does it
-            const u32 curSize = holder->packetSize;/
-            u32 addedSize = 0;
-            if(curSize == sizeof(RKNet::RACEHEADER1Packet)) addedSize = sizeof(Network::PulRH1) - sizeof(RKNet::RACEHEADER1Packet);
-            else if(holder->packetSize == 0) addedSize = sizeof(Network::PulRH1);
-            holder->packetSize += addedSize;
-            */
-            Network::PulRH1* sendPacket = holder->packet;
-            sendPacket->chooseNextStatus = this->status;
-            const CupsConfig* cupsConfig = CupsConfig::sInstance;
-            sendPacket->nextTrack = cupsConfig->GetWinning();
-            sendPacket->variantIdx = cupsConfig->GetCurVariantIdx();
-            sendPacket->hasTrack = true;
-        }
-    }
-}
-
-SectionId ChooseNextTrack::ProcessHAW(SectionId defaultId) {
-
-    SectionId ret = defaultId;
-    const SectionMgr* sectionMgr = SectionMgr::sInstance;
-
-    //Process Received Packets:
-    RKNet::Controller* controller = RKNet::Controller::sInstance;
-    RKNet::ControllerSub& sub = controller->subs[controller->currentSub];
-
-    bool hasReceivedEveryone = true;
-    bool isEveryoneWaiting = true;
-    bool isEveryoneInRace = true;
-
-    for(int aid = 0; aid < 12; ++aid) {
-        if((1 << aid & sub.availableAids) == 0) continue;
-        if(aid == sub.localAid) continue;
-        const u32 lastBufferUsed = controller->lastReceivedBufferUsed[aid][RKNet::PACKET_RACEHEADER1];
-        const RKNet::PacketHolder<Network::PulRH1>* holder = controller->splitReceivedRACEPackets[lastBufferUsed][aid]->GetPacketHolder<Network::PulRH1>();
-
-        if(holder->packetSize == sizeof(Network::PulRH1)) {
-            const Network::PulRH1* rh1 = holder->packet;
-            if(aid == sub.hostAid) {
-                if(rh1->chooseNextStatus == STATUS_TRACK) {
-                    this->status = STATUS_TRACK;
-                    CupsConfig* cupsConfig = CupsConfig::sInstance;
-                    cupsConfig->SetWinning(static_cast<PulsarId>(rh1->nextTrack), rh1->variantIdx);
-                    //cupsConfig->selectedCourse = cupsConfig->winningCourse;
-                    Racedata::sInstance->menusScenario.settings.courseId = cupsConfig->GetCorrectTrackSlot();
+        void RaceControlButtonInfo::Update(const Input::ControllerHolder *controllerHolder)
+        {
+            Input::ControllerHolder *modHolder = const_cast<Input::ControllerHolder *>(controllerHolder);
+            bool isMirror = false;
+            // u16 oldActions;
+            if (modHolder != nullptr)
+            {
+                // oldActions = modHolder->uiinputStates[0].buttonActions;
+                isMirror = Racedata::sInstance->racesScenario.settings.modeFlags & 1;
+                if (isMirror)
+                {
+                    modHolder->uiinputStates[0].stickX = -modHolder->uiinputStates[0].stickX;
                 }
-                else if(rh1->chooseNextStatus == STATUS_HOST_START) {
+            }
+            ControlButtonInfo::Update(modHolder);
+            if (isMirror)
+            {
+                // modHolder->uiinputStates[0].buttonActions = oldActions;
+                modHolder->uiinputStates[0].stickX = -modHolder->uiinputStates[0].stickX;
+            }
+        }
+        /*
+        static void BuildChooseNextTrack(Section& section, PageId id) {
+            section.CreateAndInitPage(id);
+            if(Info::IsHAW(false)) {
+                ChooseNextTrack* choose = new(ChooseNextTrack);
+                section.Set(choose, ChooseNextTrack::fakeId);
+                choose->Init(ChooseNextTrack::fakeId);
+            }
+        }
+        kmCall(0x8062f020, BuildChooseNextTrack); //0x70
+        kmCall(0x8062f08c, BuildChooseNextTrack); //0x71
+        kmCall(0x8062f0f8, BuildChooseNextTrack); //0x72
+        kmCall(0x8062f164, BuildChooseNextTrack); //0x73
+        kmCall(0x8062f1d0, BuildChooseNextTrack); //0x74
+        kmCall(0x8062f23c, BuildChooseNextTrack); //0x75
+        kmCall(0x8062f2a8, BuildChooseNextTrack); //0x76
+        kmCall(0x8062f314, BuildChooseNextTrack); //0x77
+        */
+
+        ChooseNextTrack::ChooseNextTrack() : isBattle(Racedata::sInstance->racesScenario.settings.gamemode == MODE_PRIVATE_BATTLE)
+        {
+            const RKNet::Controller *controller = RKNet::Controller::sInstance;
+            const RKNet::ControllerSub &sub = controller->subs[controller->currentSub];
+            this->isHost = sub.hostAid == sub.localAid;
+            this->status = STATUS_NOTRACK;
+            // if(this->isHost) this->status = STATUS_NOTRACK;
+            // else this->status = STATUS_TRACK_SELECTED; //non-hosts never send a track
+
+            messageBMGId = BMG_CHOOSE_NEXT;
+            nextPage = PAGE_WWRACEEND_WAIT;
+            onRightArrowSelectHandler.subject = this;
+            onRightArrowSelectHandler.ptmf = &ChooseNextTrack::OnRightArrowSelect;
+            onLeftArrowSelectHandler.subject = this;
+            onLeftArrowSelectHandler.ptmf = &ChooseNextTrack::OnLeftArrowSelect;
+            onButtonClickHandler.ptmf = &ChooseNextTrack::OnButtonClick;
+            for (int i = 0; i < 6; ++i)
+                new (&this->manipulatorManager.holders[0].info) RaceControlButtonInfo;
+            for (int i = 0; i < 12; ++i)
+                hasReceivedHostTrack[i] = false;
+            CupsConfig *cupsConfig = CupsConfig::sInstance;
+            PulsarId lastTrack = cupsConfig->GetWinning();
+            if (!this->isBattle && cupsConfig->IsAlphabetical() && lastTrack >= PULSARID_FIRSTCT)
+                lastTrack = static_cast<PulsarId>(cupsConfig->GetInvertedArray()[lastTrack - PULSARID_FIRSTCT] + PULSARID_FIRSTCT);
+            curPageIdx = CupsConfig::ConvertCup_PulsarTrackToCup(lastTrack);
+            cupsConfig->ToggleCTs(System::sInstance->IsContext(PULSAR_CT));
+        }
+
+        void ChooseNextTrack::OnActivate()
+        {
+            this->pageId = PAGE_TT_PAUSE_MENU;
+            RaceMenu::OnActivate();
+            this->pageId = ChooseNextTrack::fakeId;
+            // this->buttons[3].SetMessage(BMG_RANDOM_TRACK);
+            this->UpdateButtonInfo(0); // to fix the bad IDs from the array
+            this->message->positionAndscale[1].position.y = 180.0f;
+            this->countdown.SetInitial(static_cast<float>(System::sInstance->GetInfo().GetChooseNextTrackTimer()));
+            this->countdown.isActive = true;
+            this->countdownControl.AnimateCurrentCountDown();
+        }
+
+        void ChooseNextTrack::OnUpdate()
+        {
+            this->countdown.Update();
+            this->countdownControl.AnimateCurrentCountDown();
+            const CupsConfig *cupsConfig = CupsConfig::sInstance;
+            if (this->duration == System::sInstance->GetInfo().GetChooseNextTrackTimer() * 60)
+            {
+                PulsarId lastTrack = cupsConfig->GetWinning();
+                if (this->isBattle && lastTrack == N64_SKYSCRAPER)
+                    lastTrack = static_cast<PulsarId>(DELFINO_PIER);
+                else
+                {
+                    const bool isAlphabetical = cupsConfig->IsAlphabetical();
+
+                    if (isAlphabetical && lastTrack >= PULSARID_FIRSTCT)
+                        lastTrack = static_cast<PulsarId>(cupsConfig->GetInvertedArray()[lastTrack - PULSARID_FIRSTCT] + PULSARID_FIRSTCT);
+                    u32 rowIdx = lastTrack % 4;
+                    PulsarCupId cupId = CupsConfig::ConvertCup_PulsarTrackToCup(lastTrack);
+                    if (rowIdx == 3)
+                    {
+                        cupId = cupsConfig->GetNextCupId(cupId, 1);
+                        rowIdx = -1;
+                    }
+                    lastTrack = cupsConfig->ConvertTrack_PulsarCupToTrack(cupId, rowIdx + 1);
+                }
+                this->buttons[0].buttonId = lastTrack;
+                this->OnButtonClick(this->buttons[0], 0);
+            }
+        }
+
+        int ChooseNextTrack::GetMessageBMG() const
+        {
+            return this->messageBMGId;
+        }
+        u32 ChooseNextTrack::GetButtonCount() const
+        {
+            return this->isBattle ? 4 : maxButtonCount;
+        }
+        const u32 *ChooseNextTrack::GetVariantsIdxArray() const
+        {
+            static const u32 array[maxButtonCount] = {0, 1, 2, 4, 5}; // can't use 3 because 808da7a8 of variant names
+            return array;
+        }
+
+        bool ChooseNextTrack::IsPausePage() const
+        {
+            return false;
+        }
+        const char *ChooseNextTrack::GetButtonsBRCTRName() const
+        {
+            return "ChooseNext";
+        }
+
+        void ChooseNextTrack::OnRightArrowSelect(SheetSelectControl &control, u32 hudSlotId)
+        {
+            this->UpdateButtonInfo(1);
+        }
+        void ChooseNextTrack::OnLeftArrowSelect(SheetSelectControl &control, u32 hudSlotId)
+        {
+            this->UpdateButtonInfo(-1);
+        }
+        void ChooseNextTrack::UpdateButtonInfo(s32 direction)
+        {
+
+            if (this->isBattle)
+            {
+                this->curPageIdx = (this->curPageIdx + direction + 3) % 3;
+                bool isHidden = false;
+                if (this->curPageIdx == 2)
+                    isHidden = true;
+                this->buttons[2].isHidden = isHidden;
+                this->buttons[2].manipulator.inaccessible = isHidden;
+                this->buttons[3].isHidden = isHidden;
+                this->buttons[3].manipulator.inaccessible = isHidden;
+
+                for (int i = 0; i < 4; ++i)
+                {
+                    u32 curId = this->curPageIdx * 4 + i;
+                    this->buttons[i].buttonId = curId + 0x20;
+                    this->buttons[i].SetMessage(BMG_BATTLE + curId);
+                }
+            }
+            else
+            {
+                const CupsConfig *cupsConfig = CupsConfig::sInstance;
+                int ret = cupsConfig->GetNextCupId(static_cast<PulsarCupId>(this->curPageIdx), direction);
+                const u32 count = cupsConfig->GetCtsTrackCount() / 4;
+                if (cupsConfig->HasOddCups() && ret == count - 1)
+                {
+                    if (direction == -1)
+                        ret = count - 2;
+                    else
+                        ret = 0;
+                }
+                this->curPageIdx = ret;
+                for (int i = 0; i < 4; ++i)
+                {
+                    this->buttons[i].buttonId = cupsConfig->ConvertTrack_PulsarCupToTrack(static_cast<PulsarCupId>(this->curPageIdx), i);
+                    this->buttons[i].SetMessage(UI::GetTrackBMGId(static_cast<PulsarId>(this->buttons[i].buttonId), true));
+                }
+            }
+            this->buttons[4].buttonId = -1;
+        }
+
+        void ChooseNextTrack::OnButtonClick(PushButton &button, u32 hudSlotId)
+        {
+            CupsConfig *cupsConfig = CupsConfig::sInstance;
+            PulsarId next;
+            if (button.buttonId == -1)
+            {
+                next = cupsConfig->RandomizeTrack();
+                if (cupsConfig->GetWinning() == next)
+                    next = cupsConfig->RandomizeTrack();
+            }
+            else
+                next = static_cast<PulsarId>(button.buttonId);
+            cupsConfig->SetWinning(next);
+            cupsConfig->SetSelected(next);
+            this->status = STATUS_TRACK;
+            this->EndStateAnimated(0, button.GetAnimationFrameSize());
+            Racedata::sInstance->menusScenario.settings.courseId = cupsConfig->GetCorrectTrackSlot();
+            Audio::RaceRSARPlayer *rsarPlayer = static_cast<Audio::RaceRSARPlayer *>(Audio::RSARPlayer::sInstance);
+            rsarPlayer->PlayEndRaceMenuButtonClickSound();
+        }
+
+        void ChooseNextTrack::InitExtraControls(u32 gameControlCount)
+        {
+            this->InitControlGroup(gameControlCount + 2);
+            this->AddControl(gameControlCount, this->arrows, 0);
+            this->arrows.SetRightArrowHandler(this->onRightArrowSelectHandler);
+            this->arrows.SetLeftArrowHandler(this->onLeftArrowSelectHandler);
+            this->arrows.Load("button", "RaceArrowRight", "ButtonArrowRight",
+                              "RaceArrowLeft", "ButtonArrowLeft", 1, 0, false);
+
+            this->AddControl(gameControlCount + 1, this->countdownControl, 0);
+            this->countdownControl.Load(this->countdown);
+        }
+
+        void ChooseNextTrack::UpdateRH1()
+        {
+            RKNet::Controller *controller = RKNet::Controller::sInstance;
+            RKNet::ControllerSub &sub = controller->subs[controller->currentSub];
+            for (int aid = 0; aid < 12; ++aid)
+            {
+                if ((1 << aid & sub.availableAids) == 0)
+                    continue;
+                if (aid == sub.localAid)
+                    continue;
+                for (int i = 0; i < 2; ++i)
+                {
+                    RKNet::PacketHolder<Network::PulRH1> *holder = controller->splitToSendRACEPackets[i][aid]->GetPacketHolder<Network::PulRH1>();
+                    /*
+                    this shouldn't be needed because the "ExportRH1ToPulRH1" always does it
+                    const u32 curSize = holder->packetSize;/
+                    u32 addedSize = 0;
+                    if(curSize == sizeof(RKNet::RACEHEADER1Packet)) addedSize = sizeof(Network::PulRH1) - sizeof(RKNet::RACEHEADER1Packet);
+                    else if(holder->packetSize == 0) addedSize = sizeof(Network::PulRH1);
+                    holder->packetSize += addedSize;
+                    */
+                    Network::PulRH1 *sendPacket = holder->packet;
+                    sendPacket->chooseNextStatus = this->status;
+                    const CupsConfig *cupsConfig = CupsConfig::sInstance;
+                    sendPacket->nextTrack = cupsConfig->GetWinning();
+                    sendPacket->variantIdx = cupsConfig->GetCurVariantIdx();
+                    sendPacket->hasTrack = true;
+                }
+            }
+        }
+
+        SectionId ChooseNextTrack::ProcessHAW(SectionId defaultId)
+        {
+
+            SectionId ret = defaultId;
+            const SectionMgr *sectionMgr = SectionMgr::sInstance;
+
+            // Process Received Packets:
+            RKNet::Controller *controller = RKNet::Controller::sInstance;
+            RKNet::ControllerSub &sub = controller->subs[controller->currentSub];
+
+            bool hasReceivedEveryone = true;
+            bool isEveryoneWaiting = true;
+            bool isEveryoneInRace = true;
+
+            for (int aid = 0; aid < 12; ++aid)
+            {
+                if ((1 << aid & sub.availableAids) == 0)
+                    continue;
+                if (aid == sub.localAid)
+                    continue;
+                const u32 lastBufferUsed = controller->lastReceivedBufferUsed[aid][RKNet::PACKET_RACEHEADER1];
+                const RKNet::PacketHolder<Network::PulRH1> *holder = controller->splitReceivedRACEPackets[lastBufferUsed][aid]->GetPacketHolder<Network::PulRH1>();
+
+                if (holder->packetSize == sizeof(Network::PulRH1))
+                {
+                    const Network::PulRH1 *rh1 = holder->packet;
+                    if (aid == sub.hostAid)
+                    {
+                        if (rh1->chooseNextStatus == STATUS_TRACK)
+                        {
+                            this->status = STATUS_TRACK;
+                            CupsConfig *cupsConfig = CupsConfig::sInstance;
+                            cupsConfig->SetWinning(static_cast<PulsarId>(rh1->nextTrack), rh1->variantIdx);
+                            // cupsConfig->selectedCourse = cupsConfig->winningCourse;
+                            Racedata::sInstance->menusScenario.settings.courseId = cupsConfig->GetCorrectTrackSlot();
+                        }
+                        else if (rh1->chooseNextStatus == STATUS_HOST_START)
+                        {
+                            this->status = STATUS_RH1_READY;
+                        }
+                    }
+
+                    if (this->isHost)
+                    {
+                        if (rh1->chooseNextStatus < STATUS_TRACK)
+                            hasReceivedEveryone = false;
+                        else if (rh1->timer != 0)
+                            isEveryoneInRace = false;
+                    }
+                }
+            }
+
+            if (this->isHost)
+            {
+                if (hasReceivedEveryone && this->status == STATUS_TRACK)
+                {
+                    this->status = STATUS_HOST_START;
+                }
+                if (isEveryoneInRace && this->status == STATUS_HOST_START)
+                {
                     this->status = STATUS_RH1_READY;
                 }
             }
-
-            if(this->isHost) {
-                if(rh1->chooseNextStatus < STATUS_TRACK) hasReceivedEveryone = false;
-                else if(rh1->timer != 0) isEveryoneInRace = false;
+            if (this->status == STATUS_RH1_READY)
+            {
+                ret = sectionMgr->curSection->sectionId;
             }
+            else
+            {
+                ret = SECTION_NONE;
+                this->UpdateRH1();
+            }
+            return ret;
         }
-    }
 
-    if(this->isHost) {
-        if(hasReceivedEveryone && this->status == STATUS_TRACK) {
-            this->status = STATUS_HOST_START;
+        PageId ChooseNextTrack::GetPageAfterWifiResults(PageId defaultId) const
+        {
+            PageId ret = defaultId;
+            if (this->isHost)
+            {
+                const SectionParams *params = SectionMgr::sInstance->sectionParams;
+                if (System::sInstance->IsContext(PULSAR_MODE_KO) || this->isBattle && params->redWins < 2 && params->blueWins < 2 || !this->isBattle && params->onlineParams.currentRaceNumber != System::sInstance->netMgr.racesPerGP)
+                    ret = static_cast<PageId>(ChooseNextTrack::id);
+            }
+            return ret;
         }
-        if(isEveryoneInRace && this->status == STATUS_HOST_START) {
-            this->status = STATUS_RH1_READY;
-        }
-    }
-    if(this->status == STATUS_RH1_READY) {
-        ret = sectionMgr->curSection->sectionId;
-    }
-    else {
-        ret = SECTION_NONE;
-        this->UpdateRH1();
-    }
-    return ret;
-}
 
-PageId ChooseNextTrack::GetPageAfterWifiResults(PageId defaultId) const {
-    PageId ret = defaultId;
-    if(this->isHost) {
-        const SectionParams* params = SectionMgr::sInstance->sectionParams;
-        if(System::sInstance->IsContext(PULSAR_MODE_KO)
-            || this->isBattle && params->redWins < 2 && params->blueWins < 2
-            || !this->isBattle && params->onlineParams.currentRaceNumber != System::sInstance->netMgr.racesPerGP) ret = static_cast<PageId>(ChooseNextTrack::id);
-    }
-    return ret;
-}
-
-}//namespace UI
-}//namespace Pulsar
+    } // namespace UI
+} // namespace Pulsar

--- a/PulsarEngine/Debug/Debug.hpp
+++ b/PulsarEngine/Debug/Debug.hpp
@@ -1,58 +1,66 @@
 #ifndef _PUL_Debug_
 #define _PUL_Debug_
 
-#include <core/rvl/os/OSError.hpp>
+#include <core/rvl/OS/OSError.hpp>
 
-namespace Pulsar {
-namespace Debug {
+namespace Pulsar
+{
+    namespace Debug
+    {
 
-void FatalError(const char* string);
-void LaunchSoftware();
-struct GPR {
-    void Set(const OS::Context& context, u32 idx, u32 regValue) {
-        gpr = context.gpr[idx];
-        name = 'r00:' + regValue;
-    }
-    u32 name;
-    u32 gpr;
-};
+        void FatalError(const char *string);
+        void LaunchSoftware();
+        struct GPR
+        {
+            void Set(const OS::Context &context, u32 idx, u32 regValue)
+            {
+                gpr = context.gpr[idx];
+                name = 'r00:' + regValue;
+            }
+            u32 name;
+            u32 gpr;
+        };
 
-struct FPR {
-    void Set(const OS::Context& context, u32 idx, u32 regValue) {
-        fpr = context.fpr[idx];
-        name = 'f00:' + regValue;
-    }
-    u32 name;
-    double fpr;
-};
+        struct FPR
+        {
+            void Set(const OS::Context &context, u32 idx, u32 regValue)
+            {
+                fpr = context.fpr[idx];
+                name = 'f00:' + regValue;
+            }
+            u32 name;
+            double fpr;
+        };
 
-struct StackFrame {
-    StackFrame() : spName('sp: '), sp(0), lrName('lr: '), lr(0) {};
-    u32 spName;
-    u32 sp;
-    u32 lrName;
-    u32 lr;
-};
+        struct StackFrame
+        {
+            StackFrame() : spName('sp: '), sp(0), lrName('lr: '), lr(0) {};
+            u32 spName;
+            u32 sp;
+            u32 lrName;
+            u32 lr;
+        };
 
-struct ExceptionFile {
-    explicit ExceptionFile(const OS::Context& context);
+        struct ExceptionFile
+        {
+            explicit ExceptionFile(const OS::Context &context);
 
-    u32 magic;
-    u32 region;
-    u32 reserved;
-    OS::Error error;
-    GPR srr0;
-    GPR srr1;
-    GPR msr;
-    GPR cr;
-    GPR lr;
-    GPR gprs[32];
-    FPR fprs[32];
-    FPR fpscr;
-    StackFrame frames[10];
-};
+            u32 magic;
+            u32 region;
+            u32 reserved;
+            OS::Error error;
+            GPR srr0;
+            GPR srr1;
+            GPR msr;
+            GPR cr;
+            GPR lr;
+            GPR gprs[32];
+            FPR fprs[32];
+            FPR fpscr;
+            StackFrame frames[10];
+        };
 
-}//namespace Debug
-}//namespace Pulsar
+    } // namespace Debug
+} // namespace Pulsar
 
 #endif

--- a/PulsarEngine/Debug/ExceptionHandler.cpp
+++ b/PulsarEngine/Debug/ExceptionHandler.cpp
@@ -1,214 +1,231 @@
 #include <kamek.hpp>
 #include <core/System/SystemManager.hpp>
 #include <core/rvl/base/ppc.hpp>
-#include <core/rvl/os/OSthread.hpp>
-#include <core/rvl/os/OSTitle.hpp>
-#include <core/rvl/os/OSBootInfo.hpp>
-#include <core/rvl/pad.hpp>
-#include <core/rvl/kpad.hpp>
+#include <core/rvl/OS/OSthread.hpp>
+#include <core/rvl/OS/OSTitle.hpp>
+#include <core/rvl/OS/OSBootInfo.hpp>
+#include <core/rvl/PAD.hpp>
+#include <core/rvl/KPAD.hpp>
 #include <core/egg/Exception.hpp>
 #include <Debug/Debug.hpp>
 #include <PulsarSystem.hpp>
 #include <IO/IO.hpp>
 
-namespace Pulsar {
-namespace Debug {
+namespace Pulsar
+{
+    namespace Debug
+    {
 
-OS::Thread* crashThread = nullptr;
-static u16 crashError = 0;
+        OS::Thread *crashThread = nullptr;
+        static u16 crashError = 0;
 
-using namespace nw4r;
+        using namespace nw4r;
 
-
-void FatalError(const char* string) {
-    GX::Color fg;
-    fg.rgba = 0xFFFFFFFF;
-    GX::Color bg ={ 0 };
-    OS::Fatal(fg, bg, string);
-}
+        void FatalError(const char *string)
+        {
+            GX::Color fg;
+            fg.rgba = 0xFFFFFFFF;
+            GX::Color bg = {0};
+            OS::Fatal(fg, bg, string);
+        }
 
 #pragma suppress_warnings on
-void LaunchSoftware() { //If dolphin, restarts game, else launches Riivo->HBC->OHBC->WiiMenu
-    s32 result = IO::OpenFix("/dev/dolphin", IOS::MODE_NONE);
-    if(result >= 0) {
-        IOS::Close(result);
-        SystemManager::Shutdown();
-        return;
-    }
-    result = IO::OpenFix("/title/00010001/57524554/content/title.tmd\0", IOS::MODE_NONE); //Riivo
-    if(result >= 0) {
-        ISFS::Close(result);
-        OS::__LaunchTitle(0x00010001, 0x57524554);
-        return;
-    }
-    result = IO::OpenFix("/title/00010001/4c554c5a/content/title.tmd\0", IOS::MODE_NONE); //OHBC
-    if(result >= 0) {
-        ISFS::Close(result);
-        OS::__LaunchTitle(0x00010001, 0x4c554c5a);
-        return;
-    }
-    result = IO::OpenFix("/title/00010001/48424330/content/title.tmd\0", IOS::MODE_NONE); // If HBC can't be found try OHBC
-    if(result >= 0) {
-        ISFS::Close(result);
-        OS::__LaunchTitle(0x00010001, 0x48424330);
-        return;
-    }
-    OS::__LaunchTitle(0x1, 0x2); // Launch Wii Menu if channel isn't found
-}
+        void LaunchSoftware()
+        { // If dolphin, restarts game, else launches Riivo->HBC->OHBC->WiiMenu
+            s32 result = IO::OpenFix("/dev/dolphin", IOS::MODE_NONE);
+            if (result >= 0)
+            {
+                IOS::Close(result);
+                SystemManager::Shutdown();
+                return;
+            }
+            result = IO::OpenFix("/title/00010001/57524554/content/title.tmd\0", IOS::MODE_NONE); // Riivo
+            if (result >= 0)
+            {
+                ISFS::Close(result);
+                OS::__LaunchTitle(0x00010001, 0x57524554);
+                return;
+            }
+            result = IO::OpenFix("/title/00010001/4c554c5a/content/title.tmd\0", IOS::MODE_NONE); // OHBC
+            if (result >= 0)
+            {
+                ISFS::Close(result);
+                OS::__LaunchTitle(0x00010001, 0x4c554c5a);
+                return;
+            }
+            result = IO::OpenFix("/title/00010001/48424330/content/title.tmd\0", IOS::MODE_NONE); // If HBC can't be found try OHBC
+            if (result >= 0)
+            {
+                ISFS::Close(result);
+                OS::__LaunchTitle(0x00010001, 0x48424330);
+                return;
+            }
+            OS::__LaunchTitle(0x1, 0x2); // Launch Wii Menu if channel isn't found
+        }
 #pragma suppress_warnings reset
 
-//Credit Star and Riidefi
+        // Credit Star and Riidefi
 
-//Data Shown
-//kmWrite16(0x802A7410, 0x00000023);
-//Show Handler
-//kmWrite32(0x802A7404, 0x00000000);
-//Show StackTrace
-kmWrite32(0x80023948, 0x281e0007);
-//Max number of lines
-//kmWrite32(0x80009324, 0x38800068);
+        // Data Shown
+        // kmWrite16(0x802A7410, 0x00000023);
+        // Show Handler
+        // kmWrite32(0x802A7404, 0x00000000);
+        // Show StackTrace
+        kmWrite32(0x80023948, 0x281e0007);
+        // Max number of lines
+        // kmWrite32(0x80009324, 0x38800068);
 
-//Lines on the screen and x-pos
-static void SetConsoleParams() {
-    db::detail::ConsoleHead* console = EGG::Exception::console;
-    console->viewLines = 0x16;
-    console->viewPosX = 0x10;
-}
-BootHook ConsoleParams(SetConsoleParams, 1);
+        // Lines on the screen and x-pos
+        static void SetConsoleParams()
+        {
+            db::detail::ConsoleHead *console = EGG::Exception::console;
+            console->viewLines = 0x16;
+            console->viewPosX = 0x10;
+        }
+        BootHook ConsoleParams(SetConsoleParams, 1);
 
+        ExceptionFile::ExceptionFile(const OS::Context &context) : magic('PULD'), region(*reinterpret_cast<u32 *>(OS::BootInfo::mInstance.diskID.gameName)), reserved(-1)
+        {
+            this->srr0.name = 'srr0';
+            this->srr0.gpr = context.srr0;
+            this->srr1.name = 'srr1';
+            this->srr1.gpr = context.srr1;
+            this->msr.name = 'msr:';
+            this->msr.gpr = PPCMfmsr();
+            this->cr.name = 'cr: ';
+            this->cr.gpr = context.cr;
+            this->lr.name = 'lr: ';
+            this->lr.gpr = context.lr;
+            for (u32 i = 0; i < 32; ++i)
+            {
+                this->gprs[i].gpr = context.gpr[i]; // r00: //r01:
+                this->fprs[i].fpr = context.fpr[i];
+                const u32 tens = i / 10U;
+                const u32 units = i - tens * 10U;
+                const u32 regValue = units * 0x100U + tens * 0x10000U;
+                this->gprs[i].name = 'r00:' + regValue;
+                this->fprs[i].name = 'f00:' + regValue;
+            }
+            this->fpscr.name = 'fscr';
+            this->fpscr.fpr = context.fpscr;
+            u32 *sp = (u32 *)context.gpr[1];
+            for (int i = 0; i < 10; ++i)
+            {
+                if (sp == nullptr || (u32)sp == 0xFFFFFFFF)
+                    break;
+                this->frames[i].sp = (u32)sp;
+                this->frames[i].lr = sp[1];
+                sp = (u32 *)*sp;
+            }
+        }
 
-ExceptionFile::ExceptionFile(const OS::Context& context) : magic('PULD'), region(*reinterpret_cast<u32*>(OS::BootInfo::mInstance.diskID.gameName)), reserved(-1) {
-    this->srr0.name = 'srr0';
-    this->srr0.gpr = context.srr0;
-    this->srr1.name = 'srr1';
-    this->srr1.gpr = context.srr1;
-    this->msr.name = 'msr:';
-    this->msr.gpr = PPCMfmsr();
-    this->cr.name = 'cr: ';
-    this->cr.gpr = context.cr;
-    this->lr.name = 'lr: ';
-    this->lr.gpr = context.lr;
-    for(u32 i = 0; i < 32; ++i) {
-        this->gprs[i].gpr = context.gpr[i]; //r00: //r01:
-        this->fprs[i].fpr = context.fpr[i];
-        const u32 tens = i / 10U;
-        const u32 units = i - tens * 10U;
-        const u32 regValue = units * 0x100U + tens * 0x10000U;
-        this->gprs[i].name = 'r00:' + regValue;
-        this->fprs[i].name = 'f00:' + regValue;
-    }
-    this->fpscr.name = 'fscr';
-    this->fpscr.fpr = context.fpscr;
-    u32* sp = (u32*)context.gpr[1];
-    for(int i = 0; i < 10; ++i) {
-        if(sp == nullptr || (u32)sp == 0xFFFFFFFF) break;
-        this->frames[i].sp = (u32)sp;
-        this->frames[i].lr = sp[1];
-        sp = (u32*)*sp;
-    }
-}
+        static void WriteHeaderCrash(u16 error, const OS::Context *context, u32 dsisr, u32 dar)
+        {
+            crashError = error;
+            crashThread = const_cast<OS::Thread *>(reinterpret_cast<const OS::Thread *>(context));
+            db::ExceptionHead &exception = db::ExceptionHead::mInstance;
+            exception.displayedInfo = 0x23;
+            exception.callbackArgs = nullptr;
 
-static void WriteHeaderCrash(u16 error, const OS::Context* context, u32 dsisr, u32 dar) {
-    crashError = error;
-    crashThread = const_cast<OS::Thread*>(reinterpret_cast<const OS::Thread*>(context));
-    db::ExceptionHead& exception = db::ExceptionHead::mInstance;
-    exception.displayedInfo = 0x23;
-    exception.callbackArgs = nullptr;
+            // char endMsg[512];
+            // snprintf(endMsg, 512, "Press A%s and send a clip\nof the crash or the crash.pul file to the pack\ncreator to help fix the bug.\n", outcome);
 
-    //char endMsg[512];
-    //snprintf(endMsg, 512, "Press A%s and send a clip\nof the crash or the crash.pul file to the pack\ncreator to help fix the bug.\n", outcome);
+            db::Exception_Printf_("Press A to exit. Send crash.pul to the creator.");
+            db::PrintContext_(error, context, dsisr, dar);
+        }
+        kmCall(0x80023484, WriteHeaderCrash);
 
-    db::Exception_Printf_("Press A to exit. Send crash.pul to the creator.");
-    db::PrintContext_(error, context, dsisr, dar);
+        static void CreateCrashFile(s32 channel, KPAD::Status buff[], u32 count)
+        {
 
-}
-kmCall(0x80023484, WriteHeaderCrash);
-
-
-static void CreateCrashFile(s32 channel, KPAD::Status buff[], u32 count) {
-
-    IO* io = IO::sInstance;;
-    bool exit = false;
-    if(io == nullptr) exit = true; //should always exist if the crash is after strap 
-    else {
-        KPAD::Read(channel, buff, count);
-        u8 wiimoteExtension = buff[0].extension;
-        if(buff[0].error == WPAD::WPAD_ERR_NONE && wiimoteExtension < WPAD::WPAD_DEV_FUTURE &&
-            (wiimoteExtension == WPAD::WPAD_DEV_CLASSIC && buff[0].extStatus.cl.trig & WPAD::WPAD_CL_BUTTON_A
-                || buff[0].trig & WPAD::WPAD_BUTTON_A)) exit = true;
-        else {
-            PAD::Status padStatus[4];
-            PAD::Read(&padStatus[0]);
-            for(int channel = 0; channel < 4; ++channel) {
-                if(padStatus[channel].error == PAD::PAD_ERR_NONE) {
-                    if(padStatus[channel].buttons & PAD::PAD_BUTTON_A) {
-                        exit = true;
-                        break;
+            IO *io = IO::sInstance;
+            ;
+            bool exit = false;
+            if (io == nullptr)
+                exit = true; // should always exist if the crash is after strap
+            else
+            {
+                KPAD::Read(channel, buff, count);
+                u8 wiimoteExtension = buff[0].extension;
+                if (buff[0].error == WPAD::WPAD_ERR_NONE && wiimoteExtension < WPAD::WPAD_DEV_FUTURE &&
+                    (wiimoteExtension == WPAD::WPAD_DEV_CLASSIC && buff[0].extStatus.cl.trig & WPAD::WPAD_CL_BUTTON_A || buff[0].trig & WPAD::WPAD_BUTTON_A))
+                    exit = true;
+                else
+                {
+                    PAD::Status padStatus[4];
+                    PAD::Read(&padStatus[0]);
+                    for (int channel = 0; channel < 4; ++channel)
+                    {
+                        if (padStatus[channel].error == PAD::PAD_ERR_NONE)
+                        {
+                            if (padStatus[channel].buttons & PAD::PAD_BUTTON_A)
+                            {
+                                exit = true;
+                                break;
+                            }
+                        }
                     }
                 }
+                if (exit)
+                {
+                    OS::Thread *thread = crashThread;
+                    OS::DetachThread(thread);
+                    OS::CancelThread(thread);
+
+                    /* failsafe, but bad for ISI
+                    register u32* const addressPtr = (u32*)(thread->context.srr0 + 4);
+                    const s32 diff = static_cast<int>(reinterpret_cast<u32>(&LaunchSoftware) - reinterpret_cast<u32>(addressPtr));
+                    u32 instruction = 0x48000000;
+                    if(diff < 0) instruction = 0x4B000000;
+                    *addressPtr = instruction + (diff & 0x00FFFFFF);
+                    asm{
+                        ASM(
+                        dcbst 0, addressPtr; //update main memory from data cache so that it contains the correct instruction at addressPtr
+                        sync;                //memory barrier, ie wait for dcbst to complete
+                        icbi 0, addressPtr;  //invalidate instruction cache block at addressPtr so that the instruciton is fetched from the (updated) main memory
+                        isync;               //discard prefetched instructions in case the update addressPtr was prefetched
+                        )
+                    }
+                    */
+
+                    alignas(0x20) ExceptionFile exception(thread->context);
+                    exception.error = static_cast<OS::Error>(crashError);
+                    char path[IOS::ipcMaxPath];
+                    const System *system = System::sInstance;
+                    snprintf(path, IOS::ipcMaxPath, "%s/Crash.pul", system->GetModFolder());
+                    io->CreateAndOpen(path, IOS::MODE_READ_WRITE);
+                    io->Overwrite(sizeof(ExceptionFile), &exception);
+                    io->Close();
+                }
             }
+            if (exit)
+                LaunchSoftware();
         }
-        if(exit) {
-            OS::Thread* thread = crashThread;
-            OS::DetachThread(thread);
-            OS::CancelThread(thread);
+        kmCall(0x80226610, CreateCrashFile);
 
-            /* failsafe, but bad for ISI
-            register u32* const addressPtr = (u32*)(thread->context.srr0 + 4);
-            const s32 diff = static_cast<int>(reinterpret_cast<u32>(&LaunchSoftware) - reinterpret_cast<u32>(addressPtr));
-            u32 instruction = 0x48000000;
-            if(diff < 0) instruction = 0x4B000000;
-            *addressPtr = instruction + (diff & 0x00FFFFFF);
-            asm{
-                ASM(
-                dcbst 0, addressPtr; //update main memory from data cache so that it contains the correct instruction at addressPtr
-                sync;                //memory barrier, ie wait for dcbst to complete
-                icbi 0, addressPtr;  //invalidate instruction cache block at addressPtr so that the instruciton is fetched from the (updated) main memory
-                isync;               //discard prefetched instructions in case the update addressPtr was prefetched
-                )
+        /*
+        static void OnCrashEnd() {
+            IO* io = IO::sInstance;;
+            if(file != nullptr) { //should always exist if the crash is after strap
+                register u32* const addressPtr = (u32*)(crashThread->context.srr0 + 4);
+                const s32 diff = static_cast<int>(reinterpret_cast<u32>(&LaunchSoftware) - reinterpret_cast<u32>(addressPtr));
+                u32 instruction = 0x48000000;
+                if(diff < 0) instruction = 0x4B000000;
+                *addressPtr = instruction + (diff & 0x00FFFFFF) + 1;
+                asm{
+                    ASM(
+                    dcbst 0, addressPtr;
+                    sync;
+                    icbi 0, addressPtr;
+                    )
+                }
+                OS::Thread::current = crashThread;
+                OS::SelectThread(0);
+
             }
-            */
-
-            alignas(0x20) ExceptionFile exception(thread->context);
-            exception.error = static_cast<OS::Error>(crashError);
-            char path[IOS::ipcMaxPath];
-            const System* system = System::sInstance;
-            snprintf(path, IOS::ipcMaxPath, "%s/Crash.pul", system->GetModFolder());
-            io->CreateAndOpen(path, IOS::MODE_READ_WRITE);
-            io->Overwrite(sizeof(ExceptionFile), &exception);
-            io->Close();
+            else LaunchSoftware();
         }
-    }
-    if(exit) LaunchSoftware();
-}
-kmCall(0x80226610, CreateCrashFile);
+        */
 
-/*
-static void OnCrashEnd() {
-    IO* io = IO::sInstance;;
-    if(file != nullptr) { //should always exist if the crash is after strap
-        register u32* const addressPtr = (u32*)(crashThread->context.srr0 + 4);
-        const s32 diff = static_cast<int>(reinterpret_cast<u32>(&LaunchSoftware) - reinterpret_cast<u32>(addressPtr));
-        u32 instruction = 0x48000000;
-        if(diff < 0) instruction = 0x4B000000;
-        *addressPtr = instruction + (diff & 0x00FFFFFF) + 1;
-        asm{
-            ASM(
-            dcbst 0, addressPtr;
-            sync;
-            icbi 0, addressPtr;
-            )
-        }
-        OS::Thread::current = crashThread;
-        OS::SelectThread(0);
-
-    }
-    else LaunchSoftware();
-}
-*/
-
-
-}//namespace Debug
-}//namespace Pulsar
-
-
+    } // namespace Debug
+} // namespace Pulsar

--- a/PulsarEngine/Extensions/LECODE/Lex.cpp
+++ b/PulsarEngine/Extensions/LECODE/Lex.cpp
@@ -2,160 +2,184 @@
 #include <Extensions/LECODE/Lex.hpp>
 #include <MarioKartWii/Archive/ArchiveMgr.hpp>
 #include <MarioKartWii/UI/Ctrl/CtrlRace/CtrlRaceRankNum.hpp>
-#include <MarioKartWii/Race/Raceinfo/Raceinfo.hpp>
+#include <MarioKartWii/Race/RaceInfo/RaceInfo.hpp>
 #include <MarioKartWii/Item/Obj/ItemObj.hpp>
 #include <PulsarSystem.hpp>
 #include <Extensions/LECODE/LECODEMgr.hpp>
 
-//https://wiki.tockdom.com/wiki/LEX_(File_Format)
+// https://wiki.tockdom.com/wiki/LEX_(File_Format)
 
-namespace LECODE {
+namespace LECODE
+{
 
-void LexMgr::Reset() {
-    this->lex = nullptr;
-    this->set1 = nullptr;
-    this->cann = nullptr;
-    this->hiptList = nullptr;
-    this->hiptLength = 0;
-}
+    void LexMgr::Reset()
+    {
+        this->lex = nullptr;
+        this->set1 = nullptr;
+        this->cann = nullptr;
+        this->hiptList = nullptr;
+        this->hiptLength = 0;
+    }
 
-const KMPHeader* LexMgr::LoadLEXAndKMP(u32, const char* kmpString) {
-    Pulsar::System* system = Pulsar::System::sInstance;
-    LexMgr& self = system->lecodeMgr.lexMgr;
-    self.Reset();
-    if(system->IsContext(Pulsar::PULSAR_CT)) {
-        LEXHeader* header = static_cast<LEXHeader*>(ArchiveMgr::sInstance->GetFile(ARCHIVE_HOLDER_COURSE, "course.lex"));
-        if(header != nullptr) {
-            if(header->magic == LEXHeader::goodMagic && header->majorVersion == 1) {
+    const KMPHeader *LexMgr::LoadLEXAndKMP(u32, const char *kmpString)
+    {
+        Pulsar::System *system = Pulsar::System::sInstance;
+        LexMgr &self = system->lecodeMgr.lexMgr;
+        self.Reset();
+        if (system->IsContext(Pulsar::PULSAR_CT))
+        {
+            LEXHeader *header = static_cast<LEXHeader *>(ArchiveMgr::sInstance->GetFile(ARCHIVE_HOLDER_COURSE, "course.lex"));
+            if (header != nullptr)
+            {
+                if (header->magic == LEXHeader::goodMagic && header->majorVersion == 1)
+                {
 
-                LEXSectionHeader* section = reinterpret_cast<LEXSectionHeader*>(reinterpret_cast<u8*>(header) + header->offsetToFirstSection);
-                while(section->magic != 0) {
-                    u8* data = reinterpret_cast<u8*>(section) + sizeof(LEXSectionHeader);
-                    switch(section->magic) {
+                    LEXSectionHeader *section = reinterpret_cast<LEXSectionHeader *>(reinterpret_cast<u8 *>(header) + header->offsetToFirstSection);
+                    while (section->magic != 0)
+                    {
+                        u8 *data = reinterpret_cast<u8 *>(section) + sizeof(LEXSectionHeader);
+                        switch (section->magic)
+                        {
                         case SET1::magic:
-                            self.set1 = reinterpret_cast<SET1*>(section);
+                            self.set1 = reinterpret_cast<SET1 *>(section);
                             break;
                         case HIPT::magic:
-                            self.hiptList = reinterpret_cast<HIPT::List*>(data);
+                            self.hiptList = reinterpret_cast<HIPT::List *>(data);
                             self.hiptLength = section->dataSize / sizeof(HIPT::List);
                             break;
                         case CANN::magic:
-                            self.cann = reinterpret_cast<Kart::Movement::CannonParams*>(data + sizeof(u32));
+                            self.cann = reinterpret_cast<Kart::Movement::CannonParams *>(data + sizeof(u32));
                             break;
                         default:
+                        }
+                        section = reinterpret_cast<LEXSectionHeader *>(data + section->dataSize);
                     }
-                    section = reinterpret_cast<LEXSectionHeader*>(data + section->dataSize);
                 }
-
-
             }
+            self.lex = header;
         }
-        self.lex = header;
+        return KMP::Manager::GetRawKMP(ARCHIVE_HOLDER_COURSE, kmpString);
     }
-    return KMP::Manager::GetRawKMP(ARCHIVE_HOLDER_COURSE, kmpString);
-}
-kmCall(0x80512820, LexMgr::LoadLEXAndKMP);
+    kmCall(0x80512820, LexMgr::LoadLEXAndKMP);
 
-bool ApplyHIPT(CtrlRaceRankNum& tracker) { //return value: if true, tracker is hidden
-    bool isInactive = tracker.CtrlRaceRankNum::IsInactive();
-    if(!isInactive) {
-        const u8 playerId = tracker.GetPlayerId();
-        const LexMgr& mgr = Pulsar::System::sInstance->lecodeMgr.lexMgr;
-        const HIPT::List* list = mgr.hiptList;
-        if(list != nullptr) {
-            const RacedataSettings& settings = Racedata::sInstance->racesScenario.settings;
-            const RaceinfoPlayer* player = Raceinfo::sInstance->players[playerId];
-            const GameMode mode = settings.gamemode;
-            const u8 lapCount = settings.lapCount;
-            const u16 curLap = player->currentLap;
-            const u16 curCP = player->checkpoint; //check if applies to CP
+    bool ApplyHIPT(CtrlRaceRankNum &tracker)
+    { // return value: if true, tracker is hidden
+        bool isInactive = tracker.CtrlRaceRankNum::IsInactive();
+        if (!isInactive)
+        {
+            const u8 playerId = tracker.GetPlayerId();
+            const LexMgr &mgr = Pulsar::System::sInstance->lecodeMgr.lexMgr;
+            const HIPT::List *list = mgr.hiptList;
+            if (list != nullptr)
+            {
+                const RacedataSettings &settings = Racedata::sInstance->racesScenario.settings;
+                const RaceinfoPlayer *player = Raceinfo::sInstance->players[playerId];
+                const GameMode mode = settings.gamemode;
+                const u8 lapCount = settings.lapCount;
+                const u16 curLap = player->currentLap;
+                const u16 curCP = player->checkpoint; // check if applies to CP
 
-            for(int i = 0; i < mgr.hiptLength; ++i) {
-                const HIPT::List& cur = list[i];
-                bool appliesToMode = false;
-                switch(cur.contextCondition) {
-                    case 1: //offline only
+                for (int i = 0; i < mgr.hiptLength; ++i)
+                {
+                    const HIPT::List &cur = list[i];
+                    bool appliesToMode = false;
+                    switch (cur.contextCondition)
+                    {
+                    case 1: // offline only
                         appliesToMode = mode <= MODE_BATTLE;
                         break;
-                    case 2: //online only
+                    case 2: // online only
                         appliesToMode = mode >= MODE_PRIVATE_VS && mode <= MODE_PRIVATE_BATTLE;
                         break;
-                    case 3: //everywhere
+                    case 3: // everywhere
                         appliesToMode = true;
                         break;
-                }
-                if(appliesToMode) {
-                    bool appliesToLap;
-                    const s8 listLap = cur.lap;
-                    if(listLap == 99) appliesToLap = true;
-                    else if(listLap >= 0) appliesToLap = listLap == curLap;
-                    else appliesToLap = listLap == (curLap - lapCount - 1); //if 3 laps, cur lap is 2, 2 - 3 - 1 = -2, ie second to last lap
-                    if(appliesToLap) {
-                        if(cur.cpFrom <= curCP && curCP <= cur.cpTo) return !cur.showTracker;
+                    }
+                    if (appliesToMode)
+                    {
+                        bool appliesToLap;
+                        const s8 listLap = cur.lap;
+                        if (listLap == 99)
+                            appliesToLap = true;
+                        else if (listLap >= 0)
+                            appliesToLap = listLap == curLap;
+                        else
+                            appliesToLap = listLap == (curLap - lapCount - 1); // if 3 laps, cur lap is 2, 2 - 3 - 1 = -2, ie second to last lap
+                        if (appliesToLap)
+                        {
+                            if (cur.cpFrom <= curCP && curCP <= cur.cpTo)
+                                return !cur.showTracker;
+                        }
                     }
                 }
             }
         }
+        return isInactive;
     }
-    return isInactive;
-}
-kmWritePointer(0x808D3EE0, ApplyHIPT); //Vtable of CtrlRaceRankNum::IsInactive
+    kmWritePointer(0x808D3EE0, ApplyHIPT); // Vtable of CtrlRaceRankNum::IsInactive
 
-Kart::Movement::CannonParams* ApplyCANN(Kart::Movement::CannonParams* cannonPtr, const CNPT& rawCNPT) {
-    s16 type = rawCNPT.type;
-    if(type < 0) type = 0;
-    Kart::Movement::CannonParams* lexCann = Pulsar::System::sInstance->lecodeMgr.lexMgr.cann;
-    if(lexCann != nullptr) cannonPtr = lexCann;
-    return &cannonPtr[type];
-}
-kmCall(0x805850b8, ApplyCANN);
-kmWrite32(0x805850bc, 0x60000000);
-
-
-
-u32 ApplySET1TimeLimit(const Racedata& racedata) {
-    u32 hiTime = 0x50000; //default
-    SET1* set = Pulsar::System::sInstance->lecodeMgr.lexMgr.set1;
-    if(set != nullptr) {
-        const GameMode mode = racedata.racesScenario.settings.gamemode;
-        if(mode == MODE_PRIVATE_VS || mode == MODE_PUBLIC_VS) hiTime = set->onlineTime * 1000 + 0x93e0; //the game subtracts that after
+    Kart::Movement::CannonParams *ApplyCANN(Kart::Movement::CannonParams *cannonPtr, const CNPT &rawCNPT)
+    {
+        s16 type = rawCNPT.type;
+        if (type < 0)
+            type = 0;
+        Kart::Movement::CannonParams *lexCann = Pulsar::System::sInstance->lecodeMgr.lexMgr.cann;
+        if (lexCann != nullptr)
+            cannonPtr = lexCann;
+        return &cannonPtr[type];
     }
-    asm(lwz r5, 0x0004 (r31)); //default, make this volatile if another func is called
-    return hiTime;
-}
-kmCall(0x8053f3b8, ApplySET1TimeLimit);
+    kmCall(0x805850b8, ApplyCANN);
+    kmWrite32(0x805850bc, 0x60000000);
 
-//If extracting, position will be obj->position, if filling, position will be a copy of obj->position which may have been divided by the SET1 factors
-void* ModifyItemPos(s16* packet) {
-    register Item::Obj* obj;
-    asm(mr obj, r29;);
-    register bool extractOrFill;
-    asm(mr extractOrFill, r30);
-
-    SET1* set = Pulsar::System::sInstance->lecodeMgr.lexMgr.set1;
-    Vec3* position =  reinterpret_cast<Vec3*>(obj != nullptr ? &obj->position : nullptr);
-    if(obj != nullptr && set != nullptr) {
-        Vec3 copy = *position;
-        if(extractOrFill) {
-            copy.x /= set->itemPosFactor.x;
-            copy.y /= set->itemPosFactor.y;
-            copy.z /= set->itemPosFactor.z;
-            position = &copy; //do NOT modify position itself as this is a fill operation
+    u32 ApplySET1TimeLimit(const Racedata &racedata)
+    {
+        u32 hiTime = 0x50000; // default
+        SET1 *set = Pulsar::System::sInstance->lecodeMgr.lexMgr.set1;
+        if (set != nullptr)
+        {
+            const GameMode mode = racedata.racesScenario.settings.gamemode;
+            if (mode == MODE_PRIVATE_VS || mode == MODE_PUBLIC_VS)
+                hiTime = set->onlineTime * 1000 + 0x93e0; // the game subtracts that after
         }
-    }//-4 because +4 is added after the exitPoint
-    void* ret = reinterpret_cast<u8*>(Item::EVENTBuffer::FillOrExtractShootPos(reinterpret_cast<s16*>(reinterpret_cast<u8*>(packet) + 0x4), position, extractOrFill)) - 4;
-    if(obj != nullptr && set != nullptr && !extractOrFill) { //position guaranteed to have been edited by the func call since we're extracting
-        position->x *= set->itemPosFactor.x;
-        position->y *= set->itemPosFactor.y;
-        position->z *= set->itemPosFactor.z;
+        asm(lwz r5, 0x0004(r31)); // default, make this volatile if another func is called
+        return hiTime;
     }
-    return ret;
-}
-kmCall(0x8079b568, ModifyItemPos);
-kmPatchExitPoint(ModifyItemPos, 0x8079b860);
+    kmCall(0x8053f3b8, ApplySET1TimeLimit);
 
-kmCall(0x8079c994, Item::EVENTBuffer::FillOrExtractShoot);
-kmWrite32(0x8079c998, 0x48000000 + (0x8079d228 - 0x8079c998)); //branch to the end of the inlining
+    // If extracting, position will be obj->position, if filling, position will be a copy of obj->position which may have been divided by the SET1 factors
+    void *ModifyItemPos(s16 *packet)
+    {
+        register Item::Obj *obj;
+        asm(mr obj, r29;);
+        register bool extractOrFill;
+        asm(mr extractOrFill, r30);
 
+        SET1 *set = Pulsar::System::sInstance->lecodeMgr.lexMgr.set1;
+        Vec3 *position = reinterpret_cast<Vec3 *>(obj != nullptr ? &obj->position : nullptr);
+        if (obj != nullptr && set != nullptr)
+        {
+            Vec3 copy = *position;
+            if (extractOrFill)
+            {
+                copy.x /= set->itemPosFactor.x;
+                copy.y /= set->itemPosFactor.y;
+                copy.z /= set->itemPosFactor.z;
+                position = &copy; // do NOT modify position itself as this is a fill operation
+            }
+        } //-4 because +4 is added after the exitPoint
+        void *ret = reinterpret_cast<u8 *>(Item::EVENTBuffer::FillOrExtractShootPos(reinterpret_cast<s16 *>(reinterpret_cast<u8 *>(packet) + 0x4), position, extractOrFill)) - 4;
+        if (obj != nullptr && set != nullptr && !extractOrFill)
+        { // position guaranteed to have been edited by the func call since we're extracting
+            position->x *= set->itemPosFactor.x;
+            position->y *= set->itemPosFactor.y;
+            position->z *= set->itemPosFactor.z;
+        }
+        return ret;
+    }
+    kmCall(0x8079b568, ModifyItemPos);
+    kmPatchExitPoint(ModifyItemPos, 0x8079b860);
 
-}//namespace LECODE
+    kmCall(0x8079c994, Item::EVENTBuffer::FillOrExtractShoot);
+    kmWrite32(0x8079c998, 0x48000000 + (0x8079d228 - 0x8079c998)); // branch to the end of the inlining
+
+} // namespace LECODE

--- a/PulsarEngine/Gamemodes/KO/KOHost.cpp
+++ b/PulsarEngine/Gamemodes/KO/KOHost.cpp
@@ -9,99 +9,116 @@
 #include <MarioKartWii/UI/Page/Other/WifiVSResults.hpp>
 #include <MarioKartWii/UI/Ctrl/CtrlRace/CtrlRaceRankNum.hpp>
 #include <MarioKartWii/UI/Ctrl/CtrlRace/CtrlRaceItemWindow.hpp>
-#include <MarioKartWii/Race/Raceinfo/Raceinfo.hpp>
+#include <MarioKartWii/Race/RaceInfo/RaceInfo.hpp>
 #include <MarioKartWii/Kart/KartManager.hpp>
 #include <Network/PacketExpansion.hpp>
 #include <Gamemodes/KO/KOMgr.hpp>
 #include <Gamemodes/KO/KORaceEndPage.hpp>
 #include <Gamemodes/KO/KOWinnerPage.hpp>
 
-namespace Pulsar {
-namespace KO {
+namespace Pulsar
+{
+    namespace KO
+    {
 
-//Replicate SetModeTypes here: CC not needed, 
-void HAWChangeData() {
-    const System* system = System::sInstance;
-    RKNet::Controller* controller = RKNet::Controller::sInstance;
-    RKNet::ControllerSub& sub = controller->subs[controller->currentSub];
-    const u8 localAid = sub.localAid;
-    if(system->IsContext(PULSAR_MODE_KO)) {
-        u8 oldAidsBelonging[12];
-        u8 oldPlayerIds[12][2];
-        //u8 oldPlayerIds[12];
-        //memset(oldPlayerIds, 0xFF, sizeof(u8) * 12);
-
-        Mgr* mgr = system->koMgr;
-        mgr->PatchAids(sub);
-        int inCounter = 0;
-        int koCounter = 0;
-        for(int i = 0; i < 12; ++i) {
-            oldAidsBelonging[i] = controller->aidsBelongingToPlayerIds[i];
-            controller->aidsBelongingToPlayerIds[i] = 0xff;
-        }
-        for(int aid = 0; aid < 12; ++aid) {
-            if((1 << aid & sub.availableAids) != 0)
+        // Replicate SetModeTypes here: CC not needed,
+        void HAWChangeData()
+        {
+            const System *system = System::sInstance;
+            RKNet::Controller *controller = RKNet::Controller::sInstance;
+            RKNet::ControllerSub &sub = controller->subs[controller->currentSub];
+            const u8 localAid = sub.localAid;
+            if (system->IsContext(PULSAR_MODE_KO))
             {
-                controller->aidsBelongingToPlayerIds[inCounter] = aid;
-                ++inCounter;
-                const u8 hudCount = aid == sub.localAid ? sub.localPlayerCount : sub.connectionUserDatas[aid].playersAtConsole;
-                if(hudCount == 2) {
-                    controller->aidsBelongingToPlayerIds[inCounter] = aid;
-                    ++inCounter;
+                u8 oldAidsBelonging[12];
+                u8 oldPlayerIds[12][2];
+                // u8 oldPlayerIds[12];
+                // memset(oldPlayerIds, 0xFF, sizeof(u8) * 12);
+
+                Mgr *mgr = system->koMgr;
+                mgr->PatchAids(sub);
+                int inCounter = 0;
+                int koCounter = 0;
+                for (int i = 0; i < 12; ++i)
+                {
+                    oldAidsBelonging[i] = controller->aidsBelongingToPlayerIds[i];
+                    controller->aidsBelongingToPlayerIds[i] = 0xff;
                 }
-            }
-        }
-        for(int playerId = 0; playerId < 12; ++playerId) {
-            u8 aid = oldAidsBelonging[playerId];
-            u8 hudSlotId = 0;
-            if(playerId != 0 && oldAidsBelonging[playerId - 1] == aid) hudSlotId = 1;
-            oldPlayerIds[aid][hudSlotId] = playerId;
-        }
-
-
-
-        Racedata* racedata = Racedata::sInstance;
-        SectionMgr* sectionMgr = SectionMgr::sInstance;
-        SectionParams* params = sectionMgr->sectionParams;
-        //Swap guest and main if needed
-        if(sub.localPlayerCount == 2 && !mgr->IsKOdAid(localAid, 0) && !mgr->GetIsSwapped()) mgr->SwapControllersAndUI();
-
-        //update racedataPlayers and miis
-        for(int playerId = 0; playerId < 12; ++playerId) {
-
-            RacedataPlayer& player = racedata->menusScenario.players[playerId];
-            const u8 aid = controller->aidsBelongingToPlayerIds[playerId];
-
-            if(aid >= 12) {
-                player.playerType = PLAYER_NONE;
-                params->onlineParams.regionId[playerId] = 0xF;
-                //params->playerMiis.DeleteMii(playerId);
-            }
-            else {
-                u8 hudSlotId = 0;
-                if(playerId != 0 && controller->aidsBelongingToPlayerIds[playerId - 1] == aid) hudSlotId = 1;
-                const u8 oldPlayerId = oldPlayerIds[aid][hudSlotId];
-                const RacedataPlayer& prev = racedata->menusScenario.players[oldPlayerId];
-                memcpy(&player, &prev, sizeof(RacedataPlayer));
-                if(aid == localAid) player.playerType = PLAYER_REAL_LOCAL;
-                else player.playerType = PLAYER_REAL_ONLINE;
-                MiiGroup& playerMiis = params->playerMiis;
-                playerMiis.mii[playerId] = playerMiis.mii[oldPlayerId];
-                for(int i = 0; i < 7; ++i) {
-                    MiiTexObj* tex = playerMiis.texObj[i];
-                    if(tex != nullptr) memcpy(&tex[playerId], &tex[oldPlayerId], sizeof(MiiTexObj));
+                for (int aid = 0; aid < 12; ++aid)
+                {
+                    if ((1 << aid & sub.availableAids) != 0)
+                    {
+                        controller->aidsBelongingToPlayerIds[inCounter] = aid;
+                        ++inCounter;
+                        const u8 hudCount = aid == sub.localAid ? sub.localPlayerCount : sub.connectionUserDatas[aid].playersAtConsole;
+                        if (hudCount == 2)
+                        {
+                            controller->aidsBelongingToPlayerIds[inCounter] = aid;
+                            ++inCounter;
+                        }
+                    }
                 }
-                //params->playerMiis.AddMii(playerId, &player.mii);
+                for (int playerId = 0; playerId < 12; ++playerId)
+                {
+                    u8 aid = oldAidsBelonging[playerId];
+                    u8 hudSlotId = 0;
+                    if (playerId != 0 && oldAidsBelonging[playerId - 1] == aid)
+                        hudSlotId = 1;
+                    oldPlayerIds[aid][hudSlotId] = playerId;
+                }
+
+                Racedata *racedata = Racedata::sInstance;
+                SectionMgr *sectionMgr = SectionMgr::sInstance;
+                SectionParams *params = sectionMgr->sectionParams;
+                // Swap guest and main if needed
+                if (sub.localPlayerCount == 2 && !mgr->IsKOdAid(localAid, 0) && !mgr->GetIsSwapped())
+                    mgr->SwapControllersAndUI();
+
+                // update racedataPlayers and miis
+                for (int playerId = 0; playerId < 12; ++playerId)
+                {
+
+                    RacedataPlayer &player = racedata->menusScenario.players[playerId];
+                    const u8 aid = controller->aidsBelongingToPlayerIds[playerId];
+
+                    if (aid >= 12)
+                    {
+                        player.playerType = PLAYER_NONE;
+                        params->onlineParams.regionId[playerId] = 0xF;
+                        // params->playerMiis.DeleteMii(playerId);
+                    }
+                    else
+                    {
+                        u8 hudSlotId = 0;
+                        if (playerId != 0 && controller->aidsBelongingToPlayerIds[playerId - 1] == aid)
+                            hudSlotId = 1;
+                        const u8 oldPlayerId = oldPlayerIds[aid][hudSlotId];
+                        const RacedataPlayer &prev = racedata->menusScenario.players[oldPlayerId];
+                        memcpy(&player, &prev, sizeof(RacedataPlayer));
+                        if (aid == localAid)
+                            player.playerType = PLAYER_REAL_LOCAL;
+                        else
+                            player.playerType = PLAYER_REAL_ONLINE;
+                        MiiGroup &playerMiis = params->playerMiis;
+                        playerMiis.mii[playerId] = playerMiis.mii[oldPlayerId];
+                        for (int i = 0; i < 7; ++i)
+                        {
+                            MiiTexObj *tex = playerMiis.texObj[i];
+                            if (tex != nullptr)
+                                memcpy(&tex[playerId], &tex[oldPlayerId], sizeof(MiiTexObj));
+                        }
+                        // params->playerMiis.AddMii(playerId, &player.mii);
+                    }
+                }
+                const SectionId next = sectionMgr->nextSectionId;
+                if (sub.localPlayerCount == 1 && (next == SECTION_P2_WIFI_FRIEND_VS || next == SECTION_P2_WIFI_FRIEND_VS))
+                {
+                    sectionMgr->nextSectionId = static_cast<SectionId>(next - 4);
+                }
+
+                if (mgr->isSpectating)
+                    racedata->menusScenario.settings.gametype = GAMETYPE_ONLINE_SPECTATOR;
             }
         }
-        const SectionId next = sectionMgr->nextSectionId;
-        if(sub.localPlayerCount == 1 && (next == SECTION_P2_WIFI_FRIEND_VS || next == SECTION_P2_WIFI_FRIEND_VS)) {
-            sectionMgr->nextSectionId = static_cast<SectionId>(next - 4);
-        }
-
-        if(mgr->isSpectating) racedata->menusScenario.settings.gametype = GAMETYPE_ONLINE_SPECTATOR;
-
-    }
-}
-}//namespace KO
-}//namespace Pulsar
+    } // namespace KO
+} // namespace Pulsar

--- a/PulsarEngine/Gamemodes/KO/KOMgr.cpp
+++ b/PulsarEngine/Gamemodes/KO/KOMgr.cpp
@@ -1,4 +1,4 @@
-#include <MarioKartWii/Race/Raceinfo/Raceinfo.hpp>
+#include <MarioKartWii/Race/RaceInfo/RaceInfo.hpp>
 #include <MarioKartWii/UI/Page/Page.hpp>
 #include <MarioKartWii/Input/InputManager.hpp>
 #include <GameModes/KO/KOMgr.hpp>
@@ -6,475 +6,580 @@
 #include <Gamemodes/KO/KORaceEndPage.hpp>
 #include <Settings/SettingsParam.hpp>
 
-namespace Pulsar {
-namespace KO {
+namespace Pulsar
+{
+    namespace KO
+    {
 
-Mgr::Mgr() : winnerPlayerId(0xFF), isSpectating(false), hasSwapped(false) /*, stillInCount(playerCount)*/ {
-    const RKNet::Controller* controller = RKNet::Controller::sInstance;
-    const RKNet::ControllerSub& sub = controller->subs[controller->currentSub];
-    this->baseLocPlayerCount = sub.localPlayerCount;
-    for(int aid = 0; aid < 12; ++aid) {
-        this->status[aid][0] = NORMAL;
-        this->status[aid][1] = NORMAL;
-    }
-    this->ResetRace();
-}
-Mgr::~Mgr() {
-    RKNet::Controller* controller = RKNet::Controller::sInstance;
-    controller->subs[0].localPlayerCount = this->baseLocPlayerCount;
-    controller->subs[1].localPlayerCount = this->baseLocPlayerCount;
-    if(this->GetIsSwapped()) this->SwapControllersAndUI();
-}
-
-void Mgr::AddRaceStats() { //SHOULD ONLY BE CALLED AFTER PROCESSKOS
-    //CALC THE STATS
-    const RacedataScenario& scenario = Racedata::sInstance->racesScenario;
-    for(int hudSlot = 0; hudSlot < scenario.localPlayerCount; ++hudSlot) {
-        Stats& stats = this->stats[hudSlot];
-        if(stats.boolCountArray >= arbitraryAlmostDied) ++stats.final.almostKOdCounter;
-        const u8 pos = Raceinfo::sInstance->players[scenario.settings.hudPlayerIds[hudSlot]]->position;
-        stats.percentageSum += static_cast<float>(pos) / static_cast<float>(System::sInstance->nonTTGhostPlayersCount); //this allows higher precision across multiple races
-        stats.final.finalPercentageSum = static_cast<u8>(stats.percentageSum * 100);
-    }
-
-    this->ResetRace();
-}
-
-void Mgr::CalcWouldBeKnockedOut() {
-    const Raceinfo* raceInfo = Raceinfo::sInstance;
-    const u8 playerCount = System::sInstance->nonTTGhostPlayersCount;
-    const RacedataScenario& scenario = Racedata::sInstance->menusScenario;
-    const u8* pointsArray = &Racedata::pointsRoom[playerCount - 1][0];
-
-    // Initialize player positions array
-    PlayerPosition players[12];
-    for (u8 curPlayerId = 0; curPlayerId < playerCount; ++curPlayerId) {
-        this->wouldBeOut[curPlayerId] = false;
-        players[curPlayerId].playerId = curPlayerId;
-        
-        // Calculate position/points based on race mode
-        if (this->racesPerKO > 1) {
-            const u8 wouldBePoints = pointsArray[raceInfo->players[curPlayerId]->position - 1];
-            players[curPlayerId].position = scenario.players[curPlayerId].score + wouldBePoints;
-        } else {
-            players[curPlayerId].position = raceInfo->players[curPlayerId]->position;
-        }
-    }
-
-    // Special handling for 1v1 finals
-    if (playerCount == 2) {
-        for (int i = 0; i < playerCount; ++i) {
-            this->wouldBeOut[i] = (raceInfo->players[i]->position != 1);
-        }
-        return;
-    }
-
-    // Check if this is a KO race
-    const bool force1v1Final = System::sInstance->IsContext(Pulsar::PULSAR_KOFINAL) == KOSETTING_FINAL_ALWAYS;
-    const u32 currentRaceCount = SectionMgr::sInstance->sectionParams->onlineParams.currentRaceNumber + 1;
-    const bool isKoRace = currentRaceCount % this->racesPerKO == 0;
-
-    if (isKoRace) {
-        // Calculate how many players to KO
-        s32 roundKOs = this->koPerRace;
-        const s32 remainingPlayersAfter = playerCount - roundKOs;
-
-        if (remainingPlayersAfter < 2 && force1v1Final) {
-            roundKOs = playerCount - 2;
-        }
-
-        // Sort players by score/position (ascending)
-        qsort(players, playerCount, sizeof(PlayerPosition), 
-              reinterpret_cast<int(*)(const void*, const void*)>(SortPlayersByPosition));
-    
-        // Mark players for KO starting with lowest scores
-        s32 assignedKOs = 0;
-        if (racesPerKO > 1) {
-            for (s32 idx = 0; idx < playerCount && assignedKOs < roundKOs; ++idx) {
-                if (this->racesPerKO > 1 && idx == playerCount - 1) {
-                    continue;
-                }
-                this->wouldBeOut[players[idx].playerId] = true;
-                ++assignedKOs;
+        Mgr::Mgr() : winnerPlayerId(0xFF), isSpectating(false), hasSwapped(false) /*, stillInCount(playerCount)*/
+        {
+            const RKNet::Controller *controller = RKNet::Controller::sInstance;
+            const RKNet::ControllerSub &sub = controller->subs[controller->currentSub];
+            this->baseLocPlayerCount = sub.localPlayerCount;
+            for (int aid = 0; aid < 12; ++aid)
+            {
+                this->status[aid][0] = NORMAL;
+                this->status[aid][1] = NORMAL;
             }
+            this->ResetRace();
         }
-        else if (racesPerKO == 1) {
-        for (s32 idx = playerCount - 1; idx >= 0 && assignedKOs < roundKOs; --idx) {
-                if (this->racesPerKO == 1 && raceInfo->players[players[idx].playerId]->position == 1) {
-                    continue;
+        Mgr::~Mgr()
+        {
+            RKNet::Controller *controller = RKNet::Controller::sInstance;
+            controller->subs[0].localPlayerCount = this->baseLocPlayerCount;
+            controller->subs[1].localPlayerCount = this->baseLocPlayerCount;
+            if (this->GetIsSwapped())
+                this->SwapControllersAndUI();
+        }
+
+        void Mgr::AddRaceStats()
+        { // SHOULD ONLY BE CALLED AFTER PROCESSKOS
+            // CALC THE STATS
+            const RacedataScenario &scenario = Racedata::sInstance->racesScenario;
+            for (int hudSlot = 0; hudSlot < scenario.localPlayerCount; ++hudSlot)
+            {
+                Stats &stats = this->stats[hudSlot];
+                if (stats.boolCountArray >= arbitraryAlmostDied)
+                    ++stats.final.almostKOdCounter;
+                const u8 pos = Raceinfo::sInstance->players[scenario.settings.hudPlayerIds[hudSlot]]->position;
+                stats.percentageSum += static_cast<float>(pos) / static_cast<float>(System::sInstance->nonTTGhostPlayersCount); // this allows higher precision across multiple races
+                stats.final.finalPercentageSum = static_cast<u8>(stats.percentageSum * 100);
+            }
+
+            this->ResetRace();
+        }
+
+        void Mgr::CalcWouldBeKnockedOut()
+        {
+            const Raceinfo *raceInfo = Raceinfo::sInstance;
+            const u8 playerCount = System::sInstance->nonTTGhostPlayersCount;
+            const RacedataScenario &scenario = Racedata::sInstance->menusScenario;
+            const u8 *pointsArray = &Racedata::pointsRoom[playerCount - 1][0];
+
+            // Initialize player positions array
+            PlayerPosition players[12];
+            for (u8 curPlayerId = 0; curPlayerId < playerCount; ++curPlayerId)
+            {
+                this->wouldBeOut[curPlayerId] = false;
+                players[curPlayerId].playerId = curPlayerId;
+
+                // Calculate position/points based on race mode
+                if (this->racesPerKO > 1)
+                {
+                    const u8 wouldBePoints = pointsArray[raceInfo->players[curPlayerId]->position - 1];
+                    players[curPlayerId].position = scenario.players[curPlayerId].score + wouldBePoints;
+                }
+                else
+                {
+                    players[curPlayerId].position = raceInfo->players[curPlayerId]->position;
+                }
+            }
+
+            // Special handling for 1v1 finals
+            if (playerCount == 2)
+            {
+                for (int i = 0; i < playerCount; ++i)
+                {
+                    this->wouldBeOut[i] = (raceInfo->players[i]->position != 1);
+                }
+                return;
+            }
+
+            // Check if this is a KO race
+            const bool force1v1Final = System::sInstance->IsContext(Pulsar::PULSAR_KOFINAL) == KOSETTING_FINAL_ALWAYS;
+            const u32 currentRaceCount = SectionMgr::sInstance->sectionParams->onlineParams.currentRaceNumber + 1;
+            const bool isKoRace = currentRaceCount % this->racesPerKO == 0;
+
+            if (isKoRace)
+            {
+                // Calculate how many players to KO
+                s32 roundKOs = this->koPerRace;
+                const s32 remainingPlayersAfter = playerCount - roundKOs;
+
+                if (remainingPlayersAfter < 2 && force1v1Final)
+                {
+                    roundKOs = playerCount - 2;
+                }
+
+                // Sort players by score/position (ascending)
+                qsort(players, playerCount, sizeof(PlayerPosition),
+                      reinterpret_cast<int (*)(const void *, const void *)>(SortPlayersByPosition));
+
+                // Mark players for KO starting with lowest scores
+                s32 assignedKOs = 0;
+                if (racesPerKO > 1)
+                {
+                    for (s32 idx = 0; idx < playerCount && assignedKOs < roundKOs; ++idx)
+                    {
+                        if (this->racesPerKO > 1 && idx == playerCount - 1)
+                        {
+                            continue;
+                        }
+                        this->wouldBeOut[players[idx].playerId] = true;
+                        ++assignedKOs;
                     }
-                this->wouldBeOut[players[idx].playerId] = true;
-                ++assignedKOs;
-            }
-        }
-    }
-}
-
-void Mgr::ProcessKOs(Pages::GPVSLeaderboardUpdate::Player* playerArr, size_t nitems, size_t size, int (*compar)(const void*, const void*)) {
-    // Sort players by default sorting function
-    qsort(playerArr, nitems, size, compar);
-
-    // Only process if we're in KO mode
-    const System* system = System::sInstance;
-    if (!system->IsContext(PULSAR_MODE_KO)) {
-        return;
-    }
-
-    Mgr* self = system->koMgr;
-    RacedataScenario& scenario = Racedata::sInstance->menusScenario;
-    const RKNet::Controller* controller = RKNet::Controller::sInstance;
-    const RKNet::ControllerSub& sub = controller->subs[controller->currentSub];
-    const Raceinfo* raceinfo = Raceinfo::sInstance;
-    const u8 playerCount = system->nonTTGhostPlayersCount;
-    self->alwaysFinal = System::sInstance->IsContext(PULSAR_KOFINAL);
-    SectionParams* sectionParams = SectionMgr::sInstance->sectionParams;
-    const u32 currentRaceNumber = sectionParams->onlineParams.currentRaceNumber + 1;
-    bool hasTies = false;
-
-    // Handle disconnected players first
-    u8 disconnectedKOs = 0;
-    for (int playerId = 0; playerId < playerCount; ++playerId) {
-        const u8 aid = controller->aidsBelongingToPlayerIds[playerId];
-        if (aid >= 12) continue;
-        
-        if ((1 << aid & sub.availableAids) == 0) {
-            self->SetDisconnected(playerId);
-            ++disconnectedKOs;
-        }
-    }
-
-    // Calculate how many players to eliminate
-    u8 koCount = self->koPerRace;
-    
-    // Adjust KO count if we'd end up with fewer than 2 players and alwaysFinal is on
-    if (playerCount - koCount < 2 && self->alwaysFinal) {
-        koCount = playerCount - 2;
-    }
-
-    // Special cases for small player counts
-    if (self->koPerRace >= 2 && self->alwaysFinal && playerCount > 2) {
-        if (playerCount == 3) {
-            koCount = 1;
-        } else if (playerCount == 4 && self->koPerRace >= 2) {
-            koCount = 2;
-        }
-    } else {
-        if (playerCount == 3 && self->koPerRace >= 3) {
-            koCount = 2;
-        } else if (playerCount == 4 && self->koPerRace >= 4) {
-            koCount = 3;
-        }
-    }
-
-    // Handle 1v1 finals or near-end scenarios
-    if (playerCount == 2 || (playerCount - disconnectedKOs) == 1) {
-        // In finals or when only one player remains due to disconnects
-        self->winnerPlayerId = raceinfo->playerIdInEachPosition[0];
-        self->SetKOd(raceinfo->playerIdInEachPosition[1]);
-        self->AddRaceStats();
-        return;
-    }
-
-    // Check if this is a KO race
-    const bool isKoRace = currentRaceNumber % self->racesPerKO == 0;
-    if (!isKoRace || koCount <= 0) {
-        self->AddRaceStats();
-        return;
-    }
-
-    // Handle KO logic based on race mode
-    if (self->racesPerKO > 1) {
-        // Multi-race KO: Eliminate based on total score
-        
-        // Check for ties at the KO threshold
-        u32 koThresholdPosition = playerCount - koCount;
-        u32 tieScore = playerArr[koThresholdPosition].totalScore;
-        
-        // Count players involved in the tie
-        int tiedPlayersCount = 0;
-        int playersInKOPosition = 0;
-        int playersNotInKOPosition = 0;
-        
-        for (int position = 0; position < playerCount; ++position) {
-            if (playerArr[position].totalScore == tieScore) {
-                ++tiedPlayersCount;
-                if (position >= koThresholdPosition) {
-                    ++playersInKOPosition;
-                } else {
-                    ++playersNotInKOPosition;
+                }
+                else if (racesPerKO == 1)
+                {
+                    for (s32 idx = playerCount - 1; idx >= 0 && assignedKOs < roundKOs; --idx)
+                    {
+                        if (this->racesPerKO == 1 && raceInfo->players[players[idx].playerId]->position == 1)
+                        {
+                            continue;
+                        }
+                        this->wouldBeOut[players[idx].playerId] = true;
+                        ++assignedKOs;
+                    }
                 }
             }
         }
 
-        // Handle tie resolution
-        if (playersInKOPosition > 0 && playersNotInKOPosition > 0) {
-            // Tie spans across the KO threshold - no eliminations, repeat race
-            for (int position = 0; position < playerCount; ++position) {
-                if (playerArr[position].totalScore == tieScore) {
-                    self->SetTie(playerArr[position].playerId, playerArr[koThresholdPosition].playerId);
-                    hasTies = true;
-                }
-            }
-            if (hasTies) {
-                // Decrement race number to repeat
-                --sectionParams->onlineParams.currentRaceNumber;
-                koCount = 0;  // Don't eliminate anyone this round
-            }
-        } else if (tiedPlayersCount == koCount) {
-            // All tied players would be KO'd - eliminate them all
-            for (int position = 0; position < playerCount; ++position) {
-                if (playerArr[position].totalScore == tieScore) {
-                    self->SetKOd(playerArr[position].playerId);
-                }
-            }
-        }
+        void Mgr::ProcessKOs(Pages::GPVSLeaderboardUpdate::Player *playerArr, size_t nitems, size_t size, int (*compar)(const void *, const void *))
+        {
+            // Sort players by default sorting function
+            qsort(playerArr, nitems, size, compar);
 
-        // Reset scores after KO round (if no ties and multi-race KO)
-        if (!hasTies && isKoRace) {
-            for (int idx = 0; idx < 12; ++idx) {
-                scenario.players[idx].score = 0;
-                scenario.players[idx].previousScore = 0;
+            // Only process if we're in KO mode
+            const System *system = System::sInstance;
+            if (!system->IsContext(PULSAR_MODE_KO))
+            {
+                return;
             }
-        }
-    }
 
-    // Eliminate players based on position or score
-    if (koCount > 0) {
-        for (int idx = 0; idx < koCount; ++idx) {
-            u8 playerId;
-            u32 position = (playerCount - 1) - idx;
-            
-            if (self->racesPerKO == 1) {
-                // Single race KO: Eliminate based on race position
-                playerId = raceinfo->playerIdInEachPosition[position];
-            } else {
-                // Multi-race KO: Eliminate based on total score
-                playerId = playerArr[position].playerId;
-                
-                // Don't eliminate the winner in multi-race mode with more than 2 players
-                if (playerCount > 2 && playerId == self->winnerPlayerId) {
+            Mgr *self = system->koMgr;
+            RacedataScenario &scenario = Racedata::sInstance->menusScenario;
+            const RKNet::Controller *controller = RKNet::Controller::sInstance;
+            const RKNet::ControllerSub &sub = controller->subs[controller->currentSub];
+            const Raceinfo *raceinfo = Raceinfo::sInstance;
+            const u8 playerCount = system->nonTTGhostPlayersCount;
+            self->alwaysFinal = System::sInstance->IsContext(PULSAR_KOFINAL);
+            SectionParams *sectionParams = SectionMgr::sInstance->sectionParams;
+            const u32 currentRaceNumber = sectionParams->onlineParams.currentRaceNumber + 1;
+            bool hasTies = false;
+
+            // Handle disconnected players first
+            u8 disconnectedKOs = 0;
+            for (int playerId = 0; playerId < playerCount; ++playerId)
+            {
+                const u8 aid = controller->aidsBelongingToPlayerIds[playerId];
+                if (aid >= 12)
                     continue;
+
+                if ((1 << aid & sub.availableAids) == 0)
+                {
+                    self->SetDisconnected(playerId);
+                    ++disconnectedKOs;
                 }
             }
-            
-            // Skip already KO'd players
-            if (self->IsKOdPlayerId(playerId)) {
-                continue;
+
+            // Calculate how many players to eliminate
+            u8 koCount = self->koPerRace;
+
+            // Adjust KO count if we'd end up with fewer than 2 players and alwaysFinal is on
+            if (playerCount - koCount < 2 && self->alwaysFinal)
+            {
+                koCount = playerCount - 2;
             }
-            
-            self->SetKOd(playerId);
+
+            // Special cases for small player counts
+            if (self->koPerRace >= 2 && self->alwaysFinal && playerCount > 2)
+            {
+                if (playerCount == 3)
+                {
+                    koCount = 1;
+                }
+                else if (playerCount == 4 && self->koPerRace >= 2)
+                {
+                    koCount = 2;
+                }
+            }
+            else
+            {
+                if (playerCount == 3 && self->koPerRace >= 3)
+                {
+                    koCount = 2;
+                }
+                else if (playerCount == 4 && self->koPerRace >= 4)
+                {
+                    koCount = 3;
+                }
+            }
+
+            // Handle 1v1 finals or near-end scenarios
+            if (playerCount == 2 || (playerCount - disconnectedKOs) == 1)
+            {
+                // In finals or when only one player remains due to disconnects
+                self->winnerPlayerId = raceinfo->playerIdInEachPosition[0];
+                self->SetKOd(raceinfo->playerIdInEachPosition[1]);
+                self->AddRaceStats();
+                return;
+            }
+
+            // Check if this is a KO race
+            const bool isKoRace = currentRaceNumber % self->racesPerKO == 0;
+            if (!isKoRace || koCount <= 0)
+            {
+                self->AddRaceStats();
+                return;
+            }
+
+            // Handle KO logic based on race mode
+            if (self->racesPerKO > 1)
+            {
+                // Multi-race KO: Eliminate based on total score
+
+                // Check for ties at the KO threshold
+                u32 koThresholdPosition = playerCount - koCount;
+                u32 tieScore = playerArr[koThresholdPosition].totalScore;
+
+                // Count players involved in the tie
+                int tiedPlayersCount = 0;
+                int playersInKOPosition = 0;
+                int playersNotInKOPosition = 0;
+
+                for (int position = 0; position < playerCount; ++position)
+                {
+                    if (playerArr[position].totalScore == tieScore)
+                    {
+                        ++tiedPlayersCount;
+                        if (position >= koThresholdPosition)
+                        {
+                            ++playersInKOPosition;
+                        }
+                        else
+                        {
+                            ++playersNotInKOPosition;
+                        }
+                    }
+                }
+
+                // Handle tie resolution
+                if (playersInKOPosition > 0 && playersNotInKOPosition > 0)
+                {
+                    // Tie spans across the KO threshold - no eliminations, repeat race
+                    for (int position = 0; position < playerCount; ++position)
+                    {
+                        if (playerArr[position].totalScore == tieScore)
+                        {
+                            self->SetTie(playerArr[position].playerId, playerArr[koThresholdPosition].playerId);
+                            hasTies = true;
+                        }
+                    }
+                    if (hasTies)
+                    {
+                        // Decrement race number to repeat
+                        --sectionParams->onlineParams.currentRaceNumber;
+                        koCount = 0; // Don't eliminate anyone this round
+                    }
+                }
+                else if (tiedPlayersCount == koCount)
+                {
+                    // All tied players would be KO'd - eliminate them all
+                    for (int position = 0; position < playerCount; ++position)
+                    {
+                        if (playerArr[position].totalScore == tieScore)
+                        {
+                            self->SetKOd(playerArr[position].playerId);
+                        }
+                    }
+                }
+
+                // Reset scores after KO round (if no ties and multi-race KO)
+                if (!hasTies && isKoRace)
+                {
+                    for (int idx = 0; idx < 12; ++idx)
+                    {
+                        scenario.players[idx].score = 0;
+                        scenario.players[idx].previousScore = 0;
+                    }
+                }
+            }
+
+            // Eliminate players based on position or score
+            if (koCount > 0)
+            {
+                for (int idx = 0; idx < koCount; ++idx)
+                {
+                    u8 playerId;
+                    u32 position = (playerCount - 1) - idx;
+
+                    if (self->racesPerKO == 1)
+                    {
+                        // Single race KO: Eliminate based on race position
+                        playerId = raceinfo->playerIdInEachPosition[position];
+                    }
+                    else
+                    {
+                        // Multi-race KO: Eliminate based on total score
+                        playerId = playerArr[position].playerId;
+
+                        // Don't eliminate the winner in multi-race mode with more than 2 players
+                        if (playerCount > 2 && playerId == self->winnerPlayerId)
+                        {
+                            continue;
+                        }
+                    }
+
+                    // Skip already KO'd players
+                    if (self->IsKOdPlayerId(playerId))
+                    {
+                        continue;
+                    }
+
+                    self->SetKOd(playerId);
+                }
+            }
+
+            // Check for overall winner
+            int notKOdCount = 0;
+            u8 potentialWinner = 0xFF;
+            for (int playerId = 0; playerId < playerCount; ++playerId)
+            {
+                if (!self->IsKOdPlayerId(playerId))
+                {
+                    ++notKOdCount;
+                    potentialWinner = playerId;
+                }
+            }
+
+            if (notKOdCount == 1)
+            {
+                self->winnerPlayerId = potentialWinner;
+            }
+
+            self->AddRaceStats();
         }
-    }
+        kmCall(0x8085cb94, Mgr::ProcessKOs);
 
-    // Check for overall winner
-    int notKOdCount = 0;
-    u8 potentialWinner = 0xFF;
-    for (int playerId = 0; playerId < playerCount; ++playerId) {
-        if (!self->IsKOdPlayerId(playerId)) {
-            ++notKOdCount;
-            potentialWinner = playerId;
-        }
-    }
-    
-    if (notKOdCount == 1) {
-        self->winnerPlayerId = potentialWinner;
-    }
+        void Mgr::Update()
+        {
+            const System *system = System::sInstance;
+            if (system->IsContext(PULSAR_MODE_KO))
+            {
+                Mgr *self = System::sInstance->koMgr;
+                self->CalcWouldBeKnockedOut();
+                const RacedataScenario &scenario = Racedata::sInstance->racesScenario;
+                for (int hudSlot = 0; hudSlot < scenario.localPlayerCount; ++hudSlot)
+                {
+                    const bool wouldBeOut = self->GetWouldBeKnockedOut(scenario.settings.hudPlayerIds[hudSlot]);
+                    const u32 idx = Raceinfo::sInstance->raceFrames % 300;
 
-    self->AddRaceStats();
-}
-kmCall(0x8085cb94, Mgr::ProcessKOs);
+                    Stats &stats = self->stats[hudSlot];
+                    if (wouldBeOut)
+                        ++stats.final.timeInDanger;
+                    if (stats.isInDangerFrames[idx] == false && wouldBeOut == true)
+                        ++stats.boolCountArray;
+                    else if (stats.isInDangerFrames[idx] == true && wouldBeOut == false)
+                        --stats.boolCountArray;
+                    stats.isInDangerFrames[idx] = wouldBeOut;
+                }
 
-void Mgr::Update() {
-    const System* system = System::sInstance;
-    if(system->IsContext(PULSAR_MODE_KO)) {
-        Mgr* self = System::sInstance->koMgr;
-        self->CalcWouldBeKnockedOut();
-        const RacedataScenario& scenario = Racedata::sInstance->racesScenario;
-        for(int hudSlot = 0; hudSlot < scenario.localPlayerCount; ++hudSlot) {
-            const bool wouldBeOut = self->GetWouldBeKnockedOut(scenario.settings.hudPlayerIds[hudSlot]);
-            const u32 idx = Raceinfo::sInstance->raceFrames % 300;
+                const u8 winnerPlayerId = self->winnerPlayerId;
+                if (winnerPlayerId != 0xFF)
+                { // if the if is taken, ProcessKOs and therefore AddRaceStats are guaranteed to have been called
+                    const RKNet::Controller *controller = RKNet::Controller::sInstance;
+                    const RKNet::ControllerSub &sub = controller->subs[controller->currentSub];
+                    if (controller->aidsBelongingToPlayerIds[winnerPlayerId] == sub.localAid)
+                    { // only send the data if needed
+                        for (int aid = 0; aid < 12; ++aid)
+                        {
+                            if ((1 << aid & sub.availableAids) == 0 || aid == sub.localAid)
+                                continue;
 
-            Stats& stats = self->stats[hudSlot];
-            if(wouldBeOut) ++stats.final.timeInDanger;
-            if(stats.isInDangerFrames[idx] == false && wouldBeOut == true) ++stats.boolCountArray;
-            else if(stats.isInDangerFrames[idx] == true && wouldBeOut == false) --stats.boolCountArray;
-            stats.isInDangerFrames[idx] = wouldBeOut;
-        }
+                            Stats &stats = self->stats[0];
+                            RKNet::PacketHolder<Network::PulRH1> *holder = controller->GetSendPacketHolder<Network::PulRH1>(aid);
 
-        const u8 winnerPlayerId = self->winnerPlayerId;
-        if(winnerPlayerId != 0xFF) { //if the if is taken, ProcessKOs and therefore AddRaceStats are guaranteed to have been called
-            const RKNet::Controller* controller = RKNet::Controller::sInstance;
-            const RKNet::ControllerSub& sub = controller->subs[controller->currentSub];
-            if(controller->aidsBelongingToPlayerIds[winnerPlayerId] == sub.localAid) { //only send the data if needed 
-                for(int aid = 0; aid < 12; ++aid) {
-                    if((1 << aid & sub.availableAids) == 0 || aid == sub.localAid) continue;
-
-                    Stats& stats = self->stats[0];
-                    RKNet::PacketHolder<Network::PulRH1>* holder = controller->GetSendPacketHolder<Network::PulRH1>(aid);
-
-                    /*
-                    this shouldn't be needed because the "ExportRH1ToPulRH1" always does it
-                    const u32 curSize = holder->packetSize;/
-                    u32 addedSize = 0;
-                    if(curSize == sizeof(RKNet::RACEHEADER1Packet)) addedSize = sizeof(Network::PulRH1) - sizeof(RKNet::RACEHEADER1Packet);
-                    else if(holder->packetSize == 0) addedSize = sizeof(Network::PulRH1);
-                    holder->packetSize += addedSize;
-                    */
-                    Network::PulRH1* dest = holder->packet;
-                    dest->timeInDanger = stats.final.timeInDanger;
-                    dest->almostKOdCounter = stats.final.almostKOdCounter;
-                    dest->finalPercentageSum = stats.final.finalPercentageSum;
+                            /*
+                            this shouldn't be needed because the "ExportRH1ToPulRH1" always does it
+                            const u32 curSize = holder->packetSize;/
+                            u32 addedSize = 0;
+                            if(curSize == sizeof(RKNet::RACEHEADER1Packet)) addedSize = sizeof(Network::PulRH1) - sizeof(RKNet::RACEHEADER1Packet);
+                            else if(holder->packetSize == 0) addedSize = sizeof(Network::PulRH1);
+                            holder->packetSize += addedSize;
+                            */
+                            Network::PulRH1 *dest = holder->packet;
+                            dest->timeInDanger = stats.final.timeInDanger;
+                            dest->almostKOdCounter = stats.final.almostKOdCounter;
+                            dest->finalPercentageSum = stats.final.finalPercentageSum;
+                        }
+                    }
                 }
             }
         }
-    }
-}
-RaceFrameHook koUpdate(Mgr::Update);
+        RaceFrameHook koUpdate(Mgr::Update);
 
-/*
-void Mgr::UpdateStillInCount() {
-    u32 stillIn = 0;
-    const RKNet::Controller* controller = RKNet::Controller::sInstance;
-    const u32 availableAids =  controller->subs[controller->currentSub].availableAids;
-    for(int aid = 0; aid < 12; ++aid) {
-        u8 aid = controller->aidsBelongingToPlayerIds[aid];
-        if((1 << aid & availableAids) == 0) { //the playerId is disconnected
-            this->SetMgrd(aid);
-        }
-        if(this->IsMgrd(aid)) continue;
-        ++stillIn;
-    }
-    this->stillInCount = stillIn;
-}
-*/
-
-void Mgr::PatchAids(RKNet::ControllerSub& sub) const {
-    u32 availableAids = sub.availableAids;
-    const u8 localAid = sub.localAid;
-    for(u8 aid = 0; aid < 12; ++aid) {
-
-        bool isConsoleOut = false;
-        const bool isMainOut = this->IsKOdAid(aid, 0) || this->IsDisconnectedAid(aid, 0);
-        u8 aidPlayerCount = aid == localAid ? sub.localPlayerCount : sub.connectionUserDatas[aid].playersAtConsole;
-
-
-        if(aidPlayerCount <= 1) isConsoleOut = isMainOut;
-        else if(aidPlayerCount == 2) {
-            const bool isGuestOut = this->IsKOdAid(aid, 1) || this->IsDisconnectedAid(aid, 1);
-            if(isMainOut && isGuestOut) isConsoleOut = true;
-            else if(isMainOut != isGuestOut) {
-                aidPlayerCount = 1;
-            }
-
-        }
-        if(isConsoleOut) {
-            availableAids = availableAids & ~(1 << aid);
-            aidPlayerCount = 0;
-        }
-
-        if(aid == localAid) sub.localPlayerCount = aidPlayerCount;
-        else sub.connectionUserDatas[aid].playersAtConsole = aidPlayerCount;
-    }
-    sub.availableAids = availableAids;
-}
-
-u32 Mgr::GetAidAndSlotFromPlayerId(u8 playerId) const {
-    const RKNet::Controller* controller = RKNet::Controller::sInstance;
-    const RKNet::ControllerSub& sub = controller->subs[controller->currentSub];
-    const u8 aid = controller->aidsBelongingToPlayerIds[playerId];
-    const u8 localAid = sub.localAid;
-    u8 slot = 0;
-
-    if((aid == localAid && sub.localPlayerCount == 2) || (aid != localAid && sub.connectionUserDatas[aid].playersAtConsole == 2)) {
-        if(playerId > 0 && controller->aidsBelongingToPlayerIds[playerId - 1] == aid) slot = 1;
-        else if(playerId < 11 && this->status[aid][0] == KOD && controller->aidsBelongingToPlayerIds[playerId + 1] != aid) slot = 1;
-    }
-    return (slot << 16) | aid; //10001
-}
-
-SectionId Mgr::GetSectionAfterKO(SectionId defaultId) const {
-    const RKNet::Controller* controller = RKNet::Controller::sInstance;
-    const RKNet::ControllerSub& sub = controller->subs[controller->currentSub];
-    if(this->baseLocPlayerCount == 2) {
-        if(this->IsKOdAid(sub.localAid, 0) != this->IsKOdAid(sub.localAid, 1)) {
-            if(defaultId == SECTION_P2_WIFI_FROOM_VS_VOTING) defaultId = SECTION_P1_WIFI_FROOM_VS_VOTING; //select section
-            else if(defaultId == SECTION_P1_WIFI_FROM_FROOM_RACE || defaultId == SECTION_P2_WIFI_FROM_FROOM_RACE) {
-                defaultId = SECTION_P2_WIFI_FROM_FROOM_RACE; //after room section
-                SectionMgr::sInstance->sectionParams->localPlayerCount = 2;
-            }
-        }
-    }
-    return defaultId;
-}
-
-void OnDisconnectKO(SectionMgr* sectionMgr, SectionId id) {
-    const System* system = System::sInstance;
-    if(system->IsContext(PULSAR_MODE_KO)) id = system->koMgr->GetSectionAfterKO(id);
-    sectionMgr->SetNextSection(id, 0);
-}
-kmCall(0x80651814, OnDisconnectKO);
-
-PageId Mgr::KickPlayersOut(PageId defaultId) { //only called if KOMode
-
-    PageId ret = defaultId;
-    const System* system = System::sInstance;
-
-    Mgr* mgr = system->koMgr;
-    RacedataScenario& scenario = Racedata::sInstance->racesScenario;
-    const bool isMainOut = mgr->IsKOdPlayerId(scenario.settings.hudPlayerIds[0]) || mgr->IsDisconnectedPlayerId(scenario.settings.hudPlayerIds[0]);
-    if(system->nonTTGhostPlayersCount > 2) {
-        if(scenario.localPlayerCount == 1) {
+        /*
+        void Mgr::UpdateStillInCount() {
+            u32 stillIn = 0;
             const RKNet::Controller* controller = RKNet::Controller::sInstance;
-            const RKNet::ControllerSub& sub = controller->subs[controller->currentSub];
-            if(isMainOut) {
-                if(sub.localAid == sub.hostAid) mgr->isSpectating = true; //force the host to spectate, they should not be allowed to quit
-                else ret = static_cast<PageId>(RaceEndPage::id);
+            const u32 availableAids =  controller->subs[controller->currentSub].availableAids;
+            for(int aid = 0; aid < 12; ++aid) {
+                u8 aid = controller->aidsBelongingToPlayerIds[aid];
+                if((1 << aid & availableAids) == 0) { //the playerId is disconnected
+                    this->SetMgrd(aid);
+                }
+                if(this->IsMgrd(aid)) continue;
+                ++stillIn;
             }
+            this->stillInCount = stillIn;
         }
-        else {
-            const bool isGuestOut = mgr->IsKOdPlayerId(scenario.settings.hudPlayerIds[1]) || mgr->IsDisconnectedPlayerId(scenario.settings.hudPlayerIds[1]);
-            if(isMainOut != isGuestOut) SectionMgr::sInstance->sectionParams->localPlayerCount = 1;
-            if(isMainOut && !isGuestOut) {
-                memcpy(&mgr->stats[0], &mgr->stats[1], sizeof(Mgr::Stats));
+        */
+
+        void Mgr::PatchAids(RKNet::ControllerSub &sub) const
+        {
+            u32 availableAids = sub.availableAids;
+            const u8 localAid = sub.localAid;
+            for (u8 aid = 0; aid < 12; ++aid)
+            {
+
+                bool isConsoleOut = false;
+                const bool isMainOut = this->IsKOdAid(aid, 0) || this->IsDisconnectedAid(aid, 0);
+                u8 aidPlayerCount = aid == localAid ? sub.localPlayerCount : sub.connectionUserDatas[aid].playersAtConsole;
+
+                if (aidPlayerCount <= 1)
+                    isConsoleOut = isMainOut;
+                else if (aidPlayerCount == 2)
+                {
+                    const bool isGuestOut = this->IsKOdAid(aid, 1) || this->IsDisconnectedAid(aid, 1);
+                    if (isMainOut && isGuestOut)
+                        isConsoleOut = true;
+                    else if (isMainOut != isGuestOut)
+                    {
+                        aidPlayerCount = 1;
+                    }
+                }
+                if (isConsoleOut)
+                {
+                    availableAids = availableAids & ~(1 << aid);
+                    aidPlayerCount = 0;
+                }
+
+                if (aid == localAid)
+                    sub.localPlayerCount = aidPlayerCount;
+                else
+                    sub.connectionUserDatas[aid].playersAtConsole = aidPlayerCount;
             }
-            else if(isMainOut && isGuestOut) ret = static_cast<PageId>(RaceEndPage::id);
-
+            sub.availableAids = availableAids;
         }
-    }
-    return ret;
-}
 
-void Mgr::SwapControllersAndUI() {
+        u32 Mgr::GetAidAndSlotFromPlayerId(u8 playerId) const
+        {
+            const RKNet::Controller *controller = RKNet::Controller::sInstance;
+            const RKNet::ControllerSub &sub = controller->subs[controller->currentSub];
+            const u8 aid = controller->aidsBelongingToPlayerIds[playerId];
+            const u8 localAid = sub.localAid;
+            u8 slot = 0;
 
-    //Swap the controllers
-    Input::Manager* input = Input::Manager::sInstance;
+            if ((aid == localAid && sub.localPlayerCount == 2) || (aid != localAid && sub.connectionUserDatas[aid].playersAtConsole == 2))
+            {
+                if (playerId > 0 && controller->aidsBelongingToPlayerIds[playerId - 1] == aid)
+                    slot = 1;
+                else if (playerId < 11 && this->status[aid][0] == KOD && controller->aidsBelongingToPlayerIds[playerId + 1] != aid)
+                    slot = 1;
+            }
+            return (slot << 16) | aid; // 10001
+        }
 
-    char mainController[sizeof(Input::RealControllerHolder)];
-    memcpy(&mainController, &input->realControllerHolders[0], sizeof(Input::RealControllerHolder));
-    memcpy(&input->realControllerHolders[0], &input->realControllerHolders[1], sizeof(Input::RealControllerHolder));
-    memcpy(&input->realControllerHolders[1], &mainController, sizeof(Input::RealControllerHolder));
+        SectionId Mgr::GetSectionAfterKO(SectionId defaultId) const
+        {
+            const RKNet::Controller *controller = RKNet::Controller::sInstance;
+            const RKNet::ControllerSub &sub = controller->subs[controller->currentSub];
+            if (this->baseLocPlayerCount == 2)
+            {
+                if (this->IsKOdAid(sub.localAid, 0) != this->IsKOdAid(sub.localAid, 1))
+                {
+                    if (defaultId == SECTION_P2_WIFI_FROOM_VS_VOTING)
+                        defaultId = SECTION_P1_WIFI_FROOM_VS_VOTING; // select section
+                    else if (defaultId == SECTION_P1_WIFI_FROM_FROOM_RACE || defaultId == SECTION_P2_WIFI_FROM_FROOM_RACE)
+                    {
+                        defaultId = SECTION_P2_WIFI_FROM_FROOM_RACE; // after room section
+                        SectionMgr::sInstance->sectionParams->localPlayerCount = 2;
+                    }
+                }
+            }
+            return defaultId;
+        }
 
-    SectionMgr* sectionMgr = SectionMgr::sInstance;
-    SectionPad& pad = sectionMgr->pad;
-    PadInfo& main = pad.padInfos[0];
-    PadInfo& guest = pad.padInfos[1];
-    u32 old = main.controllerID;
-    u32 oldg = guest.controllerID;
-    main.controllerID = oldg;
-    guest.controllerID = old;
-    main.controllerIDActive = main.controllerID;
-    guest.controllerIDActive = guest.controllerID;
+        void OnDisconnectKO(SectionMgr *sectionMgr, SectionId id)
+        {
+            const System *system = System::sInstance;
+            if (system->IsContext(PULSAR_MODE_KO))
+                id = system->koMgr->GetSectionAfterKO(id);
+            sectionMgr->SetNextSection(id, 0);
+        }
+        kmCall(0x80651814, OnDisconnectKO);
 
-    //Swap the characters on the UI
-    SectionParams* params = sectionMgr->sectionParams;
-    CharacterId mainChar = params->characters[0];
-    KartId mainKart = params->karts[0];
-    params->characters[0] = params->characters[1];
-    params->karts[0] = params->karts[1];
-    params->characters[1] = mainChar;
-    params->karts[1] = mainKart;
-    memcpy(&params->combos[0], &params->combos[1], sizeof(PlayerCombo));
-    this->hasSwapped = !this->hasSwapped;
-}
-}//namespace KO
-}//namespace Pulsar
+        PageId Mgr::KickPlayersOut(PageId defaultId)
+        { // only called if KOMode
+
+            PageId ret = defaultId;
+            const System *system = System::sInstance;
+
+            Mgr *mgr = system->koMgr;
+            RacedataScenario &scenario = Racedata::sInstance->racesScenario;
+            const bool isMainOut = mgr->IsKOdPlayerId(scenario.settings.hudPlayerIds[0]) || mgr->IsDisconnectedPlayerId(scenario.settings.hudPlayerIds[0]);
+            if (system->nonTTGhostPlayersCount > 2)
+            {
+                if (scenario.localPlayerCount == 1)
+                {
+                    const RKNet::Controller *controller = RKNet::Controller::sInstance;
+                    const RKNet::ControllerSub &sub = controller->subs[controller->currentSub];
+                    if (isMainOut)
+                    {
+                        if (sub.localAid == sub.hostAid)
+                            mgr->isSpectating = true; // force the host to spectate, they should not be allowed to quit
+                        else
+                            ret = static_cast<PageId>(RaceEndPage::id);
+                    }
+                }
+                else
+                {
+                    const bool isGuestOut = mgr->IsKOdPlayerId(scenario.settings.hudPlayerIds[1]) || mgr->IsDisconnectedPlayerId(scenario.settings.hudPlayerIds[1]);
+                    if (isMainOut != isGuestOut)
+                        SectionMgr::sInstance->sectionParams->localPlayerCount = 1;
+                    if (isMainOut && !isGuestOut)
+                    {
+                        memcpy(&mgr->stats[0], &mgr->stats[1], sizeof(Mgr::Stats));
+                    }
+                    else if (isMainOut && isGuestOut)
+                        ret = static_cast<PageId>(RaceEndPage::id);
+                }
+            }
+            return ret;
+        }
+
+        void Mgr::SwapControllersAndUI()
+        {
+
+            // Swap the controllers
+            Input::Manager *input = Input::Manager::sInstance;
+
+            char mainController[sizeof(Input::RealControllerHolder)];
+            memcpy(&mainController, &input->realControllerHolders[0], sizeof(Input::RealControllerHolder));
+            memcpy(&input->realControllerHolders[0], &input->realControllerHolders[1], sizeof(Input::RealControllerHolder));
+            memcpy(&input->realControllerHolders[1], &mainController, sizeof(Input::RealControllerHolder));
+
+            SectionMgr *sectionMgr = SectionMgr::sInstance;
+            SectionPad &pad = sectionMgr->pad;
+            PadInfo &main = pad.padInfos[0];
+            PadInfo &guest = pad.padInfos[1];
+            u32 old = main.controllerID;
+            u32 oldg = guest.controllerID;
+            main.controllerID = oldg;
+            guest.controllerID = old;
+            main.controllerIDActive = main.controllerID;
+            guest.controllerIDActive = guest.controllerID;
+
+            // Swap the characters on the UI
+            SectionParams *params = sectionMgr->sectionParams;
+            CharacterId mainChar = params->characters[0];
+            KartId mainKart = params->karts[0];
+            params->characters[0] = params->characters[1];
+            params->karts[0] = params->karts[1];
+            params->characters[1] = mainChar;
+            params->karts[1] = mainKart;
+            memcpy(&params->combos[0], &params->combos[1], sizeof(PlayerCombo));
+            this->hasSwapped = !this->hasSwapped;
+        }
+    } // namespace KO
+} // namespace Pulsar

--- a/PulsarEngine/Gamemodes/KO/KOMisc.cpp
+++ b/PulsarEngine/Gamemodes/KO/KOMisc.cpp
@@ -9,306 +9,362 @@
 #include <MarioKartWii/UI/Page/Other/WifiVSResults.hpp>
 #include <MarioKartWii/UI/Ctrl/CtrlRace/CtrlRaceRankNum.hpp>
 #include <MarioKartWii/UI/Ctrl/CtrlRace/CtrlRaceItemWindow.hpp>
-#include <MarioKartWii/Race/Raceinfo/Raceinfo.hpp>
+#include <MarioKartWii/Race/RaceInfo/RaceInfo.hpp>
 #include <MarioKartWii/Kart/KartManager.hpp>
 #include <Network/PacketExpansion.hpp>
 #include <Gamemodes/KO/KOMgr.hpp>
 #include <Gamemodes/KO/KORaceEndPage.hpp>
 #include <Gamemodes/KO/KOWinnerPage.hpp>
 
+namespace Pulsar
+{
+    namespace KO
+    {
 
-namespace Pulsar {
-namespace KO {
+        static void EditLdb(CtrlRaceResult *result, u8 playerId)
+        {
+            const System *system = System::sInstance;
 
-static void EditLdb(CtrlRaceResult* result, u8 playerId) {
-    const System* system = System::sInstance;
-
-    if(system->IsContext(PULSAR_MODE_KO)) {
-        const char* pane= "player_name";
-        const Status koStatus = system->koMgr->GetPlayerStatus(playerId);
-        if(koStatus != NORMAL) {
-            u32 bmgId;
-            ut::Color color;
-            if(koStatus == KOD) {
-                bmgId = UI::BMG_KO_OUT;
-                color = 0xff0000c0;
+            if (system->IsContext(PULSAR_MODE_KO))
+            {
+                const char *pane = "player_name";
+                const Status koStatus = system->koMgr->GetPlayerStatus(playerId);
+                if (koStatus != NORMAL)
+                {
+                    u32 bmgId;
+                    ut::Color color;
+                    if (koStatus == KOD)
+                    {
+                        bmgId = UI::BMG_KO_OUT;
+                        color = 0xff0000c0;
+                    }
+                    if (koStatus == DISCONNECTED)
+                    {
+                        bmgId = UI::BMG_KO_TIE;
+                        color = 0xff0f00c0;
+                    }
+                    if (koStatus == TIE)
+                    {
+                        bmgId = UI::BMG_KO_TIE;
+                        color = 0xff00f0c0;
+                    }
+                    result->SetTextBoxMessage("player_name", bmgId);
+                    result->animator.GetAnimationGroupById(4).PlayAnimationAtFrame(6, 0.0f);
+                    lyt::Picture *selectBase = static_cast<nw4r::lyt::Picture *>(result->layout.GetPaneByName("select_base"));
+                    UI::ResetMatColor(selectBase, color);
+                    UI::UnbindRLMC(selectBase->material);
+                    selectBase->vertexColours[0] = color;
+                    selectBase->vertexColours[1] = color;
+                    selectBase->vertexColours[2] = color;
+                    selectBase->vertexColours[3] = color;
+                    return;
+                }
             }
-            if (koStatus == DISCONNECTED) {
-                bmgId = UI::BMG_KO_TIE;
-                color = 0xff0f00c0;
+            result->FillName(playerId);
+        }
+        kmCall(0x8085cc04, EditLdb);
+
+        static u8 EditPosTracker(CtrlRaceRankNum &posTracker)
+        {
+
+            const u32 playerId = posTracker.GetPlayerId();
+            const System *system = System::sInstance;
+            Mgr *mgr = system->koMgr;
+            if (system->IsContext(PULSAR_MODE_KO))
+            {
+                u8 idx = posTracker.hudSlotId;
+                lyt::Picture *posPane = static_cast<nw4r::lyt::Picture *>(posTracker.layout.GetPaneByName("position"));
+                ut::Color color = 0xffffffff;
+
+                u8 playerId;
+                if (mgr->isSpectating)
+                    playerId = RaceCameraMgr::sInstance->focusedPlayerIdx;
+                else
+                    playerId = Racedata::sInstance->racesScenario.settings.hudPlayerIds[idx];
+
+                if (Raceinfo::sInstance->raceFrames > 0 && mgr->GetWouldBeKnockedOut(playerId))
+                {
+                    s32 increment = mgr->posTrackerAnmFrames[idx] >= 31 ? 8 : -8;
+                    color.g = posPane->vertexColours[0].g + increment;
+                    color.b = color.g;
+                    ++mgr->posTrackerAnmFrames[idx];
+                    if (mgr->posTrackerAnmFrames[idx] == 62)
+                        mgr->posTrackerAnmFrames[idx] = 0;
+                }
+                else
+                    mgr->posTrackerAnmFrames[idx] = 0;
+                posPane->vertexColours[0] = color;
+                posPane->vertexColours[1] = color;
+                posPane->vertexColours[2] = color;
+                posPane->vertexColours[3] = color;
             }
-            if (koStatus == TIE) {
-                bmgId = UI::BMG_KO_TIE;
-                color = 0xff00f0c0;
+            return playerId;
+        }
+        kmCall(0x807f4b64, EditPosTracker);
+
+        // Fixes for when spectating
+        static u8 ReturnCorrectId(u8 localId)
+        {
+            const System *system = System::sInstance;
+            if (system->IsContext(PULSAR_MODE_KO) && system->koMgr->isSpectating)
+            {
+                const RaceCameraMgr *cameraMgr = RaceCameraMgr::sInstance;
+                if (cameraMgr == nullptr)
+                    return 0; // this is needed because this function is called by the ctor of racecameramgr
+                return cameraMgr->focusedPlayerIdx;
             }
-            result->SetTextBoxMessage("player_name", bmgId);
-            result->animator.GetAnimationGroupById(4).PlayAnimationAtFrame(6, 0.0f);
-            lyt::Picture* selectBase = static_cast<nw4r::lyt::Picture*>(result->layout.GetPaneByName("select_base"));
-            UI::ResetMatColor(selectBase, color);
-            UI::UnbindRLMC(selectBase->material);
-            selectBase->vertexColours[0] = color;
-            selectBase->vertexColours[1] = color;
-            selectBase->vertexColours[2] = color;
-            selectBase->vertexColours[3] = color;
-            return;
+            else
+                return localId;
         }
-    }
-    result->FillName(playerId);
-}
-kmCall(0x8085cc04, EditLdb);
+        kmBranch(0x80531f7c, ReturnCorrectId);
 
-static u8 EditPosTracker(CtrlRaceRankNum& posTracker) {
-
-    const u32 playerId = posTracker.GetPlayerId();
-    const System* system = System::sInstance;
-    Mgr* mgr = system->koMgr;
-    if(system->IsContext(PULSAR_MODE_KO)) {
-        u8 idx = posTracker.hudSlotId;
-        lyt::Picture* posPane = static_cast<nw4r::lyt::Picture*>(posTracker.layout.GetPaneByName("position"));
-        ut::Color color = 0xffffffff;
-
-        u8 playerId;
-        if(mgr->isSpectating) playerId = RaceCameraMgr::sInstance->focusedPlayerIdx;
-        else playerId = Racedata::sInstance->racesScenario.settings.hudPlayerIds[idx];
-
-        if(Raceinfo::sInstance->raceFrames > 0 && mgr->GetWouldBeKnockedOut(playerId)) {
-            s32 increment = mgr->posTrackerAnmFrames[idx] >= 31 ? 8 : -8;
-            color.g = posPane->vertexColours[0].g + increment;
-            color.b = color.g;
-            ++mgr->posTrackerAnmFrames[idx];
-            if(mgr->posTrackerAnmFrames[idx] == 62) mgr->posTrackerAnmFrames[idx] = 0;
+        static GameType SyncCountdown(const Racedata &raceData)
+        {
+            GameType type = raceData.racesScenario.settings.gametype;
+            const System *system = System::sInstance;
+            if (system->IsContext(PULSAR_MODE_KO) && type == GAMETYPE_ONLINE_SPECTATOR)
+            {
+                type = GAMETYPE_DEFAULT;
+                Racedata::sInstance->racesScenario.settings.gametype = GAMETYPE_DEFAULT;
+            }
+            return type;
         }
-        else mgr->posTrackerAnmFrames[idx] = 0;
-        posPane->vertexColours[0] = color;
-        posPane->vertexColours[1] = color;
-        posPane->vertexColours[2] = color;
-        posPane->vertexColours[3] = color;
+        kmCall(0x806537d8, SyncCountdown);
+        kmWrite32(0x806537dc, 0x2c030000);
+        kmWrite32(0x806537e4, 0x2c030006);
 
-    }
-    return playerId;
-}
-kmCall(0x807f4b64, EditPosTracker);
+        static void VoteCounterPatch(LayoutUIControl &voteCounter, u32 bmgId, Text::Info *info)
+        {
 
+            register Pages::SELECTStageMgr *mgr;
+            asm(mr mgr, r31;);
+            register Pages::Vote *vote;
+            asm(mr vote, r25;);
+            const System *system = System::sInstance;
 
-//Fixes for when spectating
-static u8 ReturnCorrectId(u8 localId) {
-    const System* system = System::sInstance;
-    if(system->IsContext(PULSAR_MODE_KO) && system->koMgr->isSpectating) {
-        const RaceCameraMgr* cameraMgr = RaceCameraMgr::sInstance;
-        if(cameraMgr == nullptr) return 0; //this is needed because this function is called by the ctor of racecameramgr
-        return cameraMgr->focusedPlayerIdx;
-    }
-    else return localId;
-}
-kmBranch(0x80531f7c, ReturnCorrectId);
+            if (system->IsContext(PULSAR_MODE_KO))
+            {
+                int stillIn = 0;
+                for (int playerId = 0; playerId < mgr->playerCount; ++playerId)
+                {
+                    if (!system->koMgr->IsKOdPlayerId(playerId))
+                        ++stillIn;
+                    else if (vote->order[playerId] != -1)
+                    {
+                        const AnimationGroup &group = vote->votes[vote->order[playerId]].animator.GetAnimationGroupById(1);
+                        if (group.curAnimation == 2)
+                            --info->intToPass[0];
+                    }
+                }
+                info->intToPass[1] = stillIn;
+            }
+            voteCounter.SetMessage(bmgId, info);
+        }
+        // kmCall(0x80644590, VoteCounterPatch);
 
-static GameType SyncCountdown(const Racedata& raceData) {
-    GameType type = raceData.racesScenario.settings.gametype;
-    const System* system = System::sInstance;
-    if(system->IsContext(PULSAR_MODE_KO) && type == GAMETYPE_ONLINE_SPECTATOR) {
-        type = GAMETYPE_DEFAULT;
-        Racedata::sInstance->racesScenario.settings.gametype = GAMETYPE_DEFAULT;
-    }
-    return type;
-}
-kmCall(0x806537d8, SyncCountdown);
-kmWrite32(0x806537dc, 0x2c030000);
-kmWrite32(0x806537e4, 0x2c030006);
+        static void SkipVoteControlFill(VoteControl &voteControl, bool isCourseIdInvalid, u32 bmgId, const MiiGroup &miiGroup, u32 playerId, bool isLocalPlayer, u32 team)
+        {
 
+            register Pages::Vote *vote;
+            asm(mr vote, r24;);
+            vote->order[playerId] = vote->lastHandledVote;
+            const System *system = System::sInstance;
 
-static void VoteCounterPatch(LayoutUIControl& voteCounter, u32 bmgId, Text::Info* info) {
+            if (system->IsContext(PULSAR_MODE_KO))
+            {
+                if (system->koMgr->IsKOdPlayerId(playerId))
+                {
+                    return;
+                }
+            }
+            voteControl.Fill(isCourseIdInvalid, bmgId, miiGroup, playerId, isLocalPlayer, team);
+            ++vote->lastHandledVote;
+        }
+        // kmCall(0x806441b8, SkipVoteControlFill);
+        // kmWrite32(0x806441c4, 0x60000000);
+        // kmWrite32(0x806441d0, 0x60000000);
 
-    register Pages::SELECTStageMgr* mgr;
-    asm(mr mgr, r31;);
-    register Pages::Vote* vote;
-    asm(mr vote, r25;);
-    const System* system = System::sInstance;
+        static void SkipVRControlFill(Pages::VR &vr, u32 index, u32 playerId, u32 team, u8 type, bool isLocalPlayer)
+        { // 1 -> 2, index = 1
+            const System *system = System::sInstance;
+            if (system->IsContext(PULSAR_MODE_KO))
+            {
+                const RKNet::Controller *controller = RKNet::Controller::sInstance;
+                const Mgr *mgr = system->koMgr;
+                u8 aid = controller->aidsBelongingToPlayerIds[playerId];
 
-    if(system->IsContext(PULSAR_MODE_KO)) {
-        int stillIn = 0;
-        for(int playerId = 0; playerId < mgr->playerCount; ++playerId) {
-            if(!system->koMgr->IsKOdPlayerId(playerId)) ++stillIn;
-            else if(vote->order[playerId] != -1) {
-                const AnimationGroup& group = vote->votes[vote->order[playerId]].animator.GetAnimationGroupById(1);
-                if(group.curAnimation == 2) --info->intToPass[0];
+                vr.vrControls[index].isHidden = true;
+                if (mgr->IsKOdPlayerId(playerId))
+                    return;
+
+                index = 0;
+                for (int id = 0; id < playerId; ++id)
+                    if (!mgr->IsKOdPlayerId(id))
+                        ++index;
+                vr.vrControls[index].isHidden = false;
+            }
+            vr.FillVRControl(index, playerId, team, type, isLocalPlayer);
+        }
+        // kmCall(0x8064aa78, SkipVRControlFill);
+
+        static void PatchAidsBeforeSELECTStageMgrSetup(Pages::SELECTStageMgr &stageMgr)
+        {
+            const System *system = System::sInstance;
+
+            if (system->IsContext(PULSAR_MODE_KO))
+            {
+                Mgr *mgr = system->koMgr;
+                RKNet::Controller *controller = RKNet::Controller::sInstance;
+                RKNet::ControllerSub &sub = controller->subs[controller->currentSub];
+                Network::ExpSELECTHandler &handler = Network::ExpSELECTHandler::Get();
+                const Network::PulSELECT *select;
+                const u8 hostAid = sub.hostAid;
+                if (hostAid == sub.localAid)
+                    select = &handler.toSendPacket;
+                else
+                    select = &handler.receivedPackets[hostAid];
+                mgr->koPerRace = select->koPerRace;
+                mgr->racesPerKO = select->racesPerKO;
+                mgr->alwaysFinal = select->alwaysFinal;
+                mgr->PatchAids(sub);
+                reinterpret_cast<RKNet::SELECTHandler &>(handler).AllocatePlayerIdsToAids();
+                controller->UpdateAidsBelongingToPlayerIds();
+            }
+
+            stageMgr.SetModeTypes();
+        }
+        kmCall(0x80650494, PatchAidsBeforeSELECTStageMgrSetup);
+
+        static u8 SwapUISelectInfo()
+        { // this can only be called if localPlayerCount > 0, ie one of the players is still in
+
+            register u8 aid;
+            register u8 localPlayerCount; // obtained from RKNet::Controller, spectators do NOT count
+            register u8 curHudSlotId;
+            asm(mr aid, r17;);
+            asm(mr localPlayerCount, r24;);
+            asm(mr curHudSlotId, r16;);
+
+            asm(stb r16, 0x1f5(r22);); // default
+            const System *system = System::sInstance;
+            if (system->IsContext(PULSAR_MODE_KO))
+            {
+                if (localPlayerCount == 1)
+                {
+                    Mgr *mgr = system->koMgr;
+                    curHudSlotId = mgr->IsKOdAid(aid, 0); // if only one localPlayer but slot 0 is KOd, that guarantees it was initially 2 players and the main is out
+                    const RKNet::Controller *controller = RKNet::Controller::sInstance;
+                    const RKNet::ControllerSub &sub = controller->subs[controller->currentSub];
+                    if (curHudSlotId == 1 && aid == sub.localAid && !mgr->GetIsSwapped())
+                        mgr->SwapControllersAndUI();
+                }
+            }
+
+            return curHudSlotId; // need to return curHudSlotId, it's not used, but it's needed otherwise the function does "nothing" c++ wise and becomes just a blr
+        }
+        kmCall(0x80651988, SwapUISelectInfo);
+        kmWrite32(0x8065198c, 0x5600063f);
+
+        static u8 SwapRaceMiis()
+        { // this can only be called if localPlayerCount > 0, ie one of the players is still in, very hacky function but until a better hook is found, this'll do
+
+            register u32 aid;
+            register u8 curHudSlotId;
+            register u32 playerId;
+            asm(mr aid, r21;);
+            asm(mr curHudSlotId, r16;);
+            asm(mr playerId, r17;);
+            const System *system = System::sInstance;
+
+            bool isKO = system->IsContext(PULSAR_MODE_KO);
+            if (isKO)
+            {
+                if (aid < 12)
+                    curHudSlotId = system->koMgr->IsKOdAid(aid, 0); // if only one localPlayer but slot 0 is KOd, that guarantees it was initially 2 players and the main is out
+                if (curHudSlotId == 1)
+                {
+                    RacedataScenario &scenario = Racedata::sInstance->menusScenario;
+                    char mainPlayer[sizeof(RacedataPlayer)];
+                    u32 guestId = playerId + 1;
+                    memcpy(&mainPlayer, &scenario.players[playerId], sizeof(RacedataPlayer));
+                    memcpy(&scenario.players[playerId], &scenario.players[guestId], sizeof(RacedataPlayer));
+                    memcpy(&scenario.players[guestId], &mainPlayer, sizeof(RacedataPlayer));
+                    scenario.players[playerId].playerType = scenario.players[guestId].playerType;
+                    scenario.players[guestId].playerType = PLAYER_NONE;
+                    scenario.players[playerId].playerType = scenario.players[guestId].playerType;
+                    scenario.players[guestId].playerType = PLAYER_NONE;
+                    curHudSlotId = 0;
+                }
+            }
+            else if (!isKO)
+                curHudSlotId = 0; // default
+            else
+                curHudSlotId++;  // never actually reached but codegen works with this
+            return curHudSlotId; // need to return curHudSlotId, it's not used, but it's needed otherwise the function does "nothing" c++ wise and becomes just a blr
+        }
+        kmCall(0x8065123c, SwapRaceMiis);
+
+        static bool CtrlRaceItemWindowIsInactive(const CtrlRaceItemWindow &itemWindow)
+        {
+            const u8 playerId = itemWindow.GetPlayerId();
+            if (SectionMgr::sInstance->curSection->isPaused)
+                return true;
+            const Item::Player &itemPlayer = Item::Manager::sInstance->players[playerId];
+            const Kart::Status *status = itemPlayer.pointers->kartStatus;
+            if (status->bitfield0 & 0x10)
+                return true;
+            if (Racedata::sInstance->racesScenario.players[playerId].playerType == PLAYER_REAL_ONLINE && System::sInstance->IsContext(PULSAR_MODE_KO))
+            {
+                return RKNet::ITEMHandler::sInstance->GetStoredItem(playerId) != ITEM_NONE;
+            }
+            else
+            { // default behaviour
+                bool isValid = true;
+                if (itemPlayer.roulette.isTheRouletteSpinning == 0 || itemPlayer.inventory.currentItemId == ITEM_NONE)
+                    isValid = false;
+                if (!isValid && itemPlayer.roulette.unknown_0x24 == ITEM_NONE)
+                    return true;
+                return false;
             }
         }
-        info->intToPass[1] = stillIn;
-    }
-    voteCounter.SetMessage(bmgId, info);
-}
-//kmCall(0x80644590, VoteCounterPatch);
+        // kmWritePointer(0x808D3D10, CtrlRaceItemWindowIsInactive);
 
-static void SkipVoteControlFill(VoteControl& voteControl, bool isCourseIdInvalid, u32 bmgId, const MiiGroup& miiGroup, u32 playerId, bool isLocalPlayer, u32 team) {
-
-    register Pages::Vote* vote;
-    asm(mr vote, r24;);
-    vote->order[playerId] = vote->lastHandledVote;
-    const System* system = System::sInstance;
-
-    if(system->IsContext(PULSAR_MODE_KO)) {
-        if(system->koMgr->IsKOdPlayerId(playerId)) {
-            return;
+        void StoreItemsForSpectating(RKNet::ITEMHandler &itemHandler)
+        {
+            itemHandler.ImportNewPackets();
+            if (System::sInstance->IsContext(PULSAR_MODE_KO))
+            { // guaranteed to be spectating already via a check in the func
+                const RacedataScenario &scenario = Racedata::sInstance->racesScenario;
+                for (int playerId = 0; playerId < System::sInstance->nonTTGhostPlayersCount; ++playerId)
+                {
+                    if (scenario.players[playerId].playerType != PLAYER_REAL_ONLINE)
+                        continue;
+                    const ItemId item = itemHandler.GetStoredItem(playerId);
+                    Item::Player &itemPlayer = Item::Manager::sInstance->players[playerId];
+                    itemPlayer.inventory.currentItemId = item;
+                    itemPlayer.inventory.currentItemCount = item != ITEM_NONE;
+                }
+            }
         }
-    }
-    voteControl.Fill(isCourseIdInvalid, bmgId, miiGroup, playerId, isLocalPlayer, team);
-    ++vote->lastHandledVote;
-}
-//kmCall(0x806441b8, SkipVoteControlFill);
-//kmWrite32(0x806441c4, 0x60000000);
-//kmWrite32(0x806441d0, 0x60000000);
+        kmCall(0x8065c69c, StoreItemsForSpectating);
 
-static void SkipVRControlFill(Pages::VR& vr, u32 index, u32 playerId, u32 team, u8 type, bool isLocalPlayer) { //1 -> 2, index = 1
-    const System* system = System::sInstance;
-    if(system->IsContext(PULSAR_MODE_KO)) {
-        const RKNet::Controller* controller = RKNet::Controller::sInstance;
-        const Mgr* mgr = system->koMgr;
-        u8 aid = controller->aidsBelongingToPlayerIds[playerId];
+        static void SkipConfirmationPage(Pages::SELECTStageMgr *_this, PageId id, u32 animDirection)
+        {
+            if (System::sInstance->IsContext(PULSAR_MODE_KO))
+            {
+                if (System::sInstance->koMgr->isSpectating)
+                {
+                    _this->status = Pages::SELECTStageMgr::STATUS_VOTES_PAGE;
+                    return _this->AddPageLayer(PAGE_VOTE, animDirection);
+                }
+            }
 
-        vr.vrControls[index].isHidden = true;
-        if(mgr->IsKOdPlayerId(playerId)) return;
-
-        index = 0;
-        for(int id = 0; id < playerId; ++id) if(!mgr->IsKOdPlayerId(id)) ++index;
-        vr.vrControls[index].isHidden = false;
-    }
-    vr.FillVRControl(index, playerId, team, type, isLocalPlayer);
-}
-//kmCall(0x8064aa78, SkipVRControlFill);
-
-
-static void PatchAidsBeforeSELECTStageMgrSetup(Pages::SELECTStageMgr& stageMgr) {
-    const System* system = System::sInstance;
-
-    if(system->IsContext(PULSAR_MODE_KO)) {
-        Mgr* mgr = system->koMgr;
-        RKNet::Controller* controller = RKNet::Controller::sInstance;
-        RKNet::ControllerSub& sub = controller->subs[controller->currentSub];
-        Network::ExpSELECTHandler& handler = Network::ExpSELECTHandler::Get();
-        const Network::PulSELECT* select;
-        const u8 hostAid = sub.hostAid;
-        if(hostAid == sub.localAid) select = &handler.toSendPacket;
-        else select = &handler.receivedPackets[hostAid];
-        mgr->koPerRace = select->koPerRace;
-        mgr->racesPerKO = select->racesPerKO;
-        mgr->alwaysFinal = select->alwaysFinal;
-        mgr->PatchAids(sub);
-        reinterpret_cast<RKNet::SELECTHandler&>(handler).AllocatePlayerIdsToAids();
-        controller->UpdateAidsBelongingToPlayerIds();
-    }
-
-    stageMgr.SetModeTypes();
-
-}
-kmCall(0x80650494, PatchAidsBeforeSELECTStageMgrSetup);
-
-static u8 SwapUISelectInfo() { //this can only be called if localPlayerCount > 0, ie one of the players is still in
-
-    register u8 aid;
-    register u8 localPlayerCount; //obtained from RKNet::Controller, spectators do NOT count
-    register u8 curHudSlotId;
-    asm(mr aid, r17;);
-    asm(mr localPlayerCount, r24;);
-    asm(mr curHudSlotId, r16;);
-
-    asm(stb r16, 0x1f5 (r22);); //default
-    const System* system = System::sInstance;
-    if(system->IsContext(PULSAR_MODE_KO)) {
-        if(localPlayerCount == 1) {
-            Mgr* mgr = system->koMgr;
-            curHudSlotId = mgr->IsKOdAid(aid, 0); //if only one localPlayer but slot 0 is KOd, that guarantees it was initially 2 players and the main is out
-            const RKNet::Controller* controller = RKNet::Controller::sInstance;
-            const RKNet::ControllerSub& sub = controller->subs[controller->currentSub];
-            if(curHudSlotId == 1 && aid == sub.localAid && !mgr->GetIsSwapped()) mgr->SwapControllersAndUI();
+            _this->status = Pages::SELECTStageMgr::STATUS_VR_PAGE;
+            return _this->AddPageLayer(id, animDirection);
         }
-    }
 
-    return curHudSlotId; //need to return curHudSlotId, it's not used, but it's needed otherwise the function does "nothing" c++ wise and becomes just a blr
-}
-kmCall(0x80651988, SwapUISelectInfo);
-kmWrite32(0x8065198c, 0x5600063f);
+        kmWriteNop(0x806508f8);
+        kmCall(0x806508f0, SkipConfirmationPage);
 
-static u8 SwapRaceMiis() { //this can only be called if localPlayerCount > 0, ie one of the players is still in, very hacky function but until a better hook is found, this'll do
-
-    register u32 aid;
-    register u8 curHudSlotId;
-    register u32 playerId;
-    asm(mr aid, r21;);
-    asm(mr curHudSlotId, r16;);
-    asm(mr playerId, r17;);
-    const System* system = System::sInstance;
-
-    bool isKO = system->IsContext(PULSAR_MODE_KO);
-    if(isKO) {
-        if(aid < 12) curHudSlotId = system->koMgr->IsKOdAid(aid, 0); //if only one localPlayer but slot 0 is KOd, that guarantees it was initially 2 players and the main is out
-        if(curHudSlotId == 1) {
-            RacedataScenario& scenario = Racedata::sInstance->menusScenario;
-            char mainPlayer[sizeof(RacedataPlayer)];
-            u32 guestId = playerId + 1;
-            memcpy(&mainPlayer, &scenario.players[playerId], sizeof(RacedataPlayer));
-            memcpy(&scenario.players[playerId], &scenario.players[guestId], sizeof(RacedataPlayer));
-            memcpy(&scenario.players[guestId], &mainPlayer, sizeof(RacedataPlayer));
-            scenario.players[playerId].playerType = scenario.players[guestId].playerType;
-            scenario.players[guestId].playerType = PLAYER_NONE;
-            scenario.players[playerId].playerType = scenario.players[guestId].playerType;
-            scenario.players[guestId].playerType = PLAYER_NONE;
-            curHudSlotId = 0;
-        }
-    }
-    else if(!isKO) curHudSlotId = 0; //default
-    else curHudSlotId++; //never actually reached but codegen works with this
-    return curHudSlotId; //need to return curHudSlotId, it's not used, but it's needed otherwise the function does "nothing" c++ wise and becomes just a blr
-}
-kmCall(0x8065123c, SwapRaceMiis);
-
-static bool CtrlRaceItemWindowIsInactive(const CtrlRaceItemWindow& itemWindow) {
-    const u8 playerId = itemWindow.GetPlayerId();
-    if(SectionMgr::sInstance->curSection->isPaused) return true;
-    const Item::Player& itemPlayer = Item::Manager::sInstance->players[playerId];
-    const Kart::Status* status = itemPlayer.pointers->kartStatus;
-    if(status->bitfield0 & 0x10) return true;
-    if(Racedata::sInstance->racesScenario.players[playerId].playerType == PLAYER_REAL_ONLINE && System::sInstance->IsContext(PULSAR_MODE_KO)) {
-        return RKNet::ITEMHandler::sInstance->GetStoredItem(playerId) != ITEM_NONE;
-    }
-    else { //default behaviour
-        bool isValid = true;
-        if(itemPlayer.roulette.isTheRouletteSpinning == 0 || itemPlayer.inventory.currentItemId == ITEM_NONE) isValid = false;
-        if(!isValid && itemPlayer.roulette.unknown_0x24 == ITEM_NONE) return true;
-        return false;
-    }
-}
-//kmWritePointer(0x808D3D10, CtrlRaceItemWindowIsInactive);
-
-void StoreItemsForSpectating(RKNet::ITEMHandler& itemHandler) {
-    itemHandler.ImportNewPackets();
-    if(System::sInstance->IsContext(PULSAR_MODE_KO)) { //guaranteed to be spectating already via a check in the func
-        const RacedataScenario& scenario = Racedata::sInstance->racesScenario;
-        for(int playerId = 0; playerId < System::sInstance->nonTTGhostPlayersCount; ++playerId) {
-            if(scenario.players[playerId].playerType != PLAYER_REAL_ONLINE) continue;
-            const ItemId item = itemHandler.GetStoredItem(playerId);
-            Item::Player& itemPlayer = Item::Manager::sInstance->players[playerId];
-            itemPlayer.inventory.currentItemId = item;
-            itemPlayer.inventory.currentItemCount = item != ITEM_NONE;
-        }
-    }
-}
-kmCall(0x8065c69c, StoreItemsForSpectating);
-
-static void SkipConfirmationPage(Pages::SELECTStageMgr* _this, PageId id, u32 animDirection) {
-    if (System::sInstance->IsContext(PULSAR_MODE_KO)) {
-        if (System::sInstance->koMgr->isSpectating) {
-            _this->status = Pages::SELECTStageMgr::STATUS_VOTES_PAGE;
-            return _this->AddPageLayer(PAGE_VOTE, animDirection);
-        }
-    }
-
-    _this->status = Pages::SELECTStageMgr::STATUS_VR_PAGE;
-    return _this->AddPageLayer(id, animDirection);
-}
-
-kmWriteNop(0x806508f8);
-kmCall(0x806508f0, SkipConfirmationPage);
-
-
-}//namespace KO
-}//namespace Pulsar
+    } // namespace KO
+} // namespace Pulsar

--- a/PulsarEngine/Gamemodes/OnlineTT/OnlineTT.cpp
+++ b/PulsarEngine/Gamemodes/OnlineTT/OnlineTT.cpp
@@ -1,6 +1,6 @@
 #include <kamek.hpp>
-#include <MarioKartWii/Race/Racedata.hpp>
-#include <MarioKartWii/Race/Raceinfo/Raceinfo.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
+#include <MarioKartWii/Race/RaceInfo/RaceInfo.hpp>
 #include <MarioKartWii/Kart/KartManager.hpp>
 #include <MarioKartWii/Objects/ObjectsMgr.hpp>
 #include <MarioKartWii/KMP/KMPManager.hpp>
@@ -23,322 +23,401 @@
 #include <Gamemodes/KO/KOMgr.hpp>
 #include <Settings/Settings.hpp>
 
-namespace Pulsar {
+namespace Pulsar
+{
 
-namespace OTT {
-void CondCollisions(Kart::Collision& collision, const Kart::Player& other) {
-    if(System::sInstance->IsContext(PULSAR_MODE_OTT)) return;
-    collision.CheckKartCollision(other);
-}
-kmCall(0x80596dc8, CondCollisions);
-
-void CondSlipstream(Kart::Movement& movement) {
-    if(System::sInstance->IsContext(PULSAR_MODE_OTT)) return;
-    movement.UpdateSlipstream();
-}
-kmCall(0x805798c0, CondSlipstream);
-
-void CondTTObjects(u32 r3, u32 r4, u32 r5, u32 r6, bool isTT) {
-    register ObjectsMgr* mgr;
-    asm(mr mgr, r31;);
-    if(System::sInstance->IsContext(PULSAR_MODE_OTT)) isTT = true;
-    mgr->isTT = isTT;
-}
-kmCall(0x8082a4ec, CondTTObjects);
-
-//TT Times 04840750 38000002
-//Start with 3 shrooms part of "SetStartingItem" in MiscRace
-//Display end times already part of Pulsar
-
-void CondStartPos(KMP::Holder<KTPT>& holder, Vec3& position, Vec3& rotation, u32 playerPosition, u32 playerCount) {
-    if(System::sInstance->IsContext(PULSAR_MODE_OTT)) {
-        playerPosition = 1;
-        playerCount = 1;
-    }
-    holder.CalcCoordinates_0Indexed(position, rotation, playerPosition, playerCount);
-}
-kmBranch(0x80514b2c, CondStartPos);
-
-bool CondAIRelatedTTCheck(bool, const Racedata& racedata) { //most notably the animation on overtake
-    const GameMode mode = racedata.racesScenario.settings.gamemode;
-    bool isTT = (mode == MODE_TIME_TRIAL || mode == MODE_GHOST_RACE);
-    if(System::sInstance->IsContext(PULSAR_MODE_OTT)) isTT = true;
-    return isTT;
-}
-kmBranch(0x807396b0, CondAIRelatedTTCheck);
-
-/*
-static const RaceinfoPlayer* GetCorrectRaceinfoPlayer(const Raceinfo& raceInfo) { //TTSplits::BeforeEntranceAnimations
-    return raceInfo.players[Racedata::sInstance->racesScenario.settings.hudPlayerIds[0]];
-}
-kmCall(0x80855b90, GetCorrectRaceinfoPlayer);
-kmWrite32(0x80855b98, 0x60000000);
-*/
-
-static bool CondTTCycles(const Raceinfo& raceInfo) { //this function is only called for onlineModes, true = objects and entity get updated this frame
-    if(System::sInstance->IsContext(PULSAR_MODE_OTT)) {
-        const OpeningPan* pan = RaceCameraMgr::sInstance->cameras[0]->openingPan;
-        if(pan->bitfield & 0x3) return true; //Is the pan not finished yet? always update the objects
-    }
-    return raceInfo.IsAtLeastStage(RACESTAGE_COUNTDOWN); //if the pan is finished but the countdown has not started, freeze the objects
-}
-kmCall(0x80554b8c, CondTTCycles);
-
-static bool CondPylonCollision(u32, u8 playerId) { //returns true if ghost collision, false if normal collision
-    PlayerType type = Racedata::sInstance->racesScenario.players[playerId].playerType;
-    if(System::sInstance->IsContext(PULSAR_MODE_OTT) && type != PLAYER_REAL_LOCAL) type = PLAYER_GHOST;
-    else if(type == PLAYER_GHOST && playerId != 1) type = PLAYER_REAL_LOCAL; //so that when you watch a ghost, it hits the main pylon
-    return type == PLAYER_GHOST;
-}
-kmCall(0x8082dc5c, CondPylonCollision);
-kmWrite32(0x8082dc60, 0x2c030001);
-
-static bool CondPoihanaStopOnHit(const Kart::Player& player) { //disables the poihana animating on hit if returns false
-    const u32 bitfield = player.pointers.kartStatus->bitfield4;
-    if(System::sInstance->IsContext(PULSAR_MODE_OTT)) return !(bitfield & 0x2); //return false if player is local, as that is the only situation where the cataquack should stop
-    else return bitfield & 0x40; //return false if player is not a ghost
-}
-kmCall(0x807493e4, CondPoihanaStopOnHit);
-
-static void CondTTSeed(RacedataScenario& scenario) { //real non-ghost count is stored in system
-    const GameMode old = scenario.settings.gamemode;
-    if(System::sInstance->IsContext(PULSAR_MODE_OTT)) scenario.settings.gamemode = MODE_TIME_TRIAL;
-    scenario.InitRNG();
-    scenario.settings.gamemode = old;
-}
-kmCall(0x8052fe18, CondTTSeed);
-
-static void CondAIMgrIsTT(u32, u32, bool isTT) {
-    register AI::Manager* mgr;
-    asm(mr mgr, r31;);
-    if(System::sInstance->IsContext(PULSAR_MODE_OTT)) isTT = true;
-    mgr->isTT = isTT;
-}
-kmCall(0x80738f64, CondAIMgrIsTT);
-
-static void CondRaceinfoRandom(Random& random) {
-    if(System::sInstance->IsContext(PULSAR_MODE_OTT)) {
-        const RaceStage stage = Raceinfo::sInstance->stage;
-        const OpeningPan* pan = RaceCameraMgr::sInstance->cameras[0]->openingPan;
-        if(stage == RACESTAGE_INTRO && (pan->bitfield & 0x8)) return; //do not update random if the pan has ended but the countdown hasn't started yet
-    }
-    random.Next();
-}
-kmCall(0x80554cf8, CondRaceinfoRandom);
-
-
-void CondOpacity() {
-    if(!System::sInstance->IsContext(PULSAR_MODE_OTT)) return;
-    Kart::Manager* kartMgr = Kart::Manager::sInstance;
-    for(int i = 0; i < kartMgr->playerCount; ++i) {
-
-        Kart::Pointers& pointers = kartMgr->players[i]->pointers;
-        u32 scnObjDrawOptionsIdx = (pointers.kartStatus->bitfield4 & 0x2) ? 0xA : 1; //is the player local?
-
-        //MAKE SHARED FUNC WITH ENHANCED REPLAY with bool istransparent and driver as args
-        DriverController* driver = pointers.driverController;
-        pointers.kartBody->UpdateModelDrawPriority(scnObjDrawOptionsIdx);
-        if(driver->driverModel != nullptr) driver->driverModel->UpdateDrawPriority(scnObjDrawOptionsIdx);
-        if(driver->driverModel_lod != nullptr) driver->driverModel_lod->UpdateDrawPriority(scnObjDrawOptionsIdx);
-        if(driver->miiHeads != nullptr) driver->miiHeads->UpdateDrawPriority(scnObjDrawOptionsIdx);
-        if(driver->ticoModel != nullptr) driver->ticoModel->tico->UpdateDrawPriority(scnObjDrawOptionsIdx);
-        if(driver->toadetteHair != nullptr && driver->toadetteHair->cb != 0) driver->toadetteHair->cb->hair->UpdateDrawPriority(scnObjDrawOptionsIdx);
-        for(int j = 0; j < pointers.values->wheelCount0; ++j) {
-            pointers.wheels[j]->UpdateModelDrawPriority(scnObjDrawOptionsIdx);
-            pointers.suspensions[j]->UpdateModelDrawPriority(scnObjDrawOptionsIdx);
+    namespace OTT
+    {
+        void CondCollisions(Kart::Collision &collision, const Kart::Player &other)
+        {
+            if (System::sInstance->IsContext(PULSAR_MODE_OTT))
+                return;
+            collision.CheckKartCollision(other);
         }
-    }
-}
-RaceLoadHook opacity(CondOpacity);
+        kmCall(0x80596dc8, CondCollisions);
 
-static void EnableOpacityFunctionality(EGG::ScnRenderer& renderer, u32 enabledEffectsFlag) {
-    if(System::sInstance->IsContext(PULSAR_MODE_OTT)) enabledEffectsFlag |= 1;
-    renderer.CreatePath(enabledEffectsFlag, nullptr);
-}
-kmCall(0x805b15e0, EnableOpacityFunctionality);
+        void CondSlipstream(Kart::Movement &movement)
+        {
+            if (System::sInstance->IsContext(PULSAR_MODE_OTT))
+                return;
+            movement.UpdateSlipstream();
+        }
+        kmCall(0x805798c0, CondSlipstream);
 
-// static UnkType PreventBurnOuts(Kart::Status& status, s32 startBoostIdx) {
-//     if(startBoostIdx == -1 && System::sInstance->IsContext(PULSAR_MODE_OTT)) {
-//         startBoostIdx = 1;
-//         status.startBoostIdx = 1;
-//     }
-//     return status.ApplyStartBoost(startBoostIdx);
-// }
-// kmCall(0x80595ad4, PreventBurnOuts);
+        void CondTTObjects(u32 r3, u32 r4, u32 r5, u32 r6, bool isTT)
+        {
+            register ObjectsMgr *mgr;
+            asm(mr mgr, r31;);
+            if (System::sInstance->IsContext(PULSAR_MODE_OTT))
+                isTT = true;
+            mgr->isTT = isTT;
+        }
+        kmCall(0x8082a4ec, CondTTObjects);
 
-static void SELECTStageMgrBeforeControlUpdate(Pages::SELECTStageMgr* stageMgr) {
-    static int waitFrames = 0; // ← Add a static counter so we can perform a fallback
+        // TT Times 04840750 38000002
+        // Start with 3 shrooms part of "SetStartingItem" in MiscRace
+        // Display end times already part of Pulsar
 
-    System* system = System::sInstance;
-    const Pages::SELECTStageMgr::Status old = stageMgr->status;
-    if(system->ottMgr.voteState != COMBO_NONE) stageMgr->status = Pages::SELECTStageMgr::STATUS_VR_PAGE; //so that the countdown shows
-    stageMgr->Pages::SELECTStageMgr::BeforeControlUpdate();
-    stageMgr->status = old;
+        void CondStartPos(KMP::Holder<KTPT> &holder, Vec3 &position, Vec3 &rotation, u32 playerPosition, u32 playerCount)
+        {
+            if (System::sInstance->IsContext(PULSAR_MODE_OTT))
+            {
+                playerPosition = 1;
+                playerCount = 1;
+            }
+            holder.CalcCoordinates_0Indexed(position, rotation, playerPosition, playerCount);
+        }
+        kmBranch(0x80514b2c, CondStartPos);
 
-    if(system->IsContext(PULSAR_MODE_OTT)) {
-        const RKNet::Controller* controller = RKNet::Controller::sInstance;
-        const RKNet::ControllerSub& sub = controller->subs[controller->currentSub];
-        Network::ExpSELECTHandler& handler = Network::ExpSELECTHandler::Get();
-        Network::PulSELECT* hostSelect;
-        const u8 hostAid = sub.hostAid;
-        const u8 localAid = sub.localAid;
-        if(hostAid == localAid) hostSelect = &handler.toSendPacket;
-        else hostSelect = &handler.receivedPackets[hostAid];
+        bool CondAIRelatedTTCheck(bool, const Racedata &racedata)
+        { // most notably the animation on overtake
+            const GameMode mode = racedata.racesScenario.settings.gamemode;
+            bool isTT = (mode == MODE_TIME_TRIAL || mode == MODE_GHOST_RACE);
+            if (System::sInstance->IsContext(PULSAR_MODE_OTT))
+                isTT = true;
+            return isTT;
+        }
+        kmBranch(0x807396b0, CondAIRelatedTTCheck);
 
-        if(hostSelect->allowChangeComboStatus > 0) {
-            bool hasReceivedEveryone = true;
-            bool isEveryoneWaiting = true;
-            //bool isEveryoneInRace = true;
+        /*
+        static const RaceinfoPlayer* GetCorrectRaceinfoPlayer(const Raceinfo& raceInfo) { //TTSplits::BeforeEntranceAnimations
+            return raceInfo.players[Racedata::sInstance->racesScenario.settings.hudPlayerIds[0]];
+        }
+        kmCall(0x80855b90, GetCorrectRaceinfoPlayer);
+        kmWrite32(0x80855b98, 0x60000000);
+        */
 
-            for(int aid = 0; aid < 12; ++aid) {
-                u32 bit = 1 << aid;
-                if((bit & sub.availableAids) == 0) continue;
-                if(aid == localAid) continue;
-                if(bit & handler.hasNewRACEHEADER_1) system->ottMgr.aidsInRace |= bit;
-                if(system->ottMgr.voteState == COMBO_SELECTED) {
-                    if(handler.receivedPackets[aid].allowChangeComboStatus < Network::SELECT_COMBO_SELECTED) hasReceivedEveryone = false;
-                }
-                if(hostAid == localAid) {
-                    if(system->ottMgr.voteState == WAITING_FOR_START) {
-                        if(handler.receivedPackets[aid].allowChangeComboStatus < Network::SELECT_COMBO_WAITING_FOR_START) isEveryoneWaiting = false;
-                    }
-                    /*
-                    else if(system->ottMgr.voteState == HOST_START) {
-                        if(Network::GetLastRecvSECTIONSize(aid, Network::PulRH1::idx) == 0) isEveryoneInRace = false;
-                    }
-                    */
+        static bool CondTTCycles(const Raceinfo &raceInfo)
+        { // this function is only called for onlineModes, true = objects and entity get updated this frame
+            if (System::sInstance->IsContext(PULSAR_MODE_OTT))
+            {
+                const OpeningPan *pan = RaceCameraMgr::sInstance->cameras[0]->openingPan;
+                if (pan->bitfield & 0x3)
+                    return true; // Is the pan not finished yet? always update the objects
+            }
+            return raceInfo.IsAtLeastStage(RACESTAGE_COUNTDOWN); // if the pan is finished but the countdown has not started, freeze the objects
+        }
+        kmCall(0x80554b8c, CondTTCycles);
+
+        static bool CondPylonCollision(u32, u8 playerId)
+        { // returns true if ghost collision, false if normal collision
+            PlayerType type = Racedata::sInstance->racesScenario.players[playerId].playerType;
+            if (System::sInstance->IsContext(PULSAR_MODE_OTT) && type != PLAYER_REAL_LOCAL)
+                type = PLAYER_GHOST;
+            else if (type == PLAYER_GHOST && playerId != 1)
+                type = PLAYER_REAL_LOCAL; // so that when you watch a ghost, it hits the main pylon
+            return type == PLAYER_GHOST;
+        }
+        kmCall(0x8082dc5c, CondPylonCollision);
+        kmWrite32(0x8082dc60, 0x2c030001);
+
+        static bool CondPoihanaStopOnHit(const Kart::Player &player)
+        { // disables the poihana animating on hit if returns false
+            const u32 bitfield = player.pointers.kartStatus->bitfield4;
+            if (System::sInstance->IsContext(PULSAR_MODE_OTT))
+                return !(bitfield & 0x2); // return false if player is local, as that is the only situation where the cataquack should stop
+            else
+                return bitfield & 0x40; // return false if player is not a ghost
+        }
+        kmCall(0x807493e4, CondPoihanaStopOnHit);
+
+        static void CondTTSeed(RacedataScenario &scenario)
+        { // real non-ghost count is stored in system
+            const GameMode old = scenario.settings.gamemode;
+            if (System::sInstance->IsContext(PULSAR_MODE_OTT))
+                scenario.settings.gamemode = MODE_TIME_TRIAL;
+            scenario.InitRNG();
+            scenario.settings.gamemode = old;
+        }
+        kmCall(0x8052fe18, CondTTSeed);
+
+        static void CondAIMgrIsTT(u32, u32, bool isTT)
+        {
+            register AI::Manager *mgr;
+            asm(mr mgr, r31;);
+            if (System::sInstance->IsContext(PULSAR_MODE_OTT))
+                isTT = true;
+            mgr->isTT = isTT;
+        }
+        kmCall(0x80738f64, CondAIMgrIsTT);
+
+        static void CondRaceinfoRandom(Random &random)
+        {
+            if (System::sInstance->IsContext(PULSAR_MODE_OTT))
+            {
+                const RaceStage stage = Raceinfo::sInstance->stage;
+                const OpeningPan *pan = RaceCameraMgr::sInstance->cameras[0]->openingPan;
+                if (stage == RACESTAGE_INTRO && (pan->bitfield & 0x8))
+                    return; // do not update random if the pan has ended but the countdown hasn't started yet
+            }
+            random.Next();
+        }
+        kmCall(0x80554cf8, CondRaceinfoRandom);
+
+        void CondOpacity()
+        {
+            if (!System::sInstance->IsContext(PULSAR_MODE_OTT))
+                return;
+            Kart::Manager *kartMgr = Kart::Manager::sInstance;
+            for (int i = 0; i < kartMgr->playerCount; ++i)
+            {
+
+                Kart::Pointers &pointers = kartMgr->players[i]->pointers;
+                u32 scnObjDrawOptionsIdx = (pointers.kartStatus->bitfield4 & 0x2) ? 0xA : 1; // is the player local?
+
+                // MAKE SHARED FUNC WITH ENHANCED REPLAY with bool istransparent and driver as args
+                DriverController *driver = pointers.driverController;
+                pointers.kartBody->UpdateModelDrawPriority(scnObjDrawOptionsIdx);
+                if (driver->driverModel != nullptr)
+                    driver->driverModel->UpdateDrawPriority(scnObjDrawOptionsIdx);
+                if (driver->driverModel_lod != nullptr)
+                    driver->driverModel_lod->UpdateDrawPriority(scnObjDrawOptionsIdx);
+                if (driver->miiHeads != nullptr)
+                    driver->miiHeads->UpdateDrawPriority(scnObjDrawOptionsIdx);
+                if (driver->ticoModel != nullptr)
+                    driver->ticoModel->tico->UpdateDrawPriority(scnObjDrawOptionsIdx);
+                if (driver->toadetteHair != nullptr && driver->toadetteHair->cb != 0)
+                    driver->toadetteHair->cb->hair->UpdateDrawPriority(scnObjDrawOptionsIdx);
+                for (int j = 0; j < pointers.values->wheelCount0; ++j)
+                {
+                    pointers.wheels[j]->UpdateModelDrawPriority(scnObjDrawOptionsIdx);
+                    pointers.suspensions[j]->UpdateModelDrawPriority(scnObjDrawOptionsIdx);
                 }
             }
+        }
+        RaceLoadHook opacity(CondOpacity);
 
-            if(hasReceivedEveryone && system->ottMgr.voteState == COMBO_SELECTED) {
-                system->ottMgr.voteState = WAITING_FOR_START;
-                handler.toSendPacket.allowChangeComboStatus = Network::SELECT_COMBO_WAITING_FOR_START;
-            }
-            if(hostAid == sub.localAid) {
-                if(system->ottMgr.voteState == WAITING_FOR_START) {
-                    if (isEveryoneWaiting) {
-                        waitFrames = 0; // Reset our fallback counter if all players appear ready
-                        system->ottMgr.voteState = HOST_START;
-                        handler.toSendPacket.allowChangeComboStatus = Network::SELECT_COMBO_HOST_START;
-                    } else {
-                        // Not everyone is done. Increment & check our fallback timer.
-                        ++waitFrames;
-                        if (waitFrames > 600) { // ~10 seconds at 60fps
-                            // Force the next state to avoid getting stuck forever.
-                            system->ottMgr.voteState = HOST_START;
-                            handler.toSendPacket.allowChangeComboStatus = Network::SELECT_COMBO_HOST_START;
+        static void EnableOpacityFunctionality(EGG::ScnRenderer &renderer, u32 enabledEffectsFlag)
+        {
+            if (System::sInstance->IsContext(PULSAR_MODE_OTT))
+                enabledEffectsFlag |= 1;
+            renderer.CreatePath(enabledEffectsFlag, nullptr);
+        }
+        kmCall(0x805b15e0, EnableOpacityFunctionality);
+
+        // static UnkType PreventBurnOuts(Kart::Status& status, s32 startBoostIdx) {
+        //     if(startBoostIdx == -1 && System::sInstance->IsContext(PULSAR_MODE_OTT)) {
+        //         startBoostIdx = 1;
+        //         status.startBoostIdx = 1;
+        //     }
+        //     return status.ApplyStartBoost(startBoostIdx);
+        // }
+        // kmCall(0x80595ad4, PreventBurnOuts);
+
+        static void SELECTStageMgrBeforeControlUpdate(Pages::SELECTStageMgr *stageMgr)
+        {
+            static int waitFrames = 0; // ← Add a static counter so we can perform a fallback
+
+            System *system = System::sInstance;
+            const Pages::SELECTStageMgr::Status old = stageMgr->status;
+            if (system->ottMgr.voteState != COMBO_NONE)
+                stageMgr->status = Pages::SELECTStageMgr::STATUS_VR_PAGE; // so that the countdown shows
+            stageMgr->Pages::SELECTStageMgr::BeforeControlUpdate();
+            stageMgr->status = old;
+
+            if (system->IsContext(PULSAR_MODE_OTT))
+            {
+                const RKNet::Controller *controller = RKNet::Controller::sInstance;
+                const RKNet::ControllerSub &sub = controller->subs[controller->currentSub];
+                Network::ExpSELECTHandler &handler = Network::ExpSELECTHandler::Get();
+                Network::PulSELECT *hostSelect;
+                const u8 hostAid = sub.hostAid;
+                const u8 localAid = sub.localAid;
+                if (hostAid == localAid)
+                    hostSelect = &handler.toSendPacket;
+                else
+                    hostSelect = &handler.receivedPackets[hostAid];
+
+                if (hostSelect->allowChangeComboStatus > 0)
+                {
+                    bool hasReceivedEveryone = true;
+                    bool isEveryoneWaiting = true;
+                    // bool isEveryoneInRace = true;
+
+                    for (int aid = 0; aid < 12; ++aid)
+                    {
+                        u32 bit = 1 << aid;
+                        if ((bit & sub.availableAids) == 0)
+                            continue;
+                        if (aid == localAid)
+                            continue;
+                        if (bit & handler.hasNewRACEHEADER_1)
+                            system->ottMgr.aidsInRace |= bit;
+                        if (system->ottMgr.voteState == COMBO_SELECTED)
+                        {
+                            if (handler.receivedPackets[aid].allowChangeComboStatus < Network::SELECT_COMBO_SELECTED)
+                                hasReceivedEveryone = false;
+                        }
+                        if (hostAid == localAid)
+                        {
+                            if (system->ottMgr.voteState == WAITING_FOR_START)
+                            {
+                                if (handler.receivedPackets[aid].allowChangeComboStatus < Network::SELECT_COMBO_WAITING_FOR_START)
+                                    isEveryoneWaiting = false;
+                            }
+                            /*
+                            else if(system->ottMgr.voteState == HOST_START) {
+                                if(Network::GetLastRecvSECTIONSize(aid, Network::PulRH1::idx) == 0) isEveryoneInRace = false;
+                            }
+                            */
                         }
                     }
+
+                    if (hasReceivedEveryone && system->ottMgr.voteState == COMBO_SELECTED)
+                    {
+                        system->ottMgr.voteState = WAITING_FOR_START;
+                        handler.toSendPacket.allowChangeComboStatus = Network::SELECT_COMBO_WAITING_FOR_START;
+                    }
+                    if (hostAid == sub.localAid)
+                    {
+                        if (system->ottMgr.voteState == WAITING_FOR_START)
+                        {
+                            if (isEveryoneWaiting)
+                            {
+                                waitFrames = 0; // Reset our fallback counter if all players appear ready
+                                system->ottMgr.voteState = HOST_START;
+                                handler.toSendPacket.allowChangeComboStatus = Network::SELECT_COMBO_HOST_START;
+                            }
+                            else
+                            {
+                                // Not everyone is done. Increment & check our fallback timer.
+                                ++waitFrames;
+                                if (waitFrames > 600)
+                                { // ~10 seconds at 60fps
+                                    // Force the next state to avoid getting stuck forever.
+                                    system->ottMgr.voteState = HOST_START;
+                                    handler.toSendPacket.allowChangeComboStatus = Network::SELECT_COMBO_HOST_START;
+                                }
+                            }
+                        }
+                        if ((system->ottMgr.aidsInRace | (1 << sub.localAid)) == sub.availableAids && system->ottMgr.voteState == HOST_START)
+                            system->ottMgr.voteState = SELECT_READY;
+                    }
+                    else if (hostSelect->allowChangeComboStatus == Network::SELECT_COMBO_HOST_START)
+                        system->ottMgr.voteState = SELECT_READY;
                 }
-                if((system->ottMgr.aidsInRace | (1 << sub.localAid)) == sub.availableAids && system->ottMgr.voteState == HOST_START) system->ottMgr.voteState = SELECT_READY;
+
+                if (system->ottMgr.voteState == SELECT_READY)
+                {
+                    stageMgr->PrepareRace();
+                    const SectionId id = static_cast<SectionId>(SectionMgr::sInstance->curSection->sectionId + 0x10);
+                    stageMgr->ChangeSectionBySceneChange(id, 0, 0.0f);
+                }
             }
-            else if(hostSelect->allowChangeComboStatus == Network::SELECT_COMBO_HOST_START) system->ottMgr.voteState = SELECT_READY;
         }
 
-        if(system->ottMgr.voteState == SELECT_READY) {
-            stageMgr->PrepareRace();
-            const SectionId id = static_cast<SectionId>(SectionMgr::sInstance->curSection->sectionId + 0x10);
-            stageMgr->ChangeSectionBySceneChange(id, 0, 0.0f);
+        kmWritePointer(0x808C06E4, SELECTStageMgrBeforeControlUpdate);
+
+        static void PreventVoteChangeSection(Pages::Vote &vote, SectionId id, float delay)
+        {
+            static int frameCounter = 0; // Added frame counter
+            frameCounter++;              // Increment frame counter
+
+            if (frameCounter >= 600)
+            { // Check if 600 frames have passed
+                System *system = System::sInstance;
+                system->ottMgr.voteState = COMBO_SELECTED; // Trigger combo selection automatically
+                vote.EndStateAnimated(0, delay);
+                frameCounter = 0; // Reset frame counter
+                return;
+            }
+
+            System *system = System::sInstance;
+            system->ottMgr.Reset();
+            if (system->IsContext(PULSAR_MODE_OTT))
+            {
+                RKNet::Controller *controller = RKNet::Controller::sInstance;
+                RKNet::ControllerSub &sub = controller->subs[controller->currentSub];
+                Network::ExpSELECTHandler &handler = Network::ExpSELECTHandler::Get();
+                const Network::PulSELECT *select;
+                const u8 hostAid = sub.hostAid;
+                if (hostAid == sub.localAid)
+                    select = &handler.toSendPacket;
+                else
+                    select = &handler.receivedPackets[hostAid];
+                if (select->allowChangeComboStatus > 0)
+                {
+                    Pages::SELECTStageMgr *page = SectionMgr::sInstance->curSection->Get<Pages::SELECTStageMgr>();
+                    page->countdown.SetInitial(10.0f);
+                    page->countdown.isActive = true;
+                    page->timerControl.Reset();
+                    if (system->IsContext(PULSAR_MODE_KO) && system->koMgr->isSpectating)
+                    {
+                        handler.toSendPacket.allowChangeComboStatus = Network::SELECT_COMBO_SELECTED;
+                        system->ottMgr.voteState = COMBO_SELECTED;
+                    }
+                    else
+                    {
+                        system->ottMgr.voteState = COMBO_SELECTION;
+                        handler.toSendPacket.allowChangeComboStatus = Network::SELECT_COMBO_SELECTING;
+                        page->AddPageLayer(PAGE_CHARACTER_SELECT, 0);
+                    }
+                    vote.EndStateAnimated(0, delay);
+                    return;
+                }
+            }
+            vote.ChangeSectionBySceneChange(id, 0, delay);
         }
-    }
-}
+        kmCall(0x80643da0, PreventVoteChangeSection);
 
-kmWritePointer(0x808C06E4, SELECTStageMgrBeforeControlUpdate);
-
-static void PreventVoteChangeSection(Pages::Vote& vote, SectionId id, float delay) {
-    static int frameCounter = 0; // Added frame counter
-    frameCounter++; // Increment frame counter
-
-    if(frameCounter >= 600) { // Check if 600 frames have passed
-        System* system = System::sInstance;
-        system->ottMgr.voteState = COMBO_SELECTED; // Trigger combo selection automatically
-        vote.EndStateAnimated(0, delay);
-        frameCounter = 0; // Reset frame counter
-        return;
-    }
-
-    System* system = System::sInstance;
-    system->ottMgr.Reset();
-    if(system->IsContext(PULSAR_MODE_OTT)) {
-        RKNet::Controller* controller = RKNet::Controller::sInstance;
-        RKNet::ControllerSub& sub = controller->subs[controller->currentSub];
-        Network::ExpSELECTHandler& handler = Network::ExpSELECTHandler::Get();
-        const Network::PulSELECT* select;
-        const u8 hostAid = sub.hostAid;
-        if(hostAid == sub.localAid) select = &handler.toSendPacket;
-        else select = &handler.receivedPackets[hostAid];
-        if(select->allowChangeComboStatus > 0) {
-            Pages::SELECTStageMgr* page = SectionMgr::sInstance->curSection->Get<Pages::SELECTStageMgr>();
-            page->countdown.SetInitial(10.0f);
-            page->countdown.isActive = true;
-            page->timerControl.Reset();
-            if(system->IsContext(PULSAR_MODE_KO) && system->koMgr->isSpectating) {
-                handler.toSendPacket.allowChangeComboStatus = Network::SELECT_COMBO_SELECTED;
+        static void FixAfterDrift(Pages::Menu &menu, PageId id, PushButton &button)
+        { // menu is either drift or multidrift
+            System *system = System::sInstance;
+            if (system->ottMgr.voteState == COMBO_SELECTION)
+            {
                 system->ottMgr.voteState = COMBO_SELECTED;
+                Network::ExpSELECTHandler &handler = Network::ExpSELECTHandler::Get();
+                handler.toSendPacket.playersData[0].character = SectionMgr::sInstance->sectionParams->characters[0];
+                handler.toSendPacket.playersData[0].kart = SectionMgr::sInstance->sectionParams->karts[0];
+                handler.toSendPacket.allowChangeComboStatus = Network::SELECT_COMBO_SELECTED;
+                menu.EndStateAnimated(0, 0.0f);
             }
-            else {
-                system->ottMgr.voteState = COMBO_SELECTION;
-                handler.toSendPacket.allowChangeComboStatus = Network::SELECT_COMBO_SELECTING;
-                page->AddPageLayer(PAGE_CHARACTER_SELECT, 0);
-            }
-            vote.EndStateAnimated(0, delay);
-            return;
+            else
+                menu.LoadNextPageById(id, button);
         }
-    }
-    vote.ChangeSectionBySceneChange(id, 0, delay);
-}
-kmCall(0x80643da0, PreventVoteChangeSection);
+        kmCall(0x8084e698, FixAfterDrift);
+        // kmCall(0x8084b7d4, FixAfterDrift);
 
-static void FixAfterDrift(Pages::Menu& menu, PageId id, PushButton& button) { //menu is either drift or multidrift
-    System* system = System::sInstance;
-    if(system->ottMgr.voteState == COMBO_SELECTION) {
-        system->ottMgr.voteState = COMBO_SELECTED;
-        Network::ExpSELECTHandler& handler = Network::ExpSELECTHandler::Get();
-        handler.toSendPacket.playersData[0].character = SectionMgr::sInstance->sectionParams->characters[0];
-        handler.toSendPacket.playersData[0].kart = SectionMgr::sInstance->sectionParams->karts[0];
-        handler.toSendPacket.allowChangeComboStatus = Network::SELECT_COMBO_SELECTED;
-        menu.EndStateAnimated(0, 0.0f);
-    }
-    else menu.LoadNextPageById(id, button);
-}
-kmCall(0x8084e698, FixAfterDrift);
-//kmCall(0x8084b7d4, FixAfterDrift);
+        // OPTIONS
+        static void MuteKartSounds(Audio::EngineMgr *mgr, Audio::KartActor *actor)
+        {
+            mgr->Init(actor);
+            if (System::sInstance->IsContext(PULSAR_MODE_OTT) && !actor->isLocal && Settings::Mgr::Get().GetSettingValue(Settings::SETTINGSTYPE_OTT, SETTINGOTT_MUTEPTANDPLAYERS) == false)
+            {
+                actor->isGhost = true;
+            }
+        }
+        kmCall(0x80707620, MuteKartSounds);
 
+        static bool MuteCharSounds(Kart::Link *link)
+        {
+            const u32 bitfield = link->pointers->kartStatus->bitfield4;
+            if (System::sInstance->IsContext(PULSAR_MODE_OTT) && Settings::Mgr::Get().GetSettingValue(Settings::SETTINGSTYPE_OTT, SETTINGOTT_MUTEPTANDPLAYERS) == false)
+            {
+                return !(bitfield & 0x2); // isLocal
+            }
+            return bitfield & 0x40; // isGhost
+        }
+        kmCall(0x80716208, MuteCharSounds);
 
-//OPTIONS
-static void MuteKartSounds(Audio::EngineMgr* mgr, Audio::KartActor* actor) {
-    mgr->Init(actor);
-    if(System::sInstance->IsContext(PULSAR_MODE_OTT) && !actor->isLocal && Settings::Mgr::Get().GetSettingValue(Settings::SETTINGSTYPE_OTT, SETTINGOTT_MUTEPTANDPLAYERS) == false) {
-        actor->isGhost = true;
-    }
-}
-kmCall(0x80707620, MuteKartSounds);
+        static bool MutePositionTracker(CtrlRaceRankNum &tracker)
+        { // isInactive = muted if true, bctrl = IsInactive
+            asmVolatile(bctrl;);
+            register bool isInactive;
+            asm(mr isInactive, r3;);
+            if (System::sInstance->IsContext(PULSAR_MODE_OTT) && isInactive)
+                isInactive = Settings::Mgr::Get().GetSettingValue(Settings::SETTINGSTYPE_OTT, SETTINGOTT_MUTEPTANDPLAYERS);
+            return isInactive;
+        }
+        kmCall(0x807F4AC4, MutePositionTracker);
+        kmCall(0x807f4b00, MutePositionTracker);
 
-static bool MuteCharSounds(Kart::Link* link) {
-    const u32 bitfield = link->pointers->kartStatus->bitfield4;
-    if(System::sInstance->IsContext(PULSAR_MODE_OTT) && Settings::Mgr::Get().GetSettingValue(Settings::SETTINGSTYPE_OTT, SETTINGOTT_MUTEPTANDPLAYERS) == false) {
-        return !(bitfield & 0x2); //isLocal
-    }
-    return bitfield & 0x40; //isGhost
-}
-kmCall(0x80716208, MuteCharSounds);
+        // Hide Names part of battleglitch
 
-static bool MutePositionTracker(CtrlRaceRankNum& tracker) { //isInactive = muted if true, bctrl = IsInactive
-    asmVolatile(bctrl;);
-    register bool isInactive;
-    asm(mr isInactive, r3;);
-    if(System::sInstance->IsContext(PULSAR_MODE_OTT) && isInactive) isInactive = Settings::Mgr::Get().GetSettingValue(Settings::SETTINGSTYPE_OTT, SETTINGOTT_MUTEPTANDPLAYERS);
-    return isInactive;
-}
-kmCall(0x807F4AC4, MutePositionTracker);
-kmCall(0x807f4b00, MutePositionTracker);
+    } // namespace OTT
+} // namespace Pulsar
+// TO DO:
+// time diff
 
-//Hide Names part of battleglitch
-
-}//namespace OTT
-}//namespace Pulsar
-//TO DO:
-//time diff
-
-//OPTIONS:
-//Mute position tracker, mute other players, allow change combo after vote (host only)
+// OPTIONS:
+// Mute position tracker, mute other players, allow change combo after vote (host only)

--- a/PulsarEngine/Ghost/UI/EnhancedReplay.cpp
+++ b/PulsarEngine/Ghost/UI/EnhancedReplay.cpp
@@ -2,176 +2,199 @@
 #include <MarioKartWii/UI/Page/RaceHUD/RaceHUD.hpp>
 #include <MarioKartWii/UI/Page/RaceMenu/GhostReplayPause.hpp>
 #include <MarioKartWii/Kart/KartManager.hpp>
-#include <MarioKartWii/Race/Raceinfo/Raceinfo.hpp>
+#include <MarioKartWii/Race/RaceInfo/RaceInfo.hpp>
 #include <UI/UI.hpp>
 
+// Very old code, but still does the job; clicking watch replay will add the TT interface, solidity to the main ghost, the speedometer, etc...
+// Spectating.hpp handles the spectating side of things
 
-//Very old code, but still does the job; clicking watch replay will add the TT interface, solidity to the main ghost, the speedometer, etc...
-//Spectating.hpp handles the spectating side of things
-
-kmWrite32(0x80630450, 0x3880000d);  //To use the correct onInit
+kmWrite32(0x80630450, 0x3880000d); // To use the correct onInit
 kmWrite32(0x80630474, 0x3880000d);
 kmWrite32(0x80630498, 0x3880000d);
-kmWrite32(0x80631ce4, 0x2c030035);  //Music
+kmWrite32(0x80631ce4, 0x2c030035); // Music
 kmWrite32(0x806320ac, 0x2c030035);
 kmWrite32(0x80711444, 0x3803ffcb);
-kmWrite32(0x8071e4a0, 0x38600000);  //Lakitu
-kmWrite32(0x807f1590, 0x60000000);  //Kart Name
-kmWrite32(0x80856e64, 0x2c040035); //Removes fade at the end
-kmWrite32(0x80857540, 0x2c000035); //Fixes instant FINISH flash at the end
-kmWrite32(0x80859ed4, 0x48000048); //no immediate unload if ghost
+kmWrite32(0x8071e4a0, 0x38600000); // Lakitu
+kmWrite32(0x807f1590, 0x60000000); // Kart Name
+kmWrite32(0x80856e64, 0x2c040035); // Removes fade at the end
+kmWrite32(0x80857540, 0x2c000035); // Fixes instant FINISH flash at the end
+kmWrite32(0x80859ed4, 0x48000048); // no immediate unload if ghost
 
-namespace Pulsar {
-static void ChangeGhostOpacity(u8 focusedPlayerIdx);
+namespace Pulsar
+{
+    static void ChangeGhostOpacity(u8 focusedPlayerIdx);
 
-namespace UI {
-static void CreateTTHUD(Section* section, PageId id) {
-    section->CreateAndInitPage(PAGE_TT_HUD);
-    section->CreateAndInitPage(PAGE_TT_SPLITS);
-    ChangeGhostOpacity(0);
-}
-kmCall(0x8062ccd4, CreateTTHUD);
-kmCall(0x8062cc5c, CreateTTHUD);
-kmCall(0x8062cc98, CreateTTHUD);
-
-static PageId TTPauseNextPage(const Pages::RaceHUD& page) {
-    const SectionId sectionId = SectionMgr::sInstance->curSection->sectionId;
-    if(sectionId >= SECTION_WATCH_GHOST_FROM_CHANNEL && sectionId <= SECTION_WATCH_GHOST_FROM_MENU) return PAGE_GHOST_REPLAY_PAUSE_MENU;
-    return page.GetPausePageId();
-}
-kmCall(0x808569e0, TTPauseNextPage);
-
-static void OnContinueButtonTTPauseClick(Pages::GhostReplayPause& page, PageId id) {
-    const u32 stage = Raceinfo::sInstance->stage;
-    if(stage == 0x4) id = PAGE_TT_SPLITS; //if race is finished, repurpose the continue button
-    page.nextPage = id;
-    return;
-}
-kmCall(0x8085a1e0, OnContinueButtonTTPauseClick);
-
-static bool WillGhostBeCompared(const Racedata& racedata) {
-    const SectionMgr* sectionMgr = SectionMgr::sInstance;
-    const SectionId sectionId = sectionMgr->curSection->sectionId;
-    register Timer* ghostTimer;
-    asm(addi ghostTimer, r15, 0x48;);
-    if(sectionId >= SECTION_WATCH_GHOST_FROM_CHANNEL && sectionId <= SECTION_WATCH_GHOST_FROM_MENU) {
-        ghostTimer->minutes = 0xFFFF; //guarantee a cheer
-        return true;
-    }
-    else if(racedata.racesScenario.settings.gamemode == MODE_GHOST_RACE) return true;
-    return false;
-}
-kmCall(0x808570a0, WillGhostBeCompared);
-kmWrite32(0x80857088, 0x40820018);
-kmWrite32(0x808570a4, 0x2C030001);
-static u8 CharCheerGetCorrectArguments(int r3, u8 id) {
-    u8 ret = Racedata::sInstance->racesScenario.players[id].hudSlotId;
-    if(ret == -1) ret = 0;
-    return ret;
-}
-kmCall(0x808570c4, CharCheerGetCorrectArguments);
-
-static void PatchFinishRaceBMGID(LayoutUIControl& control, u32 bmgId, const Text::Info* text) {
-    const SectionId sectionId = SectionMgr::sInstance->curSection->sectionId;
-    if(sectionId >= SECTION_WATCH_GHOST_FROM_CHANNEL && sectionId <= SECTION_WATCH_GHOST_FROM_MENU) bmgId = BMG_FINISH;
-    control.SetMessage(bmgId, text);
-}
-kmCall(0x8085728c, PatchFinishRaceBMGID);
-}//namespace UI
-
-
-static int ChangePlayerType(const RacedataPlayer& player, u8 id) {
-    PlayerType type = Racedata::sInstance->racesScenario.players[id].playerType;
-    if(type == PLAYER_GHOST && id == 0) return 0;
-    return type;
-}
-kmCall(0x80594444, ChangePlayerType);
-kmWrite32(0x80594434, 0x889F0010);
-kmWrite32(0x80594448, 0x2c030000);
-kmWrite32(0x80594450, 0x2c030001);
-kmWrite32(0x80594458, 0x2c030003);
-
-/*
-Kart::BRRESHandle* PatchOpacity(Kart::BRRESHandle& handle, Light* light, bool isGhost, u8 playerId) {
-    if(playerId == 0) isGhost = false;
-    return new(&handle) Kart::BRRESHandle(light, isGhost, playerId);
-}
-kmCall(0x8058e2b8, PatchOpacity);
-kmCall(0x807c7870, PatchOpacity);
-
-*/
-
-bool PatchIsLocalCheck(const Kart::Player& kartPlayer) {
-    const SectionId sectionId = SectionMgr::sInstance->curSection->sectionId;
-    if(sectionId >= SECTION_WATCH_GHOST_FROM_CHANNEL && sectionId <= SECTION_WATCH_GHOST_FROM_MENU) return false;
-    return kartPlayer.IsLocal();
-}
-kmCall(0x80783770, PatchIsLocalCheck);
-
-static bool EnableCPUDrivingAfterRace(const KartAIController& aiController) {
-    const u8 id = aiController.GetPlayerIdx();
-    const PlayerType type = Racedata::sInstance->racesScenario.players[id].playerType;
-    if(type == PLAYER_GHOST && id != 0) return true;
-    return false;
-}
-kmCall(0x80732634, EnableCPUDrivingAfterRace);
-
-asmFunc PatchSoundIssues() {
-    ASM(
-        nofralloc;
-    lwz r5, 0 (r4); //Default
-    subi r0, r5, SECTION_WATCH_GHOST_FROM_CHANNEL;
-    cmplwi r0, 2;
-    bgt + end;
-    li r5, 0x1f;
-end:;
-    blr;
-        )
-}
-kmCall(0x80716064, PatchSoundIssues);
-
-
-
-void* PatchMiiHeadsOpacity(MiiHeadsModel& model, Mii* mii, MiiDriverModel* driverModel, u32 r6, nw4r::g3d::ScnMdl::BufferOption option,
-    u32 r8, u32 id) {
-    if(Raceinfo::sInstance != nullptr && id == 0) model.scnObjDrawOptionsIdx = 0xA;
-    return model.InitModel(mii, driverModel, r6, option, r8, id);
-}
-kmCall(0x807dc0e8, PatchMiiHeadsOpacity);
-
-static void ChangeGhostOpacity(u8 focusedPlayerIdx) {
-    const SectionId id = SectionMgr::sInstance->curSection->sectionId;
-    if(id < SECTION_WATCH_GHOST_FROM_CHANNEL || id > SECTION_WATCH_GHOST_FROM_MENU) return;
-    Kart::Manager* kartMgr = Kart::Manager::sInstance;
-    for(int i = 0; i < kartMgr->playerCount; ++i) {
-        u32 scnObjDrawOptionsIdx = i == focusedPlayerIdx ? 0xA : 1;
-        Kart::Pointers& pointers = kartMgr->players[i]->pointers;
-        DriverController* driver = pointers.driverController;
-
-        pointers.kartBody->UpdateModelDrawPriority(scnObjDrawOptionsIdx);
-        if(driver->driverModel != nullptr) driver->driverModel->UpdateDrawPriority(scnObjDrawOptionsIdx);
-        if(driver->driverModel_lod != nullptr) driver->driverModel_lod->UpdateDrawPriority(scnObjDrawOptionsIdx);
-        if(driver->miiHeads != nullptr) driver->miiHeads->UpdateDrawPriority(scnObjDrawOptionsIdx);
-        if(driver->ticoModel != nullptr) driver->ticoModel->tico->UpdateDrawPriority(scnObjDrawOptionsIdx);
-        if(driver->toadetteHair != nullptr && driver->toadetteHair->cb != 0) driver->toadetteHair->cb->hair->UpdateDrawPriority(scnObjDrawOptionsIdx);
-        for(int j = 0; j < pointers.values->wheelCount0; ++j) {
-            pointers.wheels[j]->UpdateModelDrawPriority(scnObjDrawOptionsIdx);
-            pointers.suspensions[j]->UpdateModelDrawPriority(scnObjDrawOptionsIdx);
+    namespace UI
+    {
+        static void CreateTTHUD(Section *section, PageId id)
+        {
+            section->CreateAndInitPage(PAGE_TT_HUD);
+            section->CreateAndInitPage(PAGE_TT_SPLITS);
+            ChangeGhostOpacity(0);
         }
+        kmCall(0x8062ccd4, CreateTTHUD);
+        kmCall(0x8062cc5c, CreateTTHUD);
+        kmCall(0x8062cc98, CreateTTHUD);
+
+        static PageId TTPauseNextPage(const Pages::RaceHUD &page)
+        {
+            const SectionId sectionId = SectionMgr::sInstance->curSection->sectionId;
+            if (sectionId >= SECTION_WATCH_GHOST_FROM_CHANNEL && sectionId <= SECTION_WATCH_GHOST_FROM_MENU)
+                return PAGE_GHOST_REPLAY_PAUSE_MENU;
+            return page.GetPausePageId();
+        }
+        kmCall(0x808569e0, TTPauseNextPage);
+
+        static void OnContinueButtonTTPauseClick(Pages::GhostReplayPause &page, PageId id)
+        {
+            const u32 stage = Raceinfo::sInstance->stage;
+            if (stage == 0x4)
+                id = PAGE_TT_SPLITS; // if race is finished, repurpose the continue button
+            page.nextPage = id;
+            return;
+        }
+        kmCall(0x8085a1e0, OnContinueButtonTTPauseClick);
+
+        static bool WillGhostBeCompared(const Racedata &racedata)
+        {
+            const SectionMgr *sectionMgr = SectionMgr::sInstance;
+            const SectionId sectionId = sectionMgr->curSection->sectionId;
+            register Timer *ghostTimer;
+            asm(addi ghostTimer, r15, 0x48;);
+            if (sectionId >= SECTION_WATCH_GHOST_FROM_CHANNEL && sectionId <= SECTION_WATCH_GHOST_FROM_MENU)
+            {
+                ghostTimer->minutes = 0xFFFF; // guarantee a cheer
+                return true;
+            }
+            else if (racedata.racesScenario.settings.gamemode == MODE_GHOST_RACE)
+                return true;
+            return false;
+        }
+        kmCall(0x808570a0, WillGhostBeCompared);
+        kmWrite32(0x80857088, 0x40820018);
+        kmWrite32(0x808570a4, 0x2C030001);
+        static u8 CharCheerGetCorrectArguments(int r3, u8 id)
+        {
+            u8 ret = Racedata::sInstance->racesScenario.players[id].hudSlotId;
+            if (ret == -1)
+                ret = 0;
+            return ret;
+        }
+        kmCall(0x808570c4, CharCheerGetCorrectArguments);
+
+        static void PatchFinishRaceBMGID(LayoutUIControl &control, u32 bmgId, const Text::Info *text)
+        {
+            const SectionId sectionId = SectionMgr::sInstance->curSection->sectionId;
+            if (sectionId >= SECTION_WATCH_GHOST_FROM_CHANNEL && sectionId <= SECTION_WATCH_GHOST_FROM_MENU)
+                bmgId = BMG_FINISH;
+            control.SetMessage(bmgId, text);
+        }
+        kmCall(0x8085728c, PatchFinishRaceBMGID);
+    } // namespace UI
+
+    static int ChangePlayerType(const RacedataPlayer &player, u8 id)
+    {
+        PlayerType type = Racedata::sInstance->racesScenario.players[id].playerType;
+        if (type == PLAYER_GHOST && id == 0)
+            return 0;
+        return type;
     }
-    Racedata::sInstance->racesScenario.settings.hudPlayerIds[0] = focusedPlayerIdx;
-}
-kmBranch(0x805a9b60, ChangeGhostOpacity);
+    kmCall(0x80594444, ChangePlayerType);
+    kmWrite32(0x80594434, 0x889F0010);
+    kmWrite32(0x80594448, 0x2c030000);
+    kmWrite32(0x80594450, 0x2c030001);
+    kmWrite32(0x80594458, 0x2c030003);
 
+    /*
+    Kart::BRRESHandle* PatchOpacity(Kart::BRRESHandle& handle, Light* light, bool isGhost, u8 playerId) {
+        if(playerId == 0) isGhost = false;
+        return new(&handle) Kart::BRRESHandle(light, isGhost, playerId);
+    }
+    kmCall(0x8058e2b8, PatchOpacity);
+    kmCall(0x807c7870, PatchOpacity);
 
+    */
 
+    bool PatchIsLocalCheck(const Kart::Player &kartPlayer)
+    {
+        const SectionId sectionId = SectionMgr::sInstance->curSection->sectionId;
+        if (sectionId >= SECTION_WATCH_GHOST_FROM_CHANNEL && sectionId <= SECTION_WATCH_GHOST_FROM_MENU)
+            return false;
+        return kartPlayer.IsLocal();
+    }
+    kmCall(0x80783770, PatchIsLocalCheck);
 
-}//namespace Pulsar
+    static bool EnableCPUDrivingAfterRace(const KartAIController &aiController)
+    {
+        const u8 id = aiController.GetPlayerIdx();
+        const PlayerType type = Racedata::sInstance->racesScenario.players[id].playerType;
+        if (type == PLAYER_GHOST && id != 0)
+            return true;
+        return false;
+    }
+    kmCall(0x80732634, EnableCPUDrivingAfterRace);
 
+    asmFunc PatchSoundIssues()
+    {
+        ASM(
+            nofralloc;
+            lwz r5, 0(r4); // Default
+            subi r0, r5, SECTION_WATCH_GHOST_FROM_CHANNEL;
+            cmplwi r0, 2;
+            bgt + end;
+            li r5, 0x1f;
+            end :;
+            blr;)
+    }
+    kmCall(0x80716064, PatchSoundIssues);
 
-//kmWrite32(0x805a84d4, 0x38000001);
+    void *PatchMiiHeadsOpacity(MiiHeadsModel &model, Mii *mii, MiiDriverModel *driverModel, u32 r6, nw4r::g3d::ScnMdl::BufferOption option,
+                               u32 r8, u32 id)
+    {
+        if (Raceinfo::sInstance != nullptr && id == 0)
+            model.scnObjDrawOptionsIdx = 0xA;
+        return model.InitModel(mii, driverModel, r6, option, r8, id);
+    }
+    kmCall(0x807dc0e8, PatchMiiHeadsOpacity);
 
-//subi 50 bgt 2
+    static void ChangeGhostOpacity(u8 focusedPlayerIdx)
+    {
+        const SectionId id = SectionMgr::sInstance->curSection->sectionId;
+        if (id < SECTION_WATCH_GHOST_FROM_CHANNEL || id > SECTION_WATCH_GHOST_FROM_MENU)
+            return;
+        Kart::Manager *kartMgr = Kart::Manager::sInstance;
+        for (int i = 0; i < kartMgr->playerCount; ++i)
+        {
+            u32 scnObjDrawOptionsIdx = i == focusedPlayerIdx ? 0xA : 1;
+            Kart::Pointers &pointers = kartMgr->players[i]->pointers;
+            DriverController *driver = pointers.driverController;
 
-//808568cc
-//80856d78
+            pointers.kartBody->UpdateModelDrawPriority(scnObjDrawOptionsIdx);
+            if (driver->driverModel != nullptr)
+                driver->driverModel->UpdateDrawPriority(scnObjDrawOptionsIdx);
+            if (driver->driverModel_lod != nullptr)
+                driver->driverModel_lod->UpdateDrawPriority(scnObjDrawOptionsIdx);
+            if (driver->miiHeads != nullptr)
+                driver->miiHeads->UpdateDrawPriority(scnObjDrawOptionsIdx);
+            if (driver->ticoModel != nullptr)
+                driver->ticoModel->tico->UpdateDrawPriority(scnObjDrawOptionsIdx);
+            if (driver->toadetteHair != nullptr && driver->toadetteHair->cb != 0)
+                driver->toadetteHair->cb->hair->UpdateDrawPriority(scnObjDrawOptionsIdx);
+            for (int j = 0; j < pointers.values->wheelCount0; ++j)
+            {
+                pointers.wheels[j]->UpdateModelDrawPriority(scnObjDrawOptionsIdx);
+                pointers.suspensions[j]->UpdateModelDrawPriority(scnObjDrawOptionsIdx);
+            }
+        }
+        Racedata::sInstance->racesScenario.settings.hudPlayerIds[0] = focusedPlayerIdx;
+    }
+    kmBranch(0x805a9b60, ChangeGhostOpacity);
+
+} // namespace Pulsar
+
+// kmWrite32(0x805a84d4, 0x38000001);
+
+// subi 50 bgt 2
+
+// 808568cc
+// 80856d78

--- a/PulsarEngine/Ghost/UI/ExpGhostSelect.cpp
+++ b/PulsarEngine/Ghost/UI/ExpGhostSelect.cpp
@@ -1,5 +1,5 @@
-#include <MarioKartWii/Race/Racedata.hpp>
-#include <MarioKartWii/Race/Raceinfo/Raceinfo.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
+#include <MarioKartWii/Race/RaceInfo/RaceInfo.hpp>
 #include <MarioKartWii/Input/InputManager.hpp>
 #include <MarioKartWii/UI/Page/Menu/CourseSelect.hpp>
 #include <Ghost/UI/ExpGhostSelect.hpp>
@@ -7,328 +7,377 @@
 #include <Settings/Settings.hpp>
 #include <SlotExpansion/CupsConfig.hpp>
 
-namespace  Pulsar {
-namespace UI {
-//When the player goes back to the main menu, MultiGhostMgr is destroyed
-static void DestroyMultiGhostManager(Section& section, PageId pageId) {
-    section.CreateAndInitPage(pageId);
-    Ghosts::Mgr::DestroyInstance();
-}
-kmCall(0x8062cf98, DestroyMultiGhostManager);
-
-//GhostInfoControl BRCTR
-static void LoadCustomGhostInfoBRCTR(ControlLoader& loader, const char* folderName, const char* ctrName,
-    const char* variantName, const char** anims) {
-    loader.Load(folderName, "PULGhostInfo", variantName, anims);
-}
-kmCall(0x805e28c0, LoadCustomGhostInfoBRCTR);
-kmWrite32(0x80639958, 0x3880000C); //Add controls
-
-ExpGhostSelect::ExpGhostSelect() {
-    Ghosts::Mgr::CreateInstance();
-    this->onChallengeGhostClickHandler.ptmf = &ExpGhostSelect::OnChallengeGhostPress;
-    this->onWatchReplayClickHandler.ptmf = &ExpGhostSelect::OnWatchReplayPress;
-    this->onRightArrowPressHandler.ptmf = &ExpGhostSelect::OnRightArrowPress;
-    this->onLeftArrowPressHandler.ptmf = &ExpGhostSelect::OnLeftArrowPress;
-    this->onSelectGhostChangeHandler.subject = this;
-    this->onSelectGhostChangeHandler.ptmf = &ExpGhostSelect::OnSelectGhostChange;
-    this->onStartPressHandler.subject = this;
-    this->onStartPressHandler.ptmf = &ExpGhostSelect::OnStartPress;
-}
-
-void ExpGhostSelect::OnInit() {
-    GhostSelect::OnInit();
-    this->AddControl(0x9, this->bottomText, 0);
-    this->bottomText.Load();
-    this->selectGhostButton.buttonId = 0xA;
-    this->AddControl(0xA, this->selectGhostButton, 0);
-    this->selectGhostButton.Load(1, UI::buttonFolder, "SelectGhost", "SelectGhost"); //check multighost
-    this->selectGhostButton.SetOnClickHandler(this->onSelectGhostChangeHandler, 0);
-    //this->manipulatorManager.SetGlobalHandler(START_PRESS, onStartPressHandler, false, false);
-    this->AddControl(0xB, this->favGhost, 0);
-    this->favGhost.isHidden = true;
-    ControlLoader loader(&this->favGhost);
-    loader.Load(UI::controlFolder, "PULInstruction", "OTTGhost", nullptr);
-    this->Reset();
-}
-
-//BottomText will display the current TTmode as well as if the player has a trophy on the track
-void ExpGhostSelect::OnActivate() {
-    GhostSelect::OnActivate();
-    const System* system = System::sInstance;
-    if (system->GetInfo().HasTrophies()) {
-        u32 bmgId;
-        const Text::Info text = GetCourseBottomText(CupsConfig::sInstance->GetWinning(), &bmgId);
-        this->bottomText.SetMessage(bmgId, &text);
-    }
-    this->ctrlMenuPageTitleText.SetMessage(BMG_CHOOSE_GHOST_DATA);
-    this->Reset();
-    this->selectGhostButton.SetMessage(BMG_SELECT_GHOST);
-
-    const TTMode mode = system->ttMode;
-    bool isStarVisibleOnActivate = false;
-    if (mode < TTMODE_150_FEATHER) {
-        const GhostList* list = this->ghostList;
-        for (int i = 0; i < list->count; ++i) {
-            if (list->entries[i].padding[0] == Ghosts::Mgr::GetInstance()->GetFavGhostFileIndex(mode)) {
-                this->favGhostIndex = i;
-            }
-        }
-        if (this->favGhostIndex == this->page) isStarVisibleOnActivate = true;
-    }
-    this->info->SetPaneVisibility("star", isStarVisibleOnActivate);
-}
-
-void ExpGhostSelect::OnDeactivate() {
-    Ghosts::Mgr::sInstance->SaveLeaderboard();
-}
-//Creates space by making the usual 3 buttons smaller, could be done without a BRCTR but this is easier to maintain
-static void LoadButtonWithCustBRCTR(PushButton& button, const char* folderName, const char* ctrName, const char* variant,
-    u32 localPlayerBitfield, u32 r8, bool inaccessible)
+namespace Pulsar
 {
-    button.Load(folderName, "GhostListButton", variant, localPlayerBitfield, r8, inaccessible);
-}
-kmCall(0x80639ab8, LoadButtonWithCustBRCTR);
-kmCall(0x80639ad8, LoadButtonWithCustBRCTR);
-kmCall(0x80639af8, LoadButtonWithCustBRCTR);
-
-
-void ExpGhostSelect::OnChallengeGhostPress(PushButton& button, u32 hudSlotId) {
-    GhostSelect::OnChallengeGhostPress(button, hudSlotId);
-    const GhostListEntry& entry = this->ghostList->entries[this->page];
-    Ghosts::Mgr::sInstance->EnableGhost(entry, true);
-}
-
-void ExpGhostSelect::OnWatchReplayPress(PushButton& button, u32 hudSlotId) {
-    GhostSelect::OnWatchReplayPress(button, hudSlotId);
-    const GhostListEntry& entry = this->ghostList->entries[this->page];
-    Ghosts::Mgr::sInstance->EnableGhost(entry, true);
-}
-
-void ExpGhostSelect::OnSelectGhostChange(ToggleButton& button, u32) {
-    Ghosts::Mgr* mgr = Ghosts::Mgr::sInstance;
-    const GhostListEntry& entry = this->ghostList->entries[this->page];
-
-    if (button.GetState() == true) {
-        u32 index = mgr->lastUsedSlot;
-        if (mgr->EnableGhost(entry, false)) {
-            this->selectedGhostsPages[index] = this->page;
-            this->selectedGhostsCount = (this->selectedGhostsCount + 1) > 3 ? 3 : (this->selectedGhostsCount + 1);
+    namespace UI
+    {
+        // When the player goes back to the main menu, MultiGhostMgr is destroyed
+        static void DestroyMultiGhostManager(Section &section, PageId pageId)
+        {
+            section.CreateAndInitPage(pageId);
+            Ghosts::Mgr::DestroyInstance();
         }
-        else button.ToggleState(false);
-    }
-    else {
-        mgr->DisableGhost(entry);
-        this->selectedGhostsPages[mgr->lastUsedSlot] = -1;
-        this->selectedGhostsCount -= 1;
-    }
-    Text::Info text;
-    text.intToPass[0] = this->selectedGhostsCount;
-    this->ctrlMenuPageTitleText.SetMessage(BMG_GHOST_SELECTED_COUNTER, &text);
-    this->SetToggleBMG();
-}
+        kmCall(0x8062cf98, DestroyMultiGhostManager);
 
-void ExpGhostSelect::OnStartPress(u32) {
-    bool isStarVisible;
-    if (this->favGhostIndex == this->page) {
-        this->favGhostIndex = -1;
-        isStarVisible = false;
-    }
-    else {
-        this->favGhostIndex = this->page;
-        isStarVisible = true;
-    }
-    this->PlaySound(isStarVisible ? SOUND_ID_SMALL_HIGH_NOTE : SOUND_ID_BACK_PRESS, 0);
-    Ghosts::Mgr::sInstance->SetFavGhost(this->ghostList->entries[this->page], System::sInstance->ttMode, isStarVisible);
-    this->info->SetPaneVisibility("star", isStarVisible);
-
-}
-
-void ExpGhostSelect::OnRightArrowPress(SheetSelectControl& control, u32 hudSlotId) {
-    GhostSelect::OnRightArrowPress(control, hudSlotId);
-    this->OnNewPage();
-}
-
-void ExpGhostSelect::OnLeftArrowPress(SheetSelectControl& control, u32 hudSlotId) {
-    GhostSelect::OnLeftArrowPress(control, hudSlotId);
-    this->OnNewPage();
-}
-
-void ExpGhostSelect::OnNewPage() {
-    ToggleButton& button = this->selectGhostButton;
-    if (this->page == this->selectedGhostsPages[0] || this->page == this->selectedGhostsPages[1] || this->page == this->selectedGhostsPages[2]) {
-        if (button.GetState() == false) button.ToggleState(true);
-    }
-    else if (button.GetState() == true) button.ToggleState(false);
-
-    this->SetToggleBMG();
-
-    bool isStarHidden;
-    if (this->page == this->favGhostIndex) {
-        isStarHidden = true;
-    }
-    else isStarHidden = false;
-    this->info->SetPaneVisibility("star", isStarHidden);
-
-}
-
-void ExpGhostSelect::SetToggleBMG() {
-    ToggleButton& button = this->selectGhostButton;
-    const u32 bmgId = button.GetState() == false ? BMG_SELECT_GHOST : BMG_GHOST_SELECTED;
-    button.SetMessage(bmgId);
-}
-
-void ExpGhostSelect::Reset() {
-    this->selectedGhostsPages[0] = -1;
-    this->selectedGhostsPages[1] = -1;
-    this->selectedGhostsPages[2] = -1;
-    this->selectedGhostsCount = 0;
-    this->selectGhostButton.ToggleState(false);
-    this->favGhostIndex = -1;
-}
-
-//Complete rewrite TTSplits BeforeEntranceAnimations; this will request a RKG if needed (flap or top 10 time)
-void BeforeEntranceAnimations(Pages::TTSplits* page) {
-    const u32 gamemode = Racedata::sInstance->racesScenario.settings.gamemode;
-    //Init Variables
-    const SectionMgr* sectionMgr = SectionMgr::sInstance;
-    SectionParams* sectionParams = sectionMgr->sectionParams;
-    sectionParams->isNewTime = false;
-    sectionParams->fastestLapId = 0xFFFFFFFF;
-    if (System::sInstance->IsContext(PULSAR_MODE_OTT)) {
-    page->maxActiveFrames = 0x12C;
-    }
-    else if(gamemode == MODE_TIME_TRIAL) {
-    page->maxActiveFrames = 0xFFFFFFFF;
-    }
-    sectionParams->unknown_0x3D8 = false;
-    RKSYS::LicenseLdbEntry entry;
-
-    const RacedataScenario& scenario = Racedata::sInstance->racesScenario;
-    const u8 playerId = scenario.settings.hudPlayerIds[0];
-    entry.character = scenario.players[playerId].characterId;
-    entry.kart = scenario.players[playerId].kartId;
-    entry.controllerType = sectionMgr->pad.GetType(sectionMgr->pad.GetCurrentID(0));
-    const Mii* mii = sectionParams->playerMiis.GetMii(0);
-    Mii::ComputeRFLStoreData(entry.miiData, &mii->info.createID);
-
-    //Find which lap is the best
-    RaceinfoPlayer* raceInfoPlayer = Raceinfo::sInstance->players[playerId];
-    page->timers[0] = *raceInfoPlayer->raceFinishTime;
-    page->ctrlRaceTimeArray[0]->SetTimer(&page->timers[0]);
-    page->ctrlRaceTimeArray[0]->OnFocus();
-    Timer* bestLap = &page->timers[0];
-    u32 bestLapId = 1;
-    for (int i = 1; i < page->splitsRowCount; ++i) {
-        raceInfoPlayer->FillTimerWithSplits(i, &page->timers[i]);
-        if ((*bestLap) > page->timers[i]) {
-            bestLap = &page->timers[i];
-            bestLapId = i;
+        // GhostInfoControl BRCTR
+        static void LoadCustomGhostInfoBRCTR(ControlLoader &loader, const char *folderName, const char *ctrName,
+                                             const char *variantName, const char **anims)
+        {
+            loader.Load(folderName, "PULGhostInfo", variantName, anims);
         }
-        CtrlRaceTime* curRaceTime = page->ctrlRaceTimeArray[i];
-        curRaceTime->SetTimer(&page->timers[i]);
-        curRaceTime->OnFocus();
-    }
+        kmCall(0x805e28c0, LoadCustomGhostInfoBRCTR);
+        kmWrite32(0x80639958, 0x3880000C); // Add controls
 
-    //No saving and no new record in OTT for now
-    if (System::sInstance->IsContext(PULSAR_MODE_OTT)) return;
-
-    //enhanced replay
-    if (sectionMgr->curSection->sectionId >= SECTION_WATCH_GHOST_FROM_CHANNEL
-        && sectionMgr->curSection->sectionId <= SECTION_WATCH_GHOST_FROM_MENU) {
-        page->ctrlRaceTimeArray[0]->EnableFlashingAnimation();
-        page->ctrlRaceTimeArray[bestLapId]->EnableFlashingAnimation();
-        page->ctrlRaceCount.isHidden = false;
-        page->ctrlRaceCount.FadeIn();
-        page->PlaySound(SOUND_ID_NEW_RECORD, -1);
-        page->savedGhostMessage.SetMessage(UI::BMG_SAVED_GHOST);
-    }
-
-    //Finish Time Leaderboard check and request
-    else {
-        Ghosts::Mgr* manager = Ghosts::Mgr::sInstance;
-        bool hasFlap = false;
-        manager->entry = entry;
-        manager->GetLeaderboard().EntryToTimer(manager->entry.timer, Ghosts::ENTRY_FLAP);
-        if (manager->entry.timer > *bestLap) {
-            manager->entry.timer = *bestLap;
-            hasFlap = true;
-            sectionParams->fastestLapId = bestLapId;
-            page->ctrlRaceTimeArray[bestLapId]->EnableFlashingAnimation();
+        ExpGhostSelect::ExpGhostSelect()
+        {
+            Ghosts::Mgr::CreateInstance();
+            this->onChallengeGhostClickHandler.ptmf = &ExpGhostSelect::OnChallengeGhostPress;
+            this->onWatchReplayClickHandler.ptmf = &ExpGhostSelect::OnWatchReplayPress;
+            this->onRightArrowPressHandler.ptmf = &ExpGhostSelect::OnRightArrowPress;
+            this->onLeftArrowPressHandler.ptmf = &ExpGhostSelect::OnLeftArrowPress;
+            this->onSelectGhostChangeHandler.subject = this;
+            this->onSelectGhostChangeHandler.ptmf = &ExpGhostSelect::OnSelectGhostChange;
+            this->onStartPressHandler.subject = this;
+            this->onStartPressHandler.ptmf = &ExpGhostSelect::OnStartPress;
         }
-        entry.timer = page->timers[0];
-        const s32 position = manager->GetLeaderboard().GetPosition(page->timers[0]);
-        sectionParams->leaderboardPosition = position;
-        if (position == 0) {
-            page->ctrlRaceCount.isHidden = false;
-            page->ctrlRaceCount.FadeIn();
-            sectionParams->unknown_0x3D8 = true;
-            if (Input::Manager::sInstance->realControllerHolders[0].ghostWriter->status != 3 && page->timers[0].minutes < 6) {
-                sectionParams->isNewTime = true;
+
+        void ExpGhostSelect::OnInit()
+        {
+            GhostSelect::OnInit();
+            this->AddControl(0x9, this->bottomText, 0);
+            this->bottomText.Load();
+            this->selectGhostButton.buttonId = 0xA;
+            this->AddControl(0xA, this->selectGhostButton, 0);
+            this->selectGhostButton.Load(1, UI::buttonFolder, "SelectGhost", "SelectGhost"); // check multighost
+            this->selectGhostButton.SetOnClickHandler(this->onSelectGhostChangeHandler, 0);
+            // this->manipulatorManager.SetGlobalHandler(START_PRESS, onStartPressHandler, false, false);
+            this->AddControl(0xB, this->favGhost, 0);
+            this->favGhost.isHidden = true;
+            ControlLoader loader(&this->favGhost);
+            loader.Load(UI::controlFolder, "PULInstruction", "OTTGhost", nullptr);
+            this->Reset();
+        }
+
+        // BottomText will display the current TTmode as well as if the player has a trophy on the track
+        void ExpGhostSelect::OnActivate()
+        {
+            GhostSelect::OnActivate();
+            const System *system = System::sInstance;
+            if (system->GetInfo().HasTrophies())
+            {
+                u32 bmgId;
+                const Text::Info text = GetCourseBottomText(CupsConfig::sInstance->GetWinning(), &bmgId);
+                this->bottomText.SetMessage(bmgId, &text);
             }
-            page->ctrlRaceTimeArray[0]->EnableFlashingAnimation();
-            page->PlaySound(SOUND_ID_NEW_RECORD, -1);
-            page->savedGhostMessage.SetMessage(UI::BMG_SAVED_GHOST);
+            this->ctrlMenuPageTitleText.SetMessage(BMG_CHOOSE_GHOST_DATA);
+            this->Reset();
+            this->selectGhostButton.SetMessage(BMG_SELECT_GHOST);
 
+            const TTMode mode = system->ttMode;
+            bool isStarVisibleOnActivate = false;
+            if (mode < TTMODE_150_FEATHER)
+            {
+                const GhostList *list = this->ghostList;
+                for (int i = 0; i < list->count; ++i)
+                {
+                    if (list->entries[i].padding[0] == Ghosts::Mgr::GetInstance()->GetFavGhostFileIndex(mode))
+                    {
+                        this->favGhostIndex = i;
+                    }
+                }
+                if (this->favGhostIndex == this->page)
+                    isStarVisibleOnActivate = true;
+            }
+            this->info->SetPaneVisibility("star", isStarVisibleOnActivate);
         }
-        else if (position < 0) page->ctrlRaceCount.isHidden = true;
-        if (hasFlap || position >= 0) {
-            bool gotTrophy = manager->SaveGhost(entry, position, hasFlap);
-            if (gotTrophy) page->savedGhostMessage.SetMessage(UI::BMG_TROPHY_EARNED);
+
+        void ExpGhostSelect::OnDeactivate()
+        {
+            Ghosts::Mgr::sInstance->SaveLeaderboard();
         }
-    }
-}
-kmWritePointer(0x808DA614, BeforeEntranceAnimations);
+        // Creates space by making the usual 3 buttons smaller, could be done without a BRCTR but this is easier to maintain
+        static void LoadButtonWithCustBRCTR(PushButton &button, const char *folderName, const char *ctrName, const char *variant,
+                                            u32 localPlayerBitfield, u32 r8, bool inaccessible)
+        {
+            button.Load(folderName, "GhostListButton", variant, localPlayerBitfield, r8, inaccessible);
+        }
+        kmCall(0x80639ab8, LoadButtonWithCustBRCTR);
+        kmCall(0x80639ad8, LoadButtonWithCustBRCTR);
+        kmCall(0x80639af8, LoadButtonWithCustBRCTR);
 
+        void ExpGhostSelect::OnChallengeGhostPress(PushButton &button, u32 hudSlotId)
+        {
+            GhostSelect::OnChallengeGhostPress(button, hudSlotId);
+            const GhostListEntry &entry = this->ghostList->entries[this->page];
+            Ghosts::Mgr::sInstance->EnableGhost(entry, true);
+        }
 
-static void TrophyBMG(CtrlMenuInstructionText& bottomText, u32 bmgId) {
-    Text::Info text;
-    const System* system = System::sInstance;
-    const Settings::Mgr& settings = Settings::Mgr::Get();
-    u32 trophyCount = settings.GetTrophyCount(system->ttMode);
-    u32 totalCount = settings.GetTotalTrophyCount(system->ttMode);
-    text.intToPass[0] = trophyCount;
-    text.intToPass[1] = totalCount;
-    text.bmgToPass[0] = BMG_TT_MODE_BOTTOM_CUP + system->ttMode;
-    bmgId = BMG_TT_BOTTOM_CUP_NOTROPHY;
-    if (totalCount > 0 && system->GetInfo().HasTrophies()) bmgId = BMG_TT_BOTTOM_CUP;
-    bottomText.SetMessage(bmgId, &text);
-}
-kmCall(0x8084144c, TrophyBMG);
+        void ExpGhostSelect::OnWatchReplayPress(PushButton &button, u32 hudSlotId)
+        {
+            GhostSelect::OnWatchReplayPress(button, hudSlotId);
+            const GhostListEntry &entry = this->ghostList->entries[this->page];
+            Ghosts::Mgr::sInstance->EnableGhost(entry, true);
+        }
 
-void IndividualTrophyBMG(Pages::CourseSelect& courseSelect, CtrlMenuCourseSelectCourse& course, PushButton& button, u32 hudSlotId) {
-    if (Racedata::sInstance->menusScenario.settings.gamemode != MODE_TIME_TRIAL) {
-        courseSelect.UpdateBottomText(course, button, hudSlotId);
-    }
-    else {
-        u32 bmgId;
-        CupsConfig* cupsConfig = CupsConfig::sInstance;
-        const Text::Info text = GetCourseBottomText(cupsConfig->ConvertTrack_PulsarCupToTrack(cupsConfig->lastSelectedCup, button.buttonId), &bmgId); //FIX HERE
-        courseSelect.bottomText->SetMessage(bmgId, &text);
-    }
-}
-kmCall(0x807e54ec, IndividualTrophyBMG);
+        void ExpGhostSelect::OnSelectGhostChange(ToggleButton &button, u32)
+        {
+            Ghosts::Mgr *mgr = Ghosts::Mgr::sInstance;
+            const GhostListEntry &entry = this->ghostList->entries[this->page];
 
-//Global function as it is also used by CourseSelect
-const Text::Info GetCourseBottomText(PulsarId id, u32* bmgId) {
-    const System* system = System::sInstance;
-    const Settings::Mgr& settings = Settings::Mgr::Get();
-    if (settings.GetTotalTrophyCount(system->ttMode) > 0) *bmgId = BMG_TT_BOTTOM_COURSE;
-    else *bmgId = BMG_TT_BOTTOM_COURSE_NOTROPHY;
+            if (button.GetState() == true)
+            {
+                u32 index = mgr->lastUsedSlot;
+                if (mgr->EnableGhost(entry, false))
+                {
+                    this->selectedGhostsPages[index] = this->page;
+                    this->selectedGhostsCount = (this->selectedGhostsCount + 1) > 3 ? 3 : (this->selectedGhostsCount + 1);
+                }
+                else
+                    button.ToggleState(false);
+            }
+            else
+            {
+                mgr->DisableGhost(entry);
+                this->selectedGhostsPages[mgr->lastUsedSlot] = -1;
+                this->selectedGhostsCount -= 1;
+            }
+            Text::Info text;
+            text.intToPass[0] = this->selectedGhostsCount;
+            this->ctrlMenuPageTitleText.SetMessage(BMG_GHOST_SELECTED_COUNTER, &text);
+            this->SetToggleBMG();
+        }
 
-    const bool hasTrophy = settings.HasTrophy(id, system->ttMode);
-    Text::Info text;
-    text.bmgToPass[0] = BMG_TT_MODE_BOTTOM_CUP + system->ttMode;
-    u32 passedBmgId = BMG_NO_TROPHY;
-    if (hasTrophy) passedBmgId = BMG_TROPHY;
-    text.bmgToPass[1] = passedBmgId;
-    return text;
-}
+        void ExpGhostSelect::OnStartPress(u32)
+        {
+            bool isStarVisible;
+            if (this->favGhostIndex == this->page)
+            {
+                this->favGhostIndex = -1;
+                isStarVisible = false;
+            }
+            else
+            {
+                this->favGhostIndex = this->page;
+                isStarVisible = true;
+            }
+            this->PlaySound(isStarVisible ? SOUND_ID_SMALL_HIGH_NOTE : SOUND_ID_BACK_PRESS, 0);
+            Ghosts::Mgr::sInstance->SetFavGhost(this->ghostList->entries[this->page], System::sInstance->ttMode, isStarVisible);
+            this->info->SetPaneVisibility("star", isStarVisible);
+        }
 
-void SetRankingsBMG() {
+        void ExpGhostSelect::OnRightArrowPress(SheetSelectControl &control, u32 hudSlotId)
+        {
+            GhostSelect::OnRightArrowPress(control, hudSlotId);
+            this->OnNewPage();
+        }
 
-}
+        void ExpGhostSelect::OnLeftArrowPress(SheetSelectControl &control, u32 hudSlotId)
+        {
+            GhostSelect::OnLeftArrowPress(control, hudSlotId);
+            this->OnNewPage();
+        }
 
+        void ExpGhostSelect::OnNewPage()
+        {
+            ToggleButton &button = this->selectGhostButton;
+            if (this->page == this->selectedGhostsPages[0] || this->page == this->selectedGhostsPages[1] || this->page == this->selectedGhostsPages[2])
+            {
+                if (button.GetState() == false)
+                    button.ToggleState(true);
+            }
+            else if (button.GetState() == true)
+                button.ToggleState(false);
 
-}//namespace UI
-}//namespace Pulsar
+            this->SetToggleBMG();
+
+            bool isStarHidden;
+            if (this->page == this->favGhostIndex)
+            {
+                isStarHidden = true;
+            }
+            else
+                isStarHidden = false;
+            this->info->SetPaneVisibility("star", isStarHidden);
+        }
+
+        void ExpGhostSelect::SetToggleBMG()
+        {
+            ToggleButton &button = this->selectGhostButton;
+            const u32 bmgId = button.GetState() == false ? BMG_SELECT_GHOST : BMG_GHOST_SELECTED;
+            button.SetMessage(bmgId);
+        }
+
+        void ExpGhostSelect::Reset()
+        {
+            this->selectedGhostsPages[0] = -1;
+            this->selectedGhostsPages[1] = -1;
+            this->selectedGhostsPages[2] = -1;
+            this->selectedGhostsCount = 0;
+            this->selectGhostButton.ToggleState(false);
+            this->favGhostIndex = -1;
+        }
+
+        // Complete rewrite TTSplits BeforeEntranceAnimations; this will request a RKG if needed (flap or top 10 time)
+        void BeforeEntranceAnimations(Pages::TTSplits *page)
+        {
+            const u32 gamemode = Racedata::sInstance->racesScenario.settings.gamemode;
+            // Init Variables
+            const SectionMgr *sectionMgr = SectionMgr::sInstance;
+            SectionParams *sectionParams = sectionMgr->sectionParams;
+            sectionParams->isNewTime = false;
+            sectionParams->fastestLapId = 0xFFFFFFFF;
+            if (System::sInstance->IsContext(PULSAR_MODE_OTT))
+            {
+                page->maxActiveFrames = 0x12C;
+            }
+            else if (gamemode == MODE_TIME_TRIAL)
+            {
+                page->maxActiveFrames = 0xFFFFFFFF;
+            }
+            sectionParams->unknown_0x3D8 = false;
+            RKSYS::LicenseLdbEntry entry;
+
+            const RacedataScenario &scenario = Racedata::sInstance->racesScenario;
+            const u8 playerId = scenario.settings.hudPlayerIds[0];
+            entry.character = scenario.players[playerId].characterId;
+            entry.kart = scenario.players[playerId].kartId;
+            entry.controllerType = sectionMgr->pad.GetType(sectionMgr->pad.GetCurrentID(0));
+            const Mii *mii = sectionParams->playerMiis.GetMii(0);
+            Mii::ComputeRFLStoreData(entry.miiData, &mii->info.createID);
+
+            // Find which lap is the best
+            RaceinfoPlayer *raceInfoPlayer = Raceinfo::sInstance->players[playerId];
+            page->timers[0] = *raceInfoPlayer->raceFinishTime;
+            page->ctrlRaceTimeArray[0]->SetTimer(&page->timers[0]);
+            page->ctrlRaceTimeArray[0]->OnFocus();
+            Timer *bestLap = &page->timers[0];
+            u32 bestLapId = 1;
+            for (int i = 1; i < page->splitsRowCount; ++i)
+            {
+                raceInfoPlayer->FillTimerWithSplits(i, &page->timers[i]);
+                if ((*bestLap) > page->timers[i])
+                {
+                    bestLap = &page->timers[i];
+                    bestLapId = i;
+                }
+                CtrlRaceTime *curRaceTime = page->ctrlRaceTimeArray[i];
+                curRaceTime->SetTimer(&page->timers[i]);
+                curRaceTime->OnFocus();
+            }
+
+            // No saving and no new record in OTT for now
+            if (System::sInstance->IsContext(PULSAR_MODE_OTT))
+                return;
+
+            // enhanced replay
+            if (sectionMgr->curSection->sectionId >= SECTION_WATCH_GHOST_FROM_CHANNEL && sectionMgr->curSection->sectionId <= SECTION_WATCH_GHOST_FROM_MENU)
+            {
+                page->ctrlRaceTimeArray[0]->EnableFlashingAnimation();
+                page->ctrlRaceTimeArray[bestLapId]->EnableFlashingAnimation();
+                page->ctrlRaceCount.isHidden = false;
+                page->ctrlRaceCount.FadeIn();
+                page->PlaySound(SOUND_ID_NEW_RECORD, -1);
+                page->savedGhostMessage.SetMessage(UI::BMG_SAVED_GHOST);
+            }
+
+            // Finish Time Leaderboard check and request
+            else
+            {
+                Ghosts::Mgr *manager = Ghosts::Mgr::sInstance;
+                bool hasFlap = false;
+                manager->entry = entry;
+                manager->GetLeaderboard().EntryToTimer(manager->entry.timer, Ghosts::ENTRY_FLAP);
+                if (manager->entry.timer > *bestLap)
+                {
+                    manager->entry.timer = *bestLap;
+                    hasFlap = true;
+                    sectionParams->fastestLapId = bestLapId;
+                    page->ctrlRaceTimeArray[bestLapId]->EnableFlashingAnimation();
+                }
+                entry.timer = page->timers[0];
+                const s32 position = manager->GetLeaderboard().GetPosition(page->timers[0]);
+                sectionParams->leaderboardPosition = position;
+                if (position == 0)
+                {
+                    page->ctrlRaceCount.isHidden = false;
+                    page->ctrlRaceCount.FadeIn();
+                    sectionParams->unknown_0x3D8 = true;
+                    if (Input::Manager::sInstance->realControllerHolders[0].ghostWriter->status != 3 && page->timers[0].minutes < 6)
+                    {
+                        sectionParams->isNewTime = true;
+                    }
+                    page->ctrlRaceTimeArray[0]->EnableFlashingAnimation();
+                    page->PlaySound(SOUND_ID_NEW_RECORD, -1);
+                    page->savedGhostMessage.SetMessage(UI::BMG_SAVED_GHOST);
+                }
+                else if (position < 0)
+                    page->ctrlRaceCount.isHidden = true;
+                if (hasFlap || position >= 0)
+                {
+                    bool gotTrophy = manager->SaveGhost(entry, position, hasFlap);
+                    if (gotTrophy)
+                        page->savedGhostMessage.SetMessage(UI::BMG_TROPHY_EARNED);
+                }
+            }
+        }
+        kmWritePointer(0x808DA614, BeforeEntranceAnimations);
+
+        static void TrophyBMG(CtrlMenuInstructionText &bottomText, u32 bmgId)
+        {
+            Text::Info text;
+            const System *system = System::sInstance;
+            const Settings::Mgr &settings = Settings::Mgr::Get();
+            u32 trophyCount = settings.GetTrophyCount(system->ttMode);
+            u32 totalCount = settings.GetTotalTrophyCount(system->ttMode);
+            text.intToPass[0] = trophyCount;
+            text.intToPass[1] = totalCount;
+            text.bmgToPass[0] = BMG_TT_MODE_BOTTOM_CUP + system->ttMode;
+            bmgId = BMG_TT_BOTTOM_CUP_NOTROPHY;
+            if (totalCount > 0 && system->GetInfo().HasTrophies())
+                bmgId = BMG_TT_BOTTOM_CUP;
+            bottomText.SetMessage(bmgId, &text);
+        }
+        kmCall(0x8084144c, TrophyBMG);
+
+        void IndividualTrophyBMG(Pages::CourseSelect &courseSelect, CtrlMenuCourseSelectCourse &course, PushButton &button, u32 hudSlotId)
+        {
+            if (Racedata::sInstance->menusScenario.settings.gamemode != MODE_TIME_TRIAL)
+            {
+                courseSelect.UpdateBottomText(course, button, hudSlotId);
+            }
+            else
+            {
+                u32 bmgId;
+                CupsConfig *cupsConfig = CupsConfig::sInstance;
+                const Text::Info text = GetCourseBottomText(cupsConfig->ConvertTrack_PulsarCupToTrack(cupsConfig->lastSelectedCup, button.buttonId), &bmgId); // FIX HERE
+                courseSelect.bottomText->SetMessage(bmgId, &text);
+            }
+        }
+        kmCall(0x807e54ec, IndividualTrophyBMG);
+
+        // Global function as it is also used by CourseSelect
+        const Text::Info GetCourseBottomText(PulsarId id, u32 *bmgId)
+        {
+            const System *system = System::sInstance;
+            const Settings::Mgr &settings = Settings::Mgr::Get();
+            if (settings.GetTotalTrophyCount(system->ttMode) > 0)
+                *bmgId = BMG_TT_BOTTOM_COURSE;
+            else
+                *bmgId = BMG_TT_BOTTOM_COURSE_NOTROPHY;
+
+            const bool hasTrophy = settings.HasTrophy(id, system->ttMode);
+            Text::Info text;
+            text.bmgToPass[0] = BMG_TT_MODE_BOTTOM_CUP + system->ttMode;
+            u32 passedBmgId = BMG_NO_TROPHY;
+            if (hasTrophy)
+                passedBmgId = BMG_TROPHY;
+            text.bmgToPass[1] = passedBmgId;
+            return text;
+        }
+
+        void SetRankingsBMG()
+        {
+        }
+
+    } // namespace UI
+} // namespace Pulsar

--- a/PulsarEngine/Network/MiscNetwork.cpp
+++ b/PulsarEngine/Network/MiscNetwork.cpp
@@ -2,7 +2,7 @@
 #include <MarioKartWii/RKNet/RKNetController.hpp>
 #include <MarioKartWii/RKNet/Select.hpp>
 #include <MarioKartWii/System/random.hpp>
-#include <MarioKartWii/Race/Racedata.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
 #include <MarioKartWii/UI/Section/SectionMgr.hpp>
 #include <Settings/Settings.hpp>
 #include <Network/PulSELECT.hpp>
@@ -10,25 +10,30 @@
 #include <AutoTrackSelect/ChooseNextTrack.hpp>
 #include <Gamemodes/KO/KOMgr.hpp>
 
-namespace Pulsar {
-namespace Network {
+namespace Pulsar
+{
+    namespace Network
+    {
 
-static void CalcSectionAfterRace(SectionMgr* sectionMgr, SectionId id) {
+        static void CalcSectionAfterRace(SectionMgr *sectionMgr, SectionId id)
+        {
 
-    UI::ChooseNextTrack* choosePage = reinterpret_cast<UI::ExpSection*>(sectionMgr->curSection)->GetPulPage<UI::ChooseNextTrack>();
-    const System* system = System::sInstance;
-    // if(choosePage != nullptr) id = choosePage->ProcessHAW(id);
-    if(id != SECTION_NONE) {
-        if(system->IsContext(PULSAR_MODE_KO)) id = system->koMgr->GetSectionAfterKO(id);
-        sectionMgr->SetNextSection(id, 0);
-        register Pages::WWRaceEndWait* wait;
-        asm(mr wait, r31);
-        wait->EndStateAnimated(0.0f, 0);
-        sectionMgr->RequestSceneChange(0, 0xFF);
-    }
-}
-kmCall(0x8064f5fc, CalcSectionAfterRace);
-kmPatchExitPoint(CalcSectionAfterRace, 0x8064f648);
+            UI::ChooseNextTrack *choosePage = reinterpret_cast<UI::ExpSection *>(sectionMgr->curSection)->GetPulPage<UI::ChooseNextTrack>();
+            const System *system = System::sInstance;
+            // if(choosePage != nullptr) id = choosePage->ProcessHAW(id);
+            if (id != SECTION_NONE)
+            {
+                if (system->IsContext(PULSAR_MODE_KO))
+                    id = system->koMgr->GetSectionAfterKO(id);
+                sectionMgr->SetNextSection(id, 0);
+                register Pages::WWRaceEndWait *wait;
+                asm(mr wait, r31);
+                wait->EndStateAnimated(0.0f, 0);
+                sectionMgr->RequestSceneChange(0, 0xFF);
+            }
+        }
+        kmCall(0x8064f5fc, CalcSectionAfterRace);
+        kmPatchExitPoint(CalcSectionAfterRace, 0x8064f648);
 
-}//namespace Network
-}//namespace Pulsar
+    } // namespace Network
+} // namespace Pulsar

--- a/PulsarEngine/Race/BinLoader.cpp
+++ b/PulsarEngine/Race/BinLoader.cpp
@@ -1,108 +1,121 @@
 #include <RetroRewind.hpp>
 #include <MarioKartWii/Archive/ArchiveMgr.hpp>
 #include <MarioKartWii/RKNet/RKNetController.hpp>
-#include <core/rvl/os/OS.hpp>
+#include <core/rvl/OS/OS.hpp>
 #ifdef PROD
 #include <Security/BinVerifier.hpp>
 #endif
 
-namespace RetroRewind {
+namespace RetroRewind
+{
 
-void *GetCustomKartParam(ArchiveMgr *archive, ArchiveSource type, const char *name, u32 *length) {
-    bool insideAll = Pulsar::FORCE_TRANSMISSION_DEFAULT;
-    bool outsideAll = Pulsar::FORCE_TRANSMISSION_DEFAULT;
-    bool vanilla = Pulsar::FORCE_TRANSMISSION_DEFAULT;
-    if (RKNet::Controller::sInstance->roomType == RKNet::ROOMTYPE_FROOM_HOST || RKNet::Controller::sInstance->roomType == RKNet::ROOMTYPE_FROOM_NONHOST) {
-        insideAll = System::sInstance->IsContext(Pulsar::PULSAR_TRANSMISSIONINSIDE) ? Pulsar::FORCE_TRANSMISSION_INSIDE : Pulsar::FORCE_TRANSMISSION_DEFAULT;
-        outsideAll = System::sInstance->IsContext(Pulsar::PULSAR_TRANSMISSIONOUTSIDE) ? Pulsar::FORCE_TRANSMISSION_OUTSIDE : Pulsar::FORCE_TRANSMISSION_DEFAULT;
-        vanilla = System::sInstance->IsContext(Pulsar::PULSAR_TRANSMISSIONVANILLA) ? Pulsar::FORCE_TRANSMISSION_VANILLA : Pulsar::FORCE_TRANSMISSION_DEFAULT;
-    }
-    if (RKNet::Controller::sInstance->roomType == RKNet::ROOMTYPE_VS_WW || RKNet::Controller::sInstance->roomType == RKNet::ROOMTYPE_BT_WW) {
-        name = "kartParam.bin";
-    } else {
-        if (insideAll == Pulsar::FORCE_TRANSMISSION_INSIDE) {
-            name = "kartParamAll.bin";
+    void *GetCustomKartParam(ArchiveMgr *archive, ArchiveSource type, const char *name, u32 *length)
+    {
+        bool insideAll = Pulsar::FORCE_TRANSMISSION_DEFAULT;
+        bool outsideAll = Pulsar::FORCE_TRANSMISSION_DEFAULT;
+        bool vanilla = Pulsar::FORCE_TRANSMISSION_DEFAULT;
+        if (RKNet::Controller::sInstance->roomType == RKNet::ROOMTYPE_FROOM_HOST || RKNet::Controller::sInstance->roomType == RKNet::ROOMTYPE_FROOM_NONHOST)
+        {
+            insideAll = System::sInstance->IsContext(Pulsar::PULSAR_TRANSMISSIONINSIDE) ? Pulsar::FORCE_TRANSMISSION_INSIDE : Pulsar::FORCE_TRANSMISSION_DEFAULT;
+            outsideAll = System::sInstance->IsContext(Pulsar::PULSAR_TRANSMISSIONOUTSIDE) ? Pulsar::FORCE_TRANSMISSION_OUTSIDE : Pulsar::FORCE_TRANSMISSION_DEFAULT;
+            vanilla = System::sInstance->IsContext(Pulsar::PULSAR_TRANSMISSIONVANILLA) ? Pulsar::FORCE_TRANSMISSION_VANILLA : Pulsar::FORCE_TRANSMISSION_DEFAULT;
         }
-        else if (outsideAll == Pulsar::FORCE_TRANSMISSION_OUTSIDE) {
-            name = "kartParamOut.bin";
-        }
-        else if (vanilla == Pulsar::FORCE_TRANSMISSION_VANILLA) {
+        if (RKNet::Controller::sInstance->roomType == RKNet::ROOMTYPE_VS_WW || RKNet::Controller::sInstance->roomType == RKNet::ROOMTYPE_BT_WW)
+        {
             name = "kartParam.bin";
         }
-        else if (static_cast<Pulsar::Transmission>(Pulsar::Settings::Mgr::Get().GetUserSettingValue(static_cast<Pulsar::Settings::UserType>(Pulsar::Settings::SETTINGSTYPE_RR), Pulsar::SETTINGRR_RADIO_TRANSMISSION)) == Pulsar::TRANSMISSION_INSIDEALL)
+        else
         {
-            name="kartParamAll.bin";
+            if (insideAll == Pulsar::FORCE_TRANSMISSION_INSIDE)
+            {
+                name = "kartParamAll.bin";
+            }
+            else if (outsideAll == Pulsar::FORCE_TRANSMISSION_OUTSIDE)
+            {
+                name = "kartParamOut.bin";
+            }
+            else if (vanilla == Pulsar::FORCE_TRANSMISSION_VANILLA)
+            {
+                name = "kartParam.bin";
+            }
+            else if (static_cast<Pulsar::Transmission>(Pulsar::Settings::Mgr::Get().GetUserSettingValue(static_cast<Pulsar::Settings::UserType>(Pulsar::Settings::SETTINGSTYPE_RR), Pulsar::SETTINGRR_RADIO_TRANSMISSION)) == Pulsar::TRANSMISSION_INSIDEALL)
+            {
+                name = "kartParamAll.bin";
+            }
+            else if (static_cast<Pulsar::Transmission>(Pulsar::Settings::Mgr::Get().GetUserSettingValue(static_cast<Pulsar::Settings::UserType>(Pulsar::Settings::SETTINGSTYPE_RR), Pulsar::SETTINGRR_RADIO_TRANSMISSION)) == Pulsar::TRANSMISSION_INSIDEBIKE)
+            {
+                name = "kartParamBike.bin";
+            }
+            else if (static_cast<Pulsar::Transmission>(Pulsar::Settings::Mgr::Get().GetUserSettingValue(static_cast<Pulsar::Settings::UserType>(Pulsar::Settings::SETTINGSTYPE_RR), Pulsar::SETTINGRR_RADIO_TRANSMISSION)) == Pulsar::TRANSMISSION_OUTSIDE)
+            {
+                name = "kartParamOut.bin";
+            }
         }
-        else if (static_cast<Pulsar::Transmission>(Pulsar::Settings::Mgr::Get().GetUserSettingValue(static_cast<Pulsar::Settings::UserType>(Pulsar::Settings::SETTINGSTYPE_RR), Pulsar::SETTINGRR_RADIO_TRANSMISSION)) == Pulsar::TRANSMISSION_INSIDEBIKE)
-        {
-            name="kartParamBike.bin";
-        }
-        else if (static_cast<Pulsar::Transmission>(Pulsar::Settings::Mgr::Get().GetUserSettingValue(static_cast<Pulsar::Settings::UserType>(Pulsar::Settings::SETTINGSTYPE_RR), Pulsar::SETTINGRR_RADIO_TRANSMISSION)) == Pulsar::TRANSMISSION_OUTSIDE)
-        {
-            name="kartParamOut.bin";
-        }
-    }
 
 #ifdef PROD
-    AntiCheat::VerifyBinFile(name);
+        AntiCheat::VerifyBinFile(name);
 #endif
 
-    return archive->GetFile(type, name, length);
-}
-kmCall(0x80591a30, GetCustomKartParam);
+        return archive->GetFile(type, name, length);
+    }
+    kmCall(0x80591a30, GetCustomKartParam);
 
-void *GetCustomKartAIParam(ArchiveMgr *archive, ArchiveSource type, const char *name, u32 *length){
-    const GameMode gameMode = Racedata::sInstance->racesScenario.settings.gamemode;
-    if (static_cast<Pulsar::HardAI>(Pulsar::Settings::Mgr::Get().GetUserSettingValue(static_cast<Pulsar::Settings::UserType>(Pulsar::Settings::SETTINGSTYPE_RR), Pulsar::SETTINGRR_RADIO_HARDAI)) == Pulsar::HARDAI_ENABLED)
+    void *GetCustomKartAIParam(ArchiveMgr *archive, ArchiveSource type, const char *name, u32 *length)
     {
-        name="kartAISpdParamRR.bin";
-    }
-    
-    return archive->GetFile(type, name, length);
-}
-kmCall(0x8073ae9c, GetCustomKartAIParam);
+        const GameMode gameMode = Racedata::sInstance->racesScenario.settings.gamemode;
+        if (static_cast<Pulsar::HardAI>(Pulsar::Settings::Mgr::Get().GetUserSettingValue(static_cast<Pulsar::Settings::UserType>(Pulsar::Settings::SETTINGSTYPE_RR), Pulsar::SETTINGRR_RADIO_HARDAI)) == Pulsar::HARDAI_ENABLED)
+        {
+            name = "kartAISpdParamRR.bin";
+        }
 
-void *GetCustomItemSlot(ArchiveMgr *archive, ArchiveSource type, const char *name, u32 *length){
-    const RacedataScenario& scenario = Racedata::sInstance->racesScenario;
-    const GameMode mode = scenario.settings.gamemode;
-    bool itemModeRandom = Pulsar::GAMEMODE_DEFAULT;
-    bool itemModeBlast = Pulsar::GAMEMODE_DEFAULT;
-    bool itemModeNone = Pulsar::GAMEMODE_DEFAULT;
-    if (RKNet::Controller::sInstance->roomType == RKNet::ROOMTYPE_FROOM_HOST || RKNet::Controller::sInstance->roomType == RKNet::ROOMTYPE_FROOM_NONHOST || mode == MODE_VS_RACE || mode == MODE_BATTLE) {
-        itemModeRandom = System::sInstance->IsContext(Pulsar::PULSAR_ITEMMODERANDOM) ? Pulsar::GAMEMODE_RANDOM : Pulsar::GAMEMODE_DEFAULT;
-        itemModeBlast = System::sInstance->IsContext(Pulsar::PULSAR_ITEMMODEBLAST) ? Pulsar::GAMEMODE_BLAST : Pulsar::GAMEMODE_DEFAULT;
-        itemModeNone = System::sInstance->IsContext(Pulsar::PULSAR_ITEMMODENONE) ? Pulsar::GAMEMODE_NONE : Pulsar::GAMEMODE_DEFAULT;
+        return archive->GetFile(type, name, length);
     }
-    if (RKNet::Controller::sInstance->roomType == RKNet::ROOMTYPE_VS_WW || RKNet::Controller::sInstance->roomType == RKNet::ROOMTYPE_BT_WW) {
-        itemModeNone = Pulsar::GAMEMODE_NONE;
-    }
-    if (itemModeRandom == Pulsar::GAMEMODE_DEFAULT || itemModeBlast == Pulsar::GAMEMODE_DEFAULT)
+    kmCall(0x8073ae9c, GetCustomKartAIParam);
+
+    void *GetCustomItemSlot(ArchiveMgr *archive, ArchiveSource type, const char *name, u32 *length)
     {
-        name="ItemSlotRR.bin";
-    }
-    if (itemModeNone == Pulsar::GAMEMODE_NONE)
-    {
-        name="ItemSlot.bin";
-    }
-    if (itemModeRandom == Pulsar::GAMEMODE_RANDOM)
-    {
-        name="ItemSlotRandom.bin";
-    }
-    if (itemModeBlast == Pulsar::GAMEMODE_BLAST)
-    {
-        name="ItemSlotBlast.bin";
-    }
+        const RacedataScenario &scenario = Racedata::sInstance->racesScenario;
+        const GameMode mode = scenario.settings.gamemode;
+        bool itemModeRandom = Pulsar::GAMEMODE_DEFAULT;
+        bool itemModeBlast = Pulsar::GAMEMODE_DEFAULT;
+        bool itemModeNone = Pulsar::GAMEMODE_DEFAULT;
+        if (RKNet::Controller::sInstance->roomType == RKNet::ROOMTYPE_FROOM_HOST || RKNet::Controller::sInstance->roomType == RKNet::ROOMTYPE_FROOM_NONHOST || mode == MODE_VS_RACE || mode == MODE_BATTLE)
+        {
+            itemModeRandom = System::sInstance->IsContext(Pulsar::PULSAR_ITEMMODERANDOM) ? Pulsar::GAMEMODE_RANDOM : Pulsar::GAMEMODE_DEFAULT;
+            itemModeBlast = System::sInstance->IsContext(Pulsar::PULSAR_ITEMMODEBLAST) ? Pulsar::GAMEMODE_BLAST : Pulsar::GAMEMODE_DEFAULT;
+            itemModeNone = System::sInstance->IsContext(Pulsar::PULSAR_ITEMMODENONE) ? Pulsar::GAMEMODE_NONE : Pulsar::GAMEMODE_DEFAULT;
+        }
+        if (RKNet::Controller::sInstance->roomType == RKNet::ROOMTYPE_VS_WW || RKNet::Controller::sInstance->roomType == RKNet::ROOMTYPE_BT_WW)
+        {
+            itemModeNone = Pulsar::GAMEMODE_NONE;
+        }
+        if (itemModeRandom == Pulsar::GAMEMODE_DEFAULT || itemModeBlast == Pulsar::GAMEMODE_DEFAULT)
+        {
+            name = "ItemSlotRR.bin";
+        }
+        if (itemModeNone == Pulsar::GAMEMODE_NONE)
+        {
+            name = "ItemSlot.bin";
+        }
+        if (itemModeRandom == Pulsar::GAMEMODE_RANDOM)
+        {
+            name = "ItemSlotRandom.bin";
+        }
+        if (itemModeBlast == Pulsar::GAMEMODE_BLAST)
+        {
+            name = "ItemSlotBlast.bin";
+        }
 
 #ifdef PROD
-    AntiCheat::VerifyBinFile(name);
+        AntiCheat::VerifyBinFile(name);
 #endif
 
-    return archive->GetFile(type, name, length);
-}
-kmCall(0x807bb128, GetCustomItemSlot);
-kmCall(0x807bb030, GetCustomItemSlot);
-kmCall(0x807bb200, GetCustomItemSlot);
-kmCall(0x807bb53c, GetCustomItemSlot);
-kmCall(0x807bbb58, GetCustomItemSlot);
+        return archive->GetFile(type, name, length);
+    }
+    kmCall(0x807bb128, GetCustomItemSlot);
+    kmCall(0x807bb030, GetCustomItemSlot);
+    kmCall(0x807bb200, GetCustomItemSlot);
+    kmCall(0x807bb53c, GetCustomItemSlot);
+    kmCall(0x807bbb58, GetCustomItemSlot);
 
 } // namespace RetroRewind

--- a/PulsarEngine/Race/BinLoader.hpp
+++ b/PulsarEngine/Race/BinLoader.hpp
@@ -4,35 +4,37 @@
 #include <kamek.hpp>
 #include <MarioKartWii/Archive/ArchiveMgr.hpp>
 #include <Network/SHA256.hpp>
-#include <core/rvl/os/OS.hpp>
+#include <core/rvl/OS/OS.hpp>
 
-namespace RetroRewind {
+namespace RetroRewind
+{
 
-// Forward declarations
-void* GetCustomKartParam(ArchiveMgr* archive, ArchiveSource type, const char* name, u32* length);
-void* GetCustomKartAIParam(ArchiveMgr* archive, ArchiveSource type, const char* name, u32* length);
-void* GetCustomItemSlot(ArchiveMgr* archive, ArchiveSource type, const char* name, u32* length);
+    // Forward declarations
+    void *GetCustomKartParam(ArchiveMgr *archive, ArchiveSource type, const char *name, u32 *length);
+    void *GetCustomKartAIParam(ArchiveMgr *archive, ArchiveSource type, const char *name, u32 *length);
+    void *GetCustomItemSlot(ArchiveMgr *archive, ArchiveSource type, const char *name, u32 *length);
 
-// Hash calculation functions
-void CalculateKartParamHash(const void* data, u32 length, u8* hashOut);
-bool GetKartParamFileHash(ArchiveSource type, const char* filename, u8* hashOut);
+    // Hash calculation functions
+    void CalculateKartParamHash(const void *data, u32 length, u8 *hashOut);
+    bool GetKartParamFileHash(ArchiveSource type, const char *filename, u8 *hashOut);
 
-// Utility function to convert hash to string
-void HashToString(const u8* hash, char* strOut, size_t strLen);
+    // Utility function to convert hash to string
+    void HashToString(const u8 *hash, char *strOut, size_t strLen);
 
-// Log hash to Dolphin console
-void LogKartParamHash(const char* filename);
+    // Log hash to Dolphin console
+    void LogKartParamHash(const char *filename);
 
-// Hash verification
-struct FileHash {
-    const char* filename;
-    const char* expectedHash;
-};
+    // Hash verification
+    struct FileHash
+    {
+        const char *filename;
+        const char *expectedHash;
+    };
 
-bool VerifyFileHash(const char* filename, ArchiveSource type, const char* expectedHash);
-void VerifyKartParamHashes();
-void VerifyItemSlotHashes();
+    bool VerifyFileHash(const char *filename, ArchiveSource type, const char *expectedHash);
+    void VerifyKartParamHashes();
+    void VerifyItemSlotHashes();
 
-}  // namespace RetroRewind
+} // namespace RetroRewind
 
-#endif 
+#endif

--- a/PulsarEngine/Race/COOB.cpp
+++ b/PulsarEngine/Race/COOB.cpp
@@ -1,38 +1,47 @@
 #include <kamek.hpp>
 #include <MarioKartWii/KMP/KMPManager.hpp>
-#include <MarioKartWii/Race/Raceinfo/Raceinfo.hpp>
+#include <MarioKartWii/Race/RaceInfo/RaceInfo.hpp>
 #include <MarioKartWii/Kart/KartPointers.hpp>
 
-namespace Pulsar {
-namespace Race {
-s16 COOB(KMP::Manager* kmpMgr, const Vec3& position, u32 areaIdToTestFirst, u8 areaType) {
+namespace Pulsar
+{
+    namespace Race
+    {
+        s16 COOB(KMP::Manager *kmpMgr, const Vec3 &position, u32 areaIdToTestFirst, u8 areaType)
+        {
 
-    s16 foundIdx = kmpMgr->FindAREA(position, areaIdToTestFirst, areaType);
-    if(foundIdx >= 0) {
-        register Kart::Collision* collision;
-        asm(mr collision, r31;);
-        RaceinfoPlayer* raceInfoPlayer = Raceinfo::sInstance->players[collision->pointers->values->playerIdx];
+            s16 foundIdx = kmpMgr->FindAREA(position, areaIdToTestFirst, areaType);
+            if (foundIdx >= 0)
+            {
+                register Kart::Collision *collision;
+                asm(mr collision, r31;);
+                RaceinfoPlayer *raceInfoPlayer = Raceinfo::sInstance->players[collision->pointers->values->playerIdx];
 
-        AREA* area = kmpMgr->areaSection->holdersArray[foundIdx]->raw;
-        u16 s1 = area->setting1;
-        u16 s2 = area->setting2;
-        if(area->routeId == 1) {
-            u8 kcp = raceInfoPlayer->currentKCP;
-            if(!(s1 == 0 && kcp == s2 || s1 == 1 && kcp != s2)) {
-                foundIdx = -1;
+                AREA *area = kmpMgr->areaSection->holdersArray[foundIdx]->raw;
+                u16 s1 = area->setting1;
+                u16 s2 = area->setting2;
+                if (area->routeId == 1)
+                {
+                    u8 kcp = raceInfoPlayer->currentKCP;
+                    if (!(s1 == 0 && kcp == s2 || s1 == 1 && kcp != s2))
+                    {
+                        foundIdx = -1;
+                    }
+                }
+                else if (area->routeId == 0xff)
+                {
+                    if (s1 != 0 || s2 != 0)
+                    {
+                        u16 cp = raceInfoPlayer->checkpoint;
+                        bool under1 = cp < s1;
+                        bool over2 = cp >= s2;
+                        if ((s2 >= s1 && (under1 || over2) || over2 && under1))
+                            foundIdx = -1;
+                    }
+                }
             }
+            return foundIdx;
         }
-        else if(area->routeId == 0xff) {
-            if(s1 != 0 || s2 != 0) {
-                u16 cp = raceInfoPlayer->checkpoint;
-                bool under1 = cp < s1;
-                bool over2 = cp >= s2;
-                if((s2 >= s1 && (under1 || over2) || over2 && under1)) foundIdx = -1;
-            }
-        }
-    }
-    return foundIdx;
-}
-kmCall(0x80571870, COOB);
-}//namespace Race
-}//namespace Pulsar
+        kmCall(0x80571870, COOB);
+    } // namespace Race
+} // namespace Pulsar

--- a/PulsarEngine/Race/LapSpeedModifier.cpp
+++ b/PulsarEngine/Race/LapSpeedModifier.cpp
@@ -1,5 +1,5 @@
 #include <kamek.hpp>
-#include <MarioKartWii/Race/Raceinfo/Raceinfo.hpp>
+#include <MarioKartWii/Race/RaceInfo/RaceInfo.hpp>
 #include <MarioKartWii/3D/Model/ModelDirector.hpp>
 #include <MarioKartWii/Kart/KartValues.hpp>
 #include <MarioKartWii/Kart/KartMovement.hpp>
@@ -9,91 +9,102 @@
 #include <PulsarSystem.hpp>
 #include <RetroRewind.hpp>
 
-namespace Pulsar {
-namespace Race {
-//Mostly a port of MrBean's version with better hooks and arguments documentation
-RaceinfoPlayer* LoadCustomLapCount(RaceinfoPlayer* player, u8 id) {
-    const u8 lapCount = KMP::Manager::sInstance->stgiSection->holdersArray[0]->raw->lapCount;
-    Racedata::sInstance->racesScenario.settings.lapCount = lapCount;
-    return new(player) RaceinfoPlayer(id, lapCount);
-}
-kmCall(0x805328d4, LoadCustomLapCount);
+namespace Pulsar
+{
+    namespace Race
+    {
+        // Mostly a port of MrBean's version with better hooks and arguments documentation
+        RaceinfoPlayer *LoadCustomLapCount(RaceinfoPlayer *player, u8 id)
+        {
+            const u8 lapCount = KMP::Manager::sInstance->stgiSection->holdersArray[0]->raw->lapCount;
+            Racedata::sInstance->racesScenario.settings.lapCount = lapCount;
+            return new (player) RaceinfoPlayer(id, lapCount);
+        }
+        kmCall(0x805328d4, LoadCustomLapCount);
 
-//kmWrite32(0x80723d64, 0x7FA4EB78);
-void DisplayCorrectLap(AnmTexPatHolder* texPat) { //This Anm is held by a ModelDirector in a Lakitu::Player
-    register u32 maxLap;
-    asm(mr maxLap, r29;);
-    texPat->UpdateRateAndSetFrame((float)(maxLap - 2));
-    return;
-}
-kmCall(0x80723d70, DisplayCorrectLap);
+        // kmWrite32(0x80723d64, 0x7FA4EB78);
+        void DisplayCorrectLap(AnmTexPatHolder *texPat)
+        { // This Anm is held by a ModelDirector in a Lakitu::Player
+            register u32 maxLap;
+            asm(mr maxLap, r29;);
+            texPat->UpdateRateAndSetFrame((float)(maxLap - 2));
+            return;
+        }
+        kmCall(0x80723d70, DisplayCorrectLap);
 
+        // kmWrite32(0x808b5cd8, 0x3F800000); //change 100cc speed ratio to 1.0
+        Kart::Stats *ApplySpeedModifier(KartId kartId, CharacterId characterId)
+        {
+            union SpeedModConv
+            {
+                float speedMod;
+                u32 kmpValue;
+            };
 
-//kmWrite32(0x808b5cd8, 0x3F800000); //change 100cc speed ratio to 1.0    
-Kart::Stats* ApplySpeedModifier(KartId kartId, CharacterId characterId) {
-    union SpeedModConv {
-        float speedMod;
-        u32 kmpValue;
-    };
+            Kart::Stats *stats = Kart::ComputeStats(kartId, characterId);
+            const GameMode gameMode = Racedata::sInstance->menusScenario.settings.gamemode;
+            const RKNet::Controller *controller = RKNet::Controller::sInstance;
+            const RKNet::RoomType roomType = RKNet::Controller::sInstance->roomType;
+            SpeedModConv speedModConv;
+            bool is200 = Racedata::sInstance->racesScenario.settings.engineClass == CC_100 && RKNet::Controller::sInstance->roomType != RKNet::ROOMTYPE_VS_WW;
+            speedModConv.kmpValue = (KMP::Manager::sInstance->stgiSection->holdersArray[0]->raw->speedMod << 16);
+            if (speedModConv.speedMod == 0.0f)
+                speedModConv.speedMod = 1.0f;
+            float factor = 1.0f;
+            if (is200 && System::sInstance->IsContext(Pulsar::PULSAR_500))
+            {
+                factor = 2.66f;
+            }
+            else if (is200)
+            {
+                factor = speedFactor;
+            }
+            else if (RetroRewind::System::Is500cc() && (gameMode == MODE_PRIVATE_VS || gameMode == MODE_VS_RACE || gameMode == MODE_PUBLIC_VS || gameMode == MODE_GRAND_PRIX))
+            {
+                factor = 3.0f;
+            }
+            else if (RetroRewind::System::Is500cc() && (gameMode == MODE_BATTLE || gameMode == MODE_PUBLIC_BATTLE || gameMode == MODE_PRIVATE_BATTLE))
+            {
+                factor = 1.214;
+            }
+            else if (System::sInstance->IsContext(PULSAR_MODE_OTT) && gameMode == MODE_PUBLIC_VS)
+            {
+                factor = 1.0f;
+            }
+            factor *= speedModConv.speedMod;
 
-    Kart::Stats* stats = Kart::ComputeStats(kartId, characterId);
-    const GameMode gameMode = Racedata::sInstance->menusScenario.settings.gamemode;
-    const RKNet::Controller* controller = RKNet::Controller::sInstance;
-    const RKNet::RoomType roomType = RKNet::Controller::sInstance->roomType;
-    SpeedModConv speedModConv;
-    bool is200 = Racedata::sInstance->racesScenario.settings.engineClass == CC_100 && RKNet::Controller::sInstance->roomType != RKNet::ROOMTYPE_VS_WW;
-    speedModConv.kmpValue = (KMP::Manager::sInstance->stgiSection->holdersArray[0]->raw->speedMod << 16);
-    if(speedModConv.speedMod == 0.0f) speedModConv.speedMod = 1.0f;
-    float factor = 1.0f;
-    if (is200 && System::sInstance->IsContext(Pulsar::PULSAR_500)){
-        factor = 2.66f;
-    }
-    else if (is200){
-        factor = speedFactor;
-    }
-    else if (RetroRewind::System::Is500cc() && (gameMode == MODE_PRIVATE_VS || gameMode == MODE_VS_RACE || gameMode == MODE_PUBLIC_VS || gameMode == MODE_GRAND_PRIX)){
-        factor = 3.0f;
-    }
-    else if (RetroRewind::System::Is500cc() && (gameMode == MODE_BATTLE || gameMode == MODE_PUBLIC_BATTLE || gameMode == MODE_PRIVATE_BATTLE)){
-        factor = 1.214;
-    }
-    else if (System::sInstance->IsContext(PULSAR_MODE_OTT) && gameMode == MODE_PUBLIC_VS) {
-        factor = 1.0f;
-    }
-    factor *= speedModConv.speedMod;
+            Item::greenShellSpeed = 105.0f * factor;
+            Item::redShellInitialSpeed = 75.0f * factor;
+            Item::redShellSpeed = 130.0f * factor;
+            Item::blueShellSpeed = 260.0f * factor;
+            Item::blueShellMinimumDiveDistance = 640000.0f * factor;
+            Item::blueShellHomingSpeed = 130.0f * factor;
 
-    Item::greenShellSpeed = 105.0f * factor;
-    Item::redShellInitialSpeed = 75.0f * factor;
-    Item::redShellSpeed = 130.0f * factor;
-    Item::blueShellSpeed = 260.0f * factor;
-    Item::blueShellMinimumDiveDistance = 640000.0f * factor;
-    Item::blueShellHomingSpeed = 130.0f * factor;
+            Kart::hardSpeedCap = 120.0f * factor;
+            Kart::bulletSpeed = 145.0f * factor;
+            Kart::starSpeed = 105.0f * factor;
+            Kart::megaTCSpeed = 95.0f * factor;
 
-    Kart::hardSpeedCap = 120.0f * factor;
-    Kart::bulletSpeed = 145.0f * factor;
-    Kart::starSpeed = 105.0f * factor;
-    Kart::megaTCSpeed = 95.0f * factor;
+            stats->baseSpeed *= factor;
+            stats->standard_acceleration_as[0] *= factor;
+            stats->standard_acceleration_as[1] *= factor;
+            stats->standard_acceleration_as[2] *= factor;
+            stats->standard_acceleration_as[3] *= factor;
 
-    stats->baseSpeed *= factor;
-    stats->standard_acceleration_as[0] *= factor;
-    stats->standard_acceleration_as[1] *= factor;
-    stats->standard_acceleration_as[2] *= factor;
-    stats->standard_acceleration_as[3] *= factor;
+            Kart::minDriftSpeedRatio = 0.55f * (factor > 1.0f ? (1.0f / factor) : 1.0f);
+            Kart::unknown_70 = 70.0f * factor;
+            Kart::regularBoostAccel = 3.0f * factor;
 
-    Kart::minDriftSpeedRatio = 0.55f * (factor > 1.0f ? (1.0f / factor) : 1.0f);
-    Kart::unknown_70 = 70.0f * factor;
-    Kart::regularBoostAccel = 3.0f * factor;
+            return stats;
+        }
+        kmCall(0x8058f670, ApplySpeedModifier);
 
-    return stats;
-}
-kmCall(0x8058f670, ApplySpeedModifier);
+        kmWrite32(0x805336B8, 0x60000000);
+        kmWrite32(0x80534350, 0x60000000);
+        kmWrite32(0x80534BBC, 0x60000000);
+        kmWrite32(0x80723D10, 0x281D0009);
+        kmWrite32(0x80723D40, 0x3BA00009);
 
-kmWrite32(0x805336B8, 0x60000000);
-kmWrite32(0x80534350, 0x60000000);
-kmWrite32(0x80534BBC, 0x60000000);
-kmWrite32(0x80723D10, 0x281D0009);
-kmWrite32(0x80723D40, 0x3BA00009);
-
-kmWrite24(0x808AAA0C, 'PUL'); //time_number -> time_numPUL
-}//namespace Race
-}//namespace Pulsar
+        kmWrite24(0x808AAA0C, 'PUL'); // time_number -> time_numPUL
+    } // namespace Race
+} // namespace Pulsar

--- a/PulsarEngine/Race/Spectating.cpp
+++ b/PulsarEngine/Race/Spectating.cpp
@@ -2,7 +2,7 @@
 #include <MarioKartWii/3D/Camera/CameraMgr.hpp>
 #include <MarioKartWii/3D/Camera/RaceCamera.hpp>
 #include <MarioKartWii/UI/Section/SectionMgr.hpp>
-#include <MarioKartWii/Race/Raceinfo/Raceinfo.hpp>
+#include <MarioKartWii/Race/RaceInfo/RaceInfo.hpp>
 #include <Gamemodes/KO/KOMgr.hpp>
 
 namespace Pulsar {

--- a/PulsarEngine/RetroRewind.cpp
+++ b/PulsarEngine/RetroRewind.cpp
@@ -1,4 +1,4 @@
-#include <MarioKartWii/Race/Racedata.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
 #include <SlotExpansion/CupsConfig.hpp>
 #include <Settings/UI/SettingsPanel.hpp>
 #include <Settings/Settings.hpp>

--- a/PulsarEngine/SlotExpansion/CupsConfig.hpp
+++ b/PulsarEngine/SlotExpansion/CupsConfig.hpp
@@ -1,7 +1,7 @@
 #ifndef _CUPSDEF_
 #define _CUPSDEF_
 #include <kamek.hpp>
-#include <MarioKartWii/Race/Racedata.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
 #include <MarioKartWii/System/Identifiers.hpp>
 #include <MarioKartWii/System/Random.hpp>
 #include <Config.hpp>

--- a/PulsarEngine/SlotExpansion/SlotProperties.cpp
+++ b/PulsarEngine/SlotExpansion/SlotProperties.cpp
@@ -2,64 +2,76 @@
 #include <kamek.hpp>
 #include <MarioKartWii/Archive/ArchiveMgr.hpp>
 #include <MarioKartWii/Effect/EffectMgr.hpp>
-#include <MarioKartWii/Race/Racedata.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
 #include <MarioKartWii/3D/Model/MatModelDirector.hpp>
 
-namespace Pulsar {
-//A bunch of patches to prevent common slot related crashes
-kmWrite32(0x8068dfc8, 0x60000000);
-KartType PreventRSLCrash(Effects::Player* effects, const Kart::Link& link) {
-    bool isSherbet = true;
-    if(Racedata::sInstance->racesScenario.settings.courseId != N64_SHERBET_LAND
-        || ArchiveMgr::sInstance->GetFile(ARCHIVE_HOLDER_COURSE, "ice.brres", 0) == nullptr) isSherbet = false;
-    effects->isSL = isSherbet;
-    return link.GetType();
-}
-kmCall(0x8068dfcc, PreventRSLCrash);
-kmWrite32(0x8068e2b0, 0x60000000);
+namespace Pulsar
+{
+    // A bunch of patches to prevent common slot related crashes
+    kmWrite32(0x8068dfc8, 0x60000000);
+    KartType PreventRSLCrash(Effects::Player *effects, const Kart::Link &link)
+    {
+        bool isSherbet = true;
+        if (Racedata::sInstance->racesScenario.settings.courseId != N64_SHERBET_LAND || ArchiveMgr::sInstance->GetFile(ARCHIVE_HOLDER_COURSE, "ice.brres", 0) == nullptr)
+            isSherbet = false;
+        effects->isSL = isSherbet;
+        return link.GetType();
+    }
+    kmCall(0x8068dfcc, PreventRSLCrash);
+    kmWrite32(0x8068e2b0, 0x60000000);
 
-static void* PreventRSBCrash(u32 shipManagerSize) {
-    if(ArchiveMgr::sInstance->GetFile(ARCHIVE_HOLDER_COURSE, "HeyhoShipGBA.brres", 0) == nullptr) return nullptr;
-    return new u8[shipManagerSize];
-}
-kmCall(0x80827a34, PreventRSBCrash);
-kmWrite32(0x80827a3c, 0x41820018); //if ptr is nullptr, skip rSGB section
+    static void *PreventRSBCrash(u32 shipManagerSize)
+    {
+        if (ArchiveMgr::sInstance->GetFile(ARCHIVE_HOLDER_COURSE, "HeyhoShipGBA.brres", 0) == nullptr)
+            return nullptr;
+        return new u8[shipManagerSize];
+    }
+    kmCall(0x80827a34, PreventRSBCrash);
+    kmWrite32(0x80827a3c, 0x41820018); // if ptr is nullptr, skip rSGB section
 
-static void* PreventMHCrash(u32 carManagerSize) {
-    const ArchiveMgr* root = ArchiveMgr::sInstance;
-    if(root->GetFile(ARCHIVE_HOLDER_COURSE, "K_car_body.brres") == nullptr
-        || root->GetFile(ARCHIVE_HOLDER_COURSE, "K_truck.brres") == nullptr) return nullptr;
-    return new u8[carManagerSize];
-}
-kmCall(0x808279ac, PreventMHCrash);
-kmWrite32(0x808279b4, 0x41820018); //if ptr is nullptr, skip MH section
+    static void *PreventMHCrash(u32 carManagerSize)
+    {
+        const ArchiveMgr *root = ArchiveMgr::sInstance;
+        if (root->GetFile(ARCHIVE_HOLDER_COURSE, "K_car_body.brres") == nullptr || root->GetFile(ARCHIVE_HOLDER_COURSE, "K_truck.brres") == nullptr)
+            return nullptr;
+        return new u8[carManagerSize];
+    }
+    kmCall(0x808279ac, PreventMHCrash);
+    kmWrite32(0x808279b4, 0x41820018); // if ptr is nullptr, skip MH section
 
-static bool PreventMHMatCrash(const Racedata& racedata) {
-    if(racedata.racesScenario.settings.courseId != MOONVIEW_HIGHWAY) return false;
-    nw4r::g3d::ResFile file;
-    file.data = reinterpret_cast<nw4r::g3d::ResFileData*>(ArchiveMgr::sInstance->GetFile(ARCHIVE_HOLDER_COURSE, "course_model.brres", 0));
-    nw4r::g3d::ResMdl mdl = file.GetResMdl("course");
-    for(int i = 0; i < 12; ++i) if(mdl.GetResMat(MHModelDirector::matNames[i]).data == nullptr) return false;
-    return true;
-}
-kmCall(0x8078e1ec, PreventMHMatCrash);
-kmWrite32(0x8078e1f0, 0x2c030001); //compare r3
+    static bool PreventMHMatCrash(const Racedata &racedata)
+    {
+        if (racedata.racesScenario.settings.courseId != MOONVIEW_HIGHWAY)
+            return false;
+        nw4r::g3d::ResFile file;
+        file.data = reinterpret_cast<nw4r::g3d::ResFileData *>(ArchiveMgr::sInstance->GetFile(ARCHIVE_HOLDER_COURSE, "course_model.brres", 0));
+        nw4r::g3d::ResMdl mdl = file.GetResMdl("course");
+        for (int i = 0; i < 12; ++i)
+            if (mdl.GetResMat(MHModelDirector::matNames[i]).data == nullptr)
+                return false;
+        return true;
+    }
+    kmCall(0x8078e1ec, PreventMHMatCrash);
+    kmWrite32(0x8078e1f0, 0x2c030001); // compare r3
 
+    // Loads ObjFlow/GeoTable binaries from the track; if they do not exist, gets them from common as per usual
+    const void *GetCommonBinary(const ArchiveMgr &root, ArchiveSource source, const char *name)
+    {
+        const void *binary = root.GetFile(ARCHIVE_HOLDER_COURSE, name);
+        if (binary == nullptr)
+            binary = root.GetFile(ARCHIVE_HOLDER_COMMON, name);
+        return binary;
+    }
+    kmCall(0x8082c140, GetCommonBinary); // ObjFlow
+    kmCall(0x807f92ac, GetCommonBinary); // GeoHitTables
 
-//Loads ObjFlow/GeoTable binaries from the track; if they do not exist, gets them from common as per usual
-const void* GetCommonBinary(const ArchiveMgr& root, ArchiveSource source, const char* name) {
-    const void* binary = root.GetFile(ARCHIVE_HOLDER_COURSE, name);
-    if(binary == nullptr) binary = root.GetFile(ARCHIVE_HOLDER_COMMON, name);
-    return binary;
-}
-kmCall(0x8082c140, GetCommonBinary); //ObjFlow
-kmCall(0x807f92ac, GetCommonBinary); //GeoHitTables
-
-//Uses the 2nd KTPT entry (if it exists in the KMP) to draw the finish line on the minimap
-const KMP::Holder<KTPT>* SecondaryKTPT(const KMP::Manager& manager, u32 idx) {
-    const KMP::Holder<KTPT>* holder = manager.GetHolder<KTPT>(1);
-    if(holder == nullptr) holder = manager.GetHolder<KTPT>(0);
-    return holder;
-}
-kmCall(0x807ea670, SecondaryKTPT);
-}//namespace Pulsar
+    // Uses the 2nd KTPT entry (if it exists in the KMP) to draw the finish line on the minimap
+    const KMP::Holder<KTPT> *SecondaryKTPT(const KMP::Manager &manager, u32 idx)
+    {
+        const KMP::Holder<KTPT> *holder = manager.GetHolder<KTPT>(1);
+        if (holder == nullptr)
+            holder = manager.GetHolder<KTPT>(0);
+        return holder;
+    }
+    kmCall(0x807ea670, SecondaryKTPT);
+} // namespace Pulsar

--- a/PulsarEngine/Sound/BRSTMSpeedUp.cpp
+++ b/PulsarEngine/Sound/BRSTMSpeedUp.cpp
@@ -1,59 +1,68 @@
 #include <kamek.hpp>
-#include <MarioKartWii/Race/Raceinfo/Raceinfo.hpp>
+#include <MarioKartWii/Race/RaceInfo/RaceInfo.hpp>
 #include <MarioKartWii/Audio/RSARPlayer.hpp>
 #include <MarioKartWii/Audio/RaceMgr.hpp>
 #include <MarioKartWii/Audio/Actors/KartActor.hpp>
 #include <MarioKartWii/UI/Ctrl/CtrlRace/CtrlRaceGhostDiffTime.hpp>
 #include <Settings/Settings.hpp>
 
-
 /*Music speedup:
 When the player reaches the final lap (if the track has >1 laps) and if the setting is set, the music will
 speedup instead of transitioning to the _f file. The jingle will still play.
 */
 
-namespace Pulsar {
-namespace Sound {
+namespace Pulsar
+{
+    namespace Sound
+    {
 
-using namespace nw4r;
-static void MusicSpeedup(Audio::RaceRSARPlayer* rsarSoundPlayer, u32 jingle, u8 hudSlotId) {
-    //static u8 hudSlotIdFinalLap;
+        using namespace nw4r;
+        static void MusicSpeedup(Audio::RaceRSARPlayer *rsarSoundPlayer, u32 jingle, u8 hudSlotId)
+        {
+            // static u8 hudSlotIdFinalLap;
 
-    u8 isSpeedUp = Settings::Mgr::Get().GetSettingValue(Settings::SETTINGSTYPE_RACE, SETTINGRACE_RADIO_SPEEDUP);
-    Audio::RaceMgr* raceAudioMgr = Audio::RaceMgr::sInstance;
-    const u8 maxLap = raceAudioMgr->maxLap;
-    const u8 curLap = raceAudioMgr->lap;
-    const RacedataSettings& raceDataSettings = Racedata::sInstance->racesScenario.settings;
-    //const u8 idFirstFinalLap = hudSlotIdFinalLap;
-    if(maxLap == 1) return;
-    if(maxLap == raceDataSettings.lapCount) {
+            u8 isSpeedUp = Settings::Mgr::Get().GetSettingValue(Settings::SETTINGSTYPE_RACE, SETTINGRACE_RADIO_SPEEDUP);
+            Audio::RaceMgr *raceAudioMgr = Audio::RaceMgr::sInstance;
+            const u8 maxLap = raceAudioMgr->maxLap;
+            const u8 curLap = raceAudioMgr->lap;
+            const RacedataSettings &raceDataSettings = Racedata::sInstance->racesScenario.settings;
+            // const u8 idFirstFinalLap = hudSlotIdFinalLap;
+            if (maxLap == 1)
+                return;
+            if (maxLap == raceDataSettings.lapCount)
+            {
 
-        register Audio::KartActor* kartActor;
-        asm(mr kartActor, r29;);
-        snd::detail::BasicSound& sound =  kartActor->soundArchivePlayer->soundPlayerArray[0].soundList.GetFront();
-        if(isSpeedUp == RACESETTING_SPEEDUP_ENABLED || sound.soundId == SOUND_ID_GALAXY_COLOSSEUM) {
-            const Raceinfo* raceInfo = Raceinfo::sInstance;
-            const Timer& raceTimer = raceInfo->timerMgr->timers[0];
-            const Timer& playerTimer = raceInfo->players[raceDataSettings.hudPlayerIds[hudSlotId]]->lapSplits[maxLap - 2];
-            const Timer difference = CtrlRaceGhostDiffTime::SubtractTimers(raceTimer, playerTimer);
-            if(difference.minutes < 1 && difference.seconds < 5) {
-                sound.ambientParam.pitch += 0.0002f;
+                register Audio::KartActor *kartActor;
+                asm(mr kartActor, r29;);
+                snd::detail::BasicSound &sound = kartActor->soundArchivePlayer->soundPlayerArray[0].soundList.GetFront();
+                if (isSpeedUp == RACESETTING_SPEEDUP_ENABLED || sound.soundId == SOUND_ID_GALAXY_COLOSSEUM)
+                {
+                    const Raceinfo *raceInfo = Raceinfo::sInstance;
+                    const Timer &raceTimer = raceInfo->timerMgr->timers[0];
+                    const Timer &playerTimer = raceInfo->players[raceDataSettings.hudPlayerIds[hudSlotId]]->lapSplits[maxLap - 2];
+                    const Timer difference = CtrlRaceGhostDiffTime::SubtractTimers(raceTimer, playerTimer);
+                    if (difference.minutes < 1 && difference.seconds < 5)
+                    {
+                        sound.ambientParam.pitch += 0.0002f;
+                    }
+                    if (maxLap != curLap)
+                        rsarSoundPlayer->PlaySound(SOUND_ID_FINAL_LAP, hudSlotId);
+                }
+                else if ((maxLap != curLap) && (raceAudioMgr->raceState == 0x4 || raceAudioMgr->raceState == 0x6))
+                {
+                    raceAudioMgr->SetRaceState(Audio::RACE_STATE_FAST);
+                }
             }
-            if(maxLap != curLap) rsarSoundPlayer->PlaySound(SOUND_ID_FINAL_LAP, hudSlotId);
+            else if (maxLap != curLap)
+            {
+                rsarSoundPlayer->PlaySound(SOUND_ID_NORMAL_LAP, hudSlotId);
+                // hudSlotIdFinalLap = raceAudioMgr->playerIdFirstLocalPlayer;
+            }
+            return;
         }
-        else if((maxLap != curLap) && (raceAudioMgr->raceState == 0x4 || raceAudioMgr->raceState == 0x6)) {
-            raceAudioMgr->SetRaceState(Audio::RACE_STATE_FAST);
-        }
-    }
-    else if(maxLap != curLap) {
-        rsarSoundPlayer->PlaySound(SOUND_ID_NORMAL_LAP, hudSlotId);
-        //hudSlotIdFinalLap = raceAudioMgr->playerIdFirstLocalPlayer;
-    }
-    return;
-}
-kmCall(0x8070b2f8, MusicSpeedup);
-kmWrite32(0x8070b2c0, 0x60000000);
-kmWrite32(0x8070b2d4, 0x60000000);
+        kmCall(0x8070b2f8, MusicSpeedup);
+        kmWrite32(0x8070b2c0, 0x60000000);
+        kmWrite32(0x8070b2d4, 0x60000000);
 
-}//namespace Sound
-}//namespace Pulsar
+    } // namespace Sound
+} // namespace Pulsar

--- a/PulsarEngine/UI/BootIntoSection.cpp
+++ b/PulsarEngine/UI/BootIntoSection.cpp
@@ -1,90 +1,105 @@
 #include <kamek.hpp>
-#include <core/rvl/pad.hpp>
-#include <core/rvl/kpad.hpp>
+#include <core/rvl/PAD.hpp>
+#include <core/rvl/KPAD.hpp>
 #include <core/System/SystemManager.hpp>
 #include <MarioKartWii/Input/InputManager.hpp>
 #include <MarioKartWii/UI/Section/SectionMgr.hpp>
 #include <MarioKartWii/System/NdevArgsExtractor.hpp>
 #include <Settings/Settings.hpp>
 
-namespace Pulsar {
-//Implements the boot into wiimmfi setting
-static u16 controllerOnStrap = 0x0;
+namespace Pulsar
+{
+    // Implements the boot into wiimmfi setting
+    static u16 controllerOnStrap = 0x0;
 
-kmWrite32(0x8000785c, 0x3be00002); //li r31, 2 if KPAD controller was used
-static bool CheckControllerStrap() {
-    //"unsafe" function that relies on no stack frame being created, which is essentially guaranteed as this doesn't call any other function
-    //I just prefer it to the asm version
-    register u32 ret;
-    asm(mr ret, r31;);
-    if(ret == 0) return false;
-    register u8 usedChannel;
-    u16 type = 0x24;
-    if(ret == 1) { //GCN
-        register PAD::Status* gcnStatus;
-        asm(addi gcnStatus, sp, 0x10;);
-        for(u8 channel = 0; channel < 4; ++channel) {
-            if(gcnStatus[channel].buttons != 0) {
-                usedChannel = channel + 1;
-                break;
+    kmWrite32(0x8000785c, 0x3be00002); // li r31, 2 if KPAD controller was used
+    static bool CheckControllerStrap()
+    {
+        //"unsafe" function that relies on no stack frame being created, which is essentially guaranteed as this doesn't call any other function
+        // I just prefer it to the asm version
+        register u32 ret;
+        asm(mr ret, r31;);
+        if (ret == 0)
+            return false;
+        register u8 usedChannel;
+        u16 type = 0x24;
+        if (ret == 1)
+        { // GCN
+            register PAD::Status *gcnStatus;
+            asm(addi gcnStatus, sp, 0x10;);
+            for (u8 channel = 0; channel < 4; ++channel)
+            {
+                if (gcnStatus[channel].buttons != 0)
+                {
+                    usedChannel = channel + 1;
+                    break;
+                }
             }
         }
+        else if (ret == 2)
+        { // ret == 2, KPAD controller
+            asm(mr usedChannel, r29;);
+            register KPAD::Status *kpadStatus;
+            asm(addi kpadStatus, sp, 0x40;);
+            type = kpadStatus->extension + 0x11;
+        }
+        controllerOnStrap = (usedChannel << 8) + type;
+        return true;
     }
-    else if(ret == 2) { //ret == 2, KPAD controller
-        asm(mr usedChannel, r29;);
-        register KPAD::Status* kpadStatus;
-        asm(addi kpadStatus, sp, 0x40;);
-        type = kpadStatus->extension + 0x11;
-    }
-    controllerOnStrap = (usedChannel << 8) + type;
-    return true;
-}
-kmCall(0x800079b0, CheckControllerStrap);
+    kmCall(0x800079b0, CheckControllerStrap);
 
-char bootParams[17];
-SectionId BootIntoSection(const NdevArgsExtractor& extractor) {
-    SectionId section = SECTION_NONE;
-    const u8 bootSetting = Settings::Mgr::Get().GetSettingValue(Settings::SETTINGSTYPE_MENU, SETTINGMENU_SCROLL_BOOT);
-    u8 license = 0;
-    if(bootSetting != MENUSETTING_BOOT_DISABLED) {
-        const RKSYS::Mgr* rksysMgr = RKSYS::Mgr::sInstance;
-        if(rksysMgr->CheckLicenseMagic(bootSetting - 1)) {
-            const RKSYS::LicenseMgr* licenseMgr = &rksysMgr->licenses[bootSetting - 1];
-            if(licenseMgr->createID.miiId != 0) {
-                section = SECTION_P1_WIFI;
-                //section = SECTION_SINGLE_PLAYER_FROM_MENU;
-                license = bootSetting - 1;
+    char bootParams[17];
+    SectionId BootIntoSection(const NdevArgsExtractor &extractor)
+    {
+        SectionId section = SECTION_NONE;
+        const u8 bootSetting = Settings::Mgr::Get().GetSettingValue(Settings::SETTINGSTYPE_MENU, SETTINGMENU_SCROLL_BOOT);
+        u8 license = 0;
+        if (bootSetting != MENUSETTING_BOOT_DISABLED)
+        {
+            const RKSYS::Mgr *rksysMgr = RKSYS::Mgr::sInstance;
+            if (rksysMgr->CheckLicenseMagic(bootSetting - 1))
+            {
+                const RKSYS::LicenseMgr *licenseMgr = &rksysMgr->licenses[bootSetting - 1];
+                if (licenseMgr->createID.miiId != 0)
+                {
+                    section = SECTION_P1_WIFI;
+                    // section = SECTION_SINGLE_PLAYER_FROM_MENU;
+                    license = bootSetting - 1;
+                }
             }
         }
+        snprintf(bootParams, 17, "-s132 -l%d -p%d", license, controllerOnStrap);
+        SystemManager::sInstance->ndevArg = bootParams;
+        extractor.ExtractAllArgs();
+        return section;
     }
-    snprintf(bootParams, 17, "-s132 -l%d -p%d", license, controllerOnStrap);
-    SystemManager::sInstance->ndevArg = bootParams;
-    extractor.ExtractAllArgs();
-    return section;
-}
-kmCall(0x80634f20, BootIntoSection);
+    kmCall(0x80634f20, BootIntoSection);
 
-//kmWrite32(0x805243e4, 0x7F65DB78); //mr r5, r27 to get slot
-using namespace Input;
-//r4 usually uses Input::Manager dummy which is slot and controller independant
-static void SetUpCorrectController(RealControllerHolder* realControllerHolder, Controller* controller) {
-    SectionPad& pad = SectionMgr::sInstance->pad;
-    const u32 controllerID = pad.padInfos[0].controllerID;  //technically hooking into a loop 
-    const ControllerType controllerType = pad.GetType(pad.padInfos[0].controllerID);
-    u32 channel = ((pad.padInfos[0].controllerID & 0xFF00) >> 0x8) - 1; //to make it 0-indexed
-    register u32 loopIndex;
-    asm(mr loopIndex, r27;);
-    if(channel == loopIndex) {
-        register Manager* input;
-        asm(mr input, r30;);
-        if(controllerType == GCN) controller = &input->gcnControllers[channel];
-        else controller = &input->wiiControllers[channel];
-        pad.padInfos[0].controllerHolder = realControllerHolder;
-        pad.padInfos[0].controllerIDActive = pad.padInfos[0].controllerID;
+    // kmWrite32(0x805243e4, 0x7F65DB78); //mr r5, r27 to get slot
+    using namespace Input;
+    // r4 usually uses Input::Manager dummy which is slot and controller independant
+    static void SetUpCorrectController(RealControllerHolder *realControllerHolder, Controller *controller)
+    {
+        SectionPad &pad = SectionMgr::sInstance->pad;
+        const u32 controllerID = pad.padInfos[0].controllerID; // technically hooking into a loop
+        const ControllerType controllerType = pad.GetType(pad.padInfos[0].controllerID);
+        u32 channel = ((pad.padInfos[0].controllerID & 0xFF00) >> 0x8) - 1; // to make it 0-indexed
+        register u32 loopIndex;
+        asm(mr loopIndex, r27;);
+        if (channel == loopIndex)
+        {
+            register Manager *input;
+            asm(mr input, r30;);
+            if (controllerType == GCN)
+                controller = &input->gcnControllers[channel];
+            else
+                controller = &input->wiiControllers[channel];
+            pad.padInfos[0].controllerHolder = realControllerHolder;
+            pad.padInfos[0].controllerIDActive = pad.padInfos[0].controllerID;
+        }
+        realControllerHolder->SetController(controller, nullptr);
     }
-    realControllerHolder->SetController(controller, nullptr);
-}
-kmCall(0x805243f4, SetUpCorrectController);
-//kmWrite32(0x8061af98, 0x60000000); silent controller changing
+    kmCall(0x805243f4, SetUpCorrectController);
+    // kmWrite32(0x8061af98, 0x60000000); silent controller changing
 
-}//namespace Pulsar
+} // namespace Pulsar

--- a/PulsarEngine/UI/ExtendedTeamSelect/ExtendedTeamManager.hpp
+++ b/PulsarEngine/UI/ExtendedTeamSelect/ExtendedTeamManager.hpp
@@ -3,171 +3,201 @@
 
 #include <UI/UI.hpp>
 #include <PulsarSystem.hpp>
-#include <MarioKartwii/UI/Ctrl/CountDown.hpp>
+#include <MarioKartWii/UI/Ctrl/CountDown.hpp>
 #include <MarioKartWii/RKNet/RKNetController.hpp>
 #include <MarioKartWii/RKNet/ROOM.hpp>
 
-namespace Pulsar {
-namespace UI {
+namespace Pulsar
+{
+    namespace UI
+    {
 
-enum ExtendedTeamID {
-    TEAM_RED,
-    TEAM_ORANGE,
-    TEAM_YELLOW,
-    TEAM_GREEN,
-    TEAM_BLUE,
-    TEAM_PURPLE,
-    TEAM_COUNT
-};
-struct ExtendedTeamPlayer {
-    u32 playerIdx;
-    u32 miiIdx;
-    u32 aid;
-    u32 playerIdOnConsole;
-    u32 active;
-    u32 done;
-    ExtendedTeamID team;
-};
+        enum ExtendedTeamID
+        {
+            TEAM_RED,
+            TEAM_ORANGE,
+            TEAM_YELLOW,
+            TEAM_GREEN,
+            TEAM_BLUE,
+            TEAM_PURPLE,
+            TEAM_COUNT
+        };
+        struct ExtendedTeamPlayer
+        {
+            u32 playerIdx;
+            u32 miiIdx;
+            u32 aid;
+            u32 playerIdOnConsole;
+            u32 active;
+            u32 done;
+            ExtendedTeamID team;
+        };
 
-class ExtendedTeamManager {
-public:
-    enum ExtendedROOMMessageType {
-        MSG_TYPE_START_RACE = 0x81,
-        MSG_TYPE_UPDATE_TEAMS = 0x82,
-        MSG_TYPE_PING = 0x83,
-        MSG_TYPE_ACK_START_RACE = 0x84
-    };
+        class ExtendedTeamManager
+        {
+        public:
+            enum ExtendedROOMMessageType
+            {
+                MSG_TYPE_START_RACE = 0x81,
+                MSG_TYPE_UPDATE_TEAMS = 0x82,
+                MSG_TYPE_PING = 0x83,
+                MSG_TYPE_ACK_START_RACE = 0x84
+            };
 
-    enum Status {
-        STATUS_NONE,
-        STATUS_WAITING_PRE,
-        STATUS_SELECTING,
-        STATUS_WAITING_POST,
-        STATUS_DONE
-    };
+            enum Status
+            {
+                STATUS_NONE,
+                STATUS_WAITING_PRE,
+                STATUS_SELECTING,
+                STATUS_WAITING_POST,
+                STATUS_DONE
+            };
 
-    static ExtendedTeamManager* sInstance;
-    static void CreateInstance(ExtendedTeamManager* obj);
-    static void DestroyInstance();
+            static ExtendedTeamManager *sInstance;
+            static void CreateInstance(ExtendedTeamManager *obj);
+            static void DestroyInstance();
 
-    ExtendedTeamManager();
+            ExtendedTeamManager();
 
-    void SetPlayerTeam(u32 idx, ExtendedTeamID team) {
-        this->players[idx].team = team;
-    }
-
-    void SetPlayerIndexes(u32 idx, u32 miiIdx, u32 aid, u32 playerIdOnConsole) {
-        this->players[idx].playerIdx = idx;
-        this->players[idx].miiIdx = miiIdx;
-        this->players[idx].aid = aid;
-        this->players[idx].playerIdOnConsole = playerIdOnConsole;
-    }
-
-    ExtendedTeamID GetPlayerTeamDeprecated(u32 idx) {
-        return this->players[idx].team;
-    }
-
-    ExtendedTeamID GetPlayerTeam(u32 idx) {
-        for (int i = 0; i < 12; i++) {
-            if (this->players[i].playerIdx == idx) {
-                return this->players[i].team;
+            void SetPlayerTeam(u32 idx, ExtendedTeamID team)
+            {
+                this->players[idx].team = team;
             }
-        }
-        return TEAM_COUNT;
-    }
 
-    ExtendedTeamID GetPlayerTeamByAID(u8 aid, u8 playerIdOnConsole) {
-        for (int i = 0; i < 12; i++) {
-            if (this->players[i].aid == aid && this->players[i].playerIdOnConsole == playerIdOnConsole) {
-                return this->players[i].team;
+            void SetPlayerIndexes(u32 idx, u32 miiIdx, u32 aid, u32 playerIdOnConsole)
+            {
+                this->players[idx].playerIdx = idx;
+                this->players[idx].miiIdx = miiIdx;
+                this->players[idx].aid = aid;
+                this->players[idx].playerIdOnConsole = playerIdOnConsole;
             }
-        }
-        return TEAM_COUNT;
-    }
 
-    u8 GetPlayerAID(u32 idx, u8 playerIdOnConsole) {
-        return this->players[idx].aid;
-    }
-
-    const ExtendedTeamPlayer* GetPlayerInfo() const {
-        return this->players;
-    }
-
-    void SendStartRacePacket();     // Host
-    void SendUpdateTeamsPacket();   // Host
-    void SendPingPacket();          // Non-Host
-    void SendAckStartRacePacket();  // Non-Host
-
-    void Update();
-    void Reset();
-    void ResetPlayers();
-
-    void VotePageSync();
-
-    Status GetStatus() {
-        return this->status;
-    }
-
-    bool IsInactiveStatus() {
-        return this->status == STATUS_NONE;
-    }
-
-    bool IsWaitingStatus() {
-        return this->status == STATUS_WAITING_PRE || this->status == STATUS_WAITING_POST;
-    }
-
-    bool IsSelectingStatus() {
-        return this->status == STATUS_SELECTING;
-    }
-
-    bool IsDoneStatus() {
-        return this->status == STATUS_DONE;
-    }
-
-    void SetActiveStatusForAID(u8 aid) {
-        for (int i = 0; i < 12; i++) {
-            if (this->players[i].aid == aid) {
-                this->players[i].active = 1;
+            ExtendedTeamID GetPlayerTeamDeprecated(u32 idx)
+            {
+                return this->players[idx].team;
             }
-        }
-    }
 
-    void SetDoneStatusForAID(u8 aid) {
-        for (int i = 0; i < 12; i++) {
-            if (this->players[i].aid == aid) {
-                this->players[i].done = 1;
+            ExtendedTeamID GetPlayerTeam(u32 idx)
+            {
+                for (int i = 0; i < 12; i++)
+                {
+                    if (this->players[i].playerIdx == idx)
+                    {
+                        return this->players[i].team;
+                    }
+                }
+                return TEAM_COUNT;
             }
-        }
-    }
 
-    void SetStatusExternal(Status status) {
-        this->status = status;
-    }
+            ExtendedTeamID GetPlayerTeamByAID(u8 aid, u8 playerIdOnConsole)
+            {
+                for (int i = 0; i < 12; i++)
+                {
+                    if (this->players[i].aid == aid && this->players[i].playerIdOnConsole == playerIdOnConsole)
+                    {
+                        return this->players[i].team;
+                    }
+                }
+                return TEAM_COUNT;
+            }
 
-    static bool IsActivated() {
-        RKNet::RoomType roomType = RKNet::Controller::sInstance->roomType;
-        return System::sInstance->IsContext(PULSAR_EXTENDEDTEAMS) && Racedata::sInstance->menusScenario.settings.gamemode == MODE_PRIVATE_VS && (roomType == RKNet::ROOMTYPE_FROOM_HOST || roomType == RKNet::ROOMTYPE_FROOM_NONHOST);
-    }
+            u8 GetPlayerAID(u32 idx, u8 playerIdOnConsole)
+            {
+                return this->players[idx].aid;
+            }
 
-private:
+            const ExtendedTeamPlayer *GetPlayerInfo() const
+            {
+                return this->players;
+            }
 
-    bool AreAllOtherPlayersActive(u8 localAid);
-    bool AreAllOtherPlayersDone(u8 localAid);
+            void SendStartRacePacket();    // Host
+            void SendUpdateTeamsPacket();  // Host
+            void SendPingPacket();         // Non-Host
+            void SendAckStartRacePacket(); // Non-Host
 
-    ExtendedTeamPlayer players[12];
+            void Update();
+            void Reset();
+            void ResetPlayers();
 
-    bool isHost;
+            void VotePageSync();
 
-    Status status;
+            Status GetStatus()
+            {
+                return this->status;
+            }
 
-public:
-    CountDown waitingTimer;
-    CountDown lastUpdateTimer;
+            bool IsInactiveStatus()
+            {
+                return this->status == STATUS_NONE;
+            }
 
-    u32 hasFriendRoomStarted;
-};
+            bool IsWaitingStatus()
+            {
+                return this->status == STATUS_WAITING_PRE || this->status == STATUS_WAITING_POST;
+            }
 
-} // namespace UI
+            bool IsSelectingStatus()
+            {
+                return this->status == STATUS_SELECTING;
+            }
+
+            bool IsDoneStatus()
+            {
+                return this->status == STATUS_DONE;
+            }
+
+            void SetActiveStatusForAID(u8 aid)
+            {
+                for (int i = 0; i < 12; i++)
+                {
+                    if (this->players[i].aid == aid)
+                    {
+                        this->players[i].active = 1;
+                    }
+                }
+            }
+
+            void SetDoneStatusForAID(u8 aid)
+            {
+                for (int i = 0; i < 12; i++)
+                {
+                    if (this->players[i].aid == aid)
+                    {
+                        this->players[i].done = 1;
+                    }
+                }
+            }
+
+            void SetStatusExternal(Status status)
+            {
+                this->status = status;
+            }
+
+            static bool IsActivated()
+            {
+                RKNet::RoomType roomType = RKNet::Controller::sInstance->roomType;
+                return System::sInstance->IsContext(PULSAR_EXTENDEDTEAMS) && Racedata::sInstance->menusScenario.settings.gamemode == MODE_PRIVATE_VS && (roomType == RKNet::ROOMTYPE_FROOM_HOST || roomType == RKNet::ROOMTYPE_FROOM_NONHOST);
+            }
+
+        private:
+            bool AreAllOtherPlayersActive(u8 localAid);
+            bool AreAllOtherPlayersDone(u8 localAid);
+
+            ExtendedTeamPlayer players[12];
+
+            bool isHost;
+
+            Status status;
+
+        public:
+            CountDown waitingTimer;
+            CountDown lastUpdateTimer;
+
+            u32 hasFriendRoomStarted;
+        };
+
+    } // namespace UI
 } // namespace Pulsar
 
 #endif


### PR DESCRIPTION
Linux enforces case-sensitivity of path-names whereas Windows typically does not. Some IDEs on Linux will complain about `#include` directives having incorrect casing, so this fixes a load of them. This is likely non-exhaustive but this was a lot of what I found.