### PR TITLE
Fix casing of some includes

### DIFF
--- a/GameSource/MarioKartWii/3D/Model/Awards.hpp
+++ b/GameSource/MarioKartWii/3D/Model/Awards.hpp
@@ -7,7 +7,7 @@
 #include <MarioKartWii/3D/Model/ModelDirector.hpp>
 #include <MarioKartWii/3D/Model/ShadowModelDirector.hpp>
 #include <MarioKartWii/Mii/MiiHeadsModel.hpp>
-#include <MarioKartWii/Race/Racedata.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
 
 using namespace nw4r;
 

--- a/GameSource/MarioKartWii/Archive/ArchiveHolder.hpp
+++ b/GameSource/MarioKartWii/Archive/ArchiveHolder.hpp
@@ -5,7 +5,7 @@
 #include <core/egg/mem/ExpHeap.hpp>
 #include <core/egg/mem/Disposer.hpp>
 #include <core/egg/Thread.hpp>
-#include <MarioKartWii/System/identifiers.hpp>
+#include <MarioKartWii/System/Identifiers.hpp>
 #include <MarioKartWii/Archive/ArchiveFile.hpp>
 
 class LayoutResources;

--- a/GameSource/MarioKartWii/Audio/Actors/CharacterActor.hpp
+++ b/GameSource/MarioKartWii/Audio/Actors/CharacterActor.hpp
@@ -1,7 +1,7 @@
 #ifndef _CHARACTERACTOR_
 #define _CHARACTERACTOR_
 #include <kamek.hpp>
-#include <MarioKartWii/Race/Racedata.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
 #include <MarioKartWii/Audio/Other/RandomAudioMgr.hpp>
 #include <MarioKartWii/Audio/Actors/RaceActor.hpp>
 

--- a/GameSource/MarioKartWii/Audio/RaceMgr.hpp
+++ b/GameSource/MarioKartWii/Audio/RaceMgr.hpp
@@ -2,8 +2,8 @@
 #define _RACEAUDIOMGR_
 #include <kamek.hpp>
 #include <core/nw4r/ut/List.hpp>
-#include <MarioKartWii/Race/racedata.hpp>
-#include <MarioKartWii/System/timer.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
+#include <MarioKartWii/System/Timer.hpp>
 #include <MarioKartWii/Audio/Other/AudioValues.hpp>
 #include <MarioKartWii/Audio/Actors/KartActor.hpp>
 /*

--- a/GameSource/MarioKartWii/Input/Controller.hpp
+++ b/GameSource/MarioKartWii/Input/Controller.hpp
@@ -9,9 +9,9 @@ Contributors:
 #ifndef _INPUT_CONTROLLER_
 #define _INPUT_CONTROLLER_
 #include <kamek.hpp>
-#include <core/rvl/pad.hpp>
-#include <core/rvl/kpad.hpp>
-#include <core/rvl/wpad.hpp>
+#include <core/rvl/PAD.hpp>
+#include <core/rvl/KPAD.hpp>
+#include <core/rvl/WPAD.hpp>
 #include <MarioKartWii/Input/InputState.hpp>
 #include <MarioKartWii/Input/GhostWriter.hpp>
 #include <MarioKartWii/System/Identifiers.hpp>

--- a/GameSource/MarioKartWii/NAND/NandUtils.hpp
+++ b/GameSource/MarioKartWii/NAND/NandUtils.hpp
@@ -1,7 +1,7 @@
 #ifndef _NANDUTILS_
 #define _NANDUTILS_
 #include <kamek.hpp>
-#include <core/rvl/nand.hpp>
+#include <core/rvl/NAND.hpp>
 
 namespace NandUtils {
 enum Result {

--- a/GameSource/MarioKartWii/RKNet/FriendMgr.hpp
+++ b/GameSource/MarioKartWii/RKNet/FriendMgr.hpp
@@ -1,7 +1,7 @@
 #ifndef _RKNETFRIENDMGR_
 #define _RKNETFRIENDMGR_
 #include <kamek.hpp>
-#include <core/rvl/os/OSmutex.hpp>
+#include <core/rvl/OS/OSMutex.hpp>
 #include <core/rvl/DWC/DWC.hpp>
 
 namespace RKNet {

--- a/GameSource/MarioKartWii/Race/RaceInfo/RaceInfo.hpp
+++ b/GameSource/MarioKartWii/Race/RaceInfo/RaceInfo.hpp
@@ -19,8 +19,8 @@ Contributors:
 #include <MarioKartWii/System/ElineManager.hpp>
 #include <MarioKartWii/System/Random.hpp>
 #include <MarioKartWii/Input/ControllerHolder.hpp>
-#include <MarioKartWii/Race/Racedata.hpp>
-#include <MarioKartWii/Race/Raceinfo/GameModeData.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
+#include <MarioKartWii/Race/RaceInfo/GameModeData.hpp>
 
 enum RaceStage {
     RACESTAGE_INTRO,

--- a/GameSource/MarioKartWii/System/CINS.hpp
+++ b/GameSource/MarioKartWii/System/CINS.hpp
@@ -1,7 +1,7 @@
 #ifndef _CHANNELINSTALLER_
 #define _CHANNELINSTALLER_
 #include <kamek.hpp>
-#include <core/rvl/os/OSTitle.hpp>
+#include <core/rvl/OS/OSTitle.hpp>
 #include <core/egg/mem/Disposer.hpp>
 #include <core/egg/mem/Heap.hpp>
 

--- a/GameSource/MarioKartWii/System/Ghost.hpp
+++ b/GameSource/MarioKartWii/System/Ghost.hpp
@@ -6,7 +6,7 @@
 #include <MarioKartWii/File/RKG.hpp>
 #include <MarioKartWii/Input/Controller.hpp>
 #include <MarioKartWii/Mii/Mii.hpp>
-#include <MarioKartWii/System/identifiers.hpp>
+#include <MarioKartWii/System/Identifiers.hpp>
 #include <MarioKartWii/System/Timer.hpp>
 
 enum GhostGroupType {

--- a/GameSource/MarioKartWii/THP/THPAudio.hpp
+++ b/GameSource/MarioKartWii/THP/THPAudio.hpp
@@ -1,7 +1,7 @@
 #ifndef _THPAUDIO_
 #define _THPAUDIO_
 #include <kamek.hpp>
-#include <core/rvl/os/OSMessage.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
 #include <MarioKartWii/THP/THPStructs.hpp>
 
 namespace THP {

--- a/GameSource/MarioKartWii/THP/THPReading.hpp
+++ b/GameSource/MarioKartWii/THP/THPReading.hpp
@@ -1,7 +1,7 @@
 #ifndef _THPREADING_
 #define _THPREADING_
 #include <kamek.hpp>
-#include <core/rvl/os/OSMessage.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
 
 namespace THP {
 

--- a/GameSource/MarioKartWii/THP/THPStructs.hpp
+++ b/GameSource/MarioKartWii/THP/THPStructs.hpp
@@ -1,9 +1,9 @@
 #ifndef _THPSTRUCTS_
 #define _THPSTRUCTS_
 #include <kamek.hpp>
-#include <core/rvl/os/OSMessage.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
 #include <core/rvl/dvd/dvd.hpp>
-#include <core/rvl/VI/vi.hpp>
+#include <core/rvl/VI/VI.hpp>
 #include <core/rvl/AI.hpp>
 #include <core/rvl/gx/GXStruct.hpp>
 #include <MarioKartWii/THP/THPFile.hpp>

--- a/GameSource/MarioKartWii/THP/THPVideo.hpp
+++ b/GameSource/MarioKartWii/THP/THPVideo.hpp
@@ -1,7 +1,7 @@
 #ifndef _THPVIDEO_
 #define _THPVIDEO_
 #include <kamek.hpp>
-#include <core/rvl/os/OSMessage.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
 #include <MarioKartWii/THP/THPStructs.hpp>
 
 namespace THP {

--- a/GameSource/MarioKartWii/UI/Ctrl/CtrlRace/CtrlRaceBase.hpp
+++ b/GameSource/MarioKartWii/UI/Ctrl/CtrlRace/CtrlRaceBase.hpp
@@ -2,7 +2,7 @@
 #define _CTRLRACEBASE_
 #include <MarioKartWii/UI/Ctrl/UIControl.hpp>
 #include <MarioKartWii/UI/Section/SectionMgr.hpp>
-#include <MarioKartWii/Race/Racedata.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
 
 
 class CtrlRaceBase : public LayoutUIControl { //one element is one CtrlRaceBase

--- a/GameSource/MarioKartWii/UI/Page/Menu/KartSelect.hpp
+++ b/GameSource/MarioKartWii/UI/Page/Menu/KartSelect.hpp
@@ -5,8 +5,8 @@
 #include <MarioKartWii/UI/Page/Page.hpp>
 #include <MarioKartWii/UI/Page/Menu/Menu.hpp>
 #include <MarioKartWii/UI/Ctrl/Menu/CtrlMenuMachineGraph.hpp>
-#include <MarioKartWii/Race/racedata.hpp>
-#include <MarioKartWii/System/identifiers.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
+#include <MarioKartWii/System/Identifiers.hpp>
 #include <MarioKartWii/UI/Ctrl/ModelControl.hpp>
 #include <MarioKartWii/UI/Ctrl/CountDown.hpp>
 

--- a/GameSource/MarioKartWii/UI/Page/Menu/MultiKartSelect.hpp
+++ b/GameSource/MarioKartWii/UI/Page/Menu/MultiKartSelect.hpp
@@ -5,8 +5,8 @@
 #include <MarioKartWii/UI/Page/Page.hpp>
 #include <MarioKartWii/UI/Page/Menu/Menu.hpp>
 #include <MarioKartWii/UI/Ctrl/Menu/CtrlMenuMachineGraph.hpp>
-#include <MarioKartWii/Race/racedata.hpp>
-#include <MarioKartWii/System/identifiers.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
+#include <MarioKartWii/System/Identifiers.hpp>
 #include <MarioKartWii/UI/Ctrl/ModelControl.hpp>
 #include <MarioKartWii/UI/Ctrl/CountDown.hpp>
 #include <MarioKartWii/UI/Ctrl/UpDown.hpp>

--- a/GameSource/MarioKartWii/UI/Section/SectionParams.hpp
+++ b/GameSource/MarioKartWii/UI/Section/SectionParams.hpp
@@ -2,7 +2,7 @@
 #define _SECTIONPARAMS_
 #include <kamek.hpp>
 #include <MarioKartWii/System/Identifiers.hpp>
-#include <MarioKartWii/MII/MiiGroup.hpp>
+#include <MarioKartWii/Mii/MiiGroup.hpp>
 
 struct PlayerCombo {
     CharacterId selCharacter;

--- a/GameSource/core/egg/Audio/ArcPlayer.hpp
+++ b/GameSource/core/egg/Audio/ArcPlayer.hpp
@@ -3,8 +3,8 @@
 
 #include <types.hpp>
 #include <core/nw4r/snd.hpp>
-#include <core/rvl/os/OSthread.hpp>
-#include <core/rvl/os/OSmessage.hpp>
+#include <core/rvl/OS/OSthread.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
 #include <core/rvl/arc/arc.hpp>
 #include <core/egg/mem/Heap.hpp>
 

--- a/GameSource/core/egg/Audio/Audio3DActor.hpp
+++ b/GameSource/core/egg/Audio/Audio3DActor.hpp
@@ -3,8 +3,8 @@
 
 #include <types.hpp>
 #include <core/nw4r/snd.hpp>
-#include <core/rvl/os/OSthread.hpp>
-#include <core/rvl/os/OSmessage.hpp>
+#include <core/rvl/OS/OSthread.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
 #include <core/rvl/arc/arc.hpp>
 #include <core/egg/mem/Heap.hpp>
 

--- a/GameSource/core/egg/Audio/AudioFx.hpp
+++ b/GameSource/core/egg/Audio/AudioFx.hpp
@@ -3,8 +3,8 @@
 
 #include <types.hpp>
 #include <core/nw4r/snd.hpp>
-#include <core/rvl/os/OSthread.hpp>
-#include <core/rvl/os/OSmessage.hpp>
+#include <core/rvl/OS/OSthread.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
 #include <core/rvl/arc/arc.hpp>
 #include <core/egg/mem/Heap.hpp>
 

--- a/GameSource/core/egg/Audio/AudioHeap.hpp
+++ b/GameSource/core/egg/Audio/AudioHeap.hpp
@@ -3,8 +3,8 @@
 
 #include <types.hpp>
 #include <core/nw4r/snd.hpp>
-#include <core/rvl/os/OSthread.hpp>
-#include <core/rvl/os/OSmessage.hpp>
+#include <core/rvl/OS/OSthread.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
 #include <core/rvl/arc/arc.hpp>
 #include <core/egg/mem/Heap.hpp>
 

--- a/GameSource/core/egg/Audio/AudioMgr.hpp
+++ b/GameSource/core/egg/Audio/AudioMgr.hpp
@@ -3,8 +3,8 @@
 
 #include <types.hpp>
 #include <core/nw4r/snd.hpp>
-#include <core/rvl/os/OSthread.hpp>
-#include <core/rvl/os/OSmessage.hpp>
+#include <core/rvl/OS/OSthread.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
 #include <core/rvl/arc/arc.hpp>
 #include <core/egg/mem/Heap.hpp>
 #include <core/egg/Audio/ArcPlayer.hpp>

--- a/GameSource/core/egg/Audio/AudioTrack.hpp
+++ b/GameSource/core/egg/Audio/AudioTrack.hpp
@@ -3,8 +3,8 @@
 
 #include <types.hpp>
 #include <core/nw4r/snd.hpp>
-#include <core/rvl/os/OSthread.hpp>
-#include <core/rvl/os/OSmessage.hpp>
+#include <core/rvl/OS/OSthread.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
 #include <core/rvl/arc/arc.hpp>
 #include <core/egg/mem/Heap.hpp>
 

--- a/GameSource/core/egg/Audio/AudioUtility.hpp
+++ b/GameSource/core/egg/Audio/AudioUtility.hpp
@@ -3,8 +3,8 @@
 
 #include <types.hpp>
 #include <core/nw4r/snd.hpp>
-#include <core/rvl/os/OSthread.hpp>
-#include <core/rvl/os/OSmessage.hpp>
+#include <core/rvl/OS/OSthread.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
 #include <core/rvl/arc/arc.hpp>
 #include <core/egg/mem/Heap.hpp>
 #include <core/egg/Audio/AudioMgr.hpp>

--- a/GameSource/core/egg/DVD/DvdFile.hpp
+++ b/GameSource/core/egg/DVD/DvdFile.hpp
@@ -1,8 +1,8 @@
 #ifndef _EGGDVDFILE_
 #define _EGGDVDFILE_
 #include <types.hpp>
-#include <core/rvl/os/OSMutex.hpp>
-#include <core/rvl/os/OSMessage.hpp>
+#include <core/rvl/OS/OSMutex.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
 #include <core/rvl/dvd/dvd.hpp>
 #include <core/nw4r/ut/List.hpp>
 

--- a/GameSource/core/egg/System.hpp
+++ b/GameSource/core/egg/System.hpp
@@ -1,8 +1,8 @@
 #ifndef _EGGSYSTEM_
 #define _EGGSYSTEM_
 #include <types.hpp>
-#include <core/rvl/os/OSContext.hpp>
-#include <core/rvl/os/OSAlarm.hpp>
+#include <core/rvl/OS/OSContext.hpp>
+#include <core/rvl/OS/OSAlarm.hpp>
 #include <core/egg/mem/ExpHeap.hpp>
 #include <core/egg/Audio/AudioMgr.hpp>
 #include <core/egg/3D/XFB.hpp>

--- a/GameSource/core/egg/Thread.hpp
+++ b/GameSource/core/egg/Thread.hpp
@@ -1,8 +1,8 @@
 #ifndef _EGG_THREAD_
 #define _EGG_THREAD_
 #include <types.hpp>
-#include <core/rvl/os/OSthread.hpp>
-#include <core/rvl/os/OSmessage.hpp>
+#include <core/rvl/OS/OSthread.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
 #include <core/rvl/mtx/mtx.hpp>
 #include <core/nw4r/ut/LinkList.hpp>
 #include <core/nw4r/ut/List.hpp>

--- a/GameSource/core/nw4r/db/Exception.hpp
+++ b/GameSource/core/nw4r/db/Exception.hpp
@@ -1,8 +1,8 @@
 #ifndef _NW4R_DB_EXCEPTION_
 #define _NW4R_DB_EXCEPTION_
 #include <types.hpp>
-#include <core/rvl/os/OSMessage.hpp>
-#include <core/rvl/os/OSthread.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
+#include <core/rvl/OS/OSthread.hpp>
 #include <core/rvl/gx/GX.hpp>
 #include <core/nw4r/db/Console.hpp>
 

--- a/GameSource/core/nw4r/lyt.hpp
+++ b/GameSource/core/nw4r/lyt.hpp
@@ -10,7 +10,7 @@
 #include <core/nw4r/lyt/lytTypes.hpp>
 #include <core/nw4r/lyt/Material.hpp>
 #include <core/nw4r/lyt/Pane.hpp>
-#include <core/nw4r/lyt/Textbox.hpp>
+#include <core/nw4r/lyt/TextBox.hpp>
 #include <core/nw4r/lyt/Picture.hpp>
 #include <core/nw4r/lyt/Window.hpp>
 #include <core/nw4r/lyt/ResourceAccessor.hpp>

--- a/GameSource/core/nw4r/lyt/Picture.hpp
+++ b/GameSource/core/nw4r/lyt/Picture.hpp
@@ -2,7 +2,7 @@
 #define _NW4R_LYTPICTURE_
 #include <types.hpp>
 #include <core/nw4r/lyt/Pane.hpp>
-#include <core/nw4r/lyt/Common.hpp>
+#include <core/nw4r/lyt/common.hpp>
 #include <core/nw4r/lyt/TexMap.hpp>
 
 namespace nw4r {

--- a/GameSource/core/nw4r/lyt/Window.hpp
+++ b/GameSource/core/nw4r/lyt/Window.hpp
@@ -2,7 +2,7 @@
 #define _NW4R_LYTWINDOW_
 #include <types.hpp>
 #include <core/nw4r/lyt/Pane.hpp>
-#include <core/nw4r/lyt/Common.hpp>
+#include <core/nw4r/lyt/common.hpp>
 #include <core/nw4r/lyt/TexMap.hpp>
 
 namespace nw4r {

--- a/GameSource/core/nw4r/snd/FrameHeap.hpp
+++ b/GameSource/core/nw4r/snd/FrameHeap.hpp
@@ -1,7 +1,7 @@
 #ifndef _NW4R_SNDFRAMEHEAP_
 #define _NW4R_SNDFRAMEHEAP_
 #include <types.hpp>
-#include <core/rvl/os/OSmutex.hpp>
+#include <core/rvl/OS/OSMutex.hpp>
 #include <core/nw4r/ut/LinkList.hpp>
 #include <core/nw4r/snd/DisposeCallbackManager.hpp>
 

--- a/GameSource/core/nw4r/snd/PlayerHeap.hpp
+++ b/GameSource/core/nw4r/snd/PlayerHeap.hpp
@@ -1,7 +1,7 @@
 #ifndef _NW4R_SNDPLAYERHEAP_
 #define _NW4R_SNDPLAYERHEAP_
 #include <types.hpp>
-#include <core/rvl/os/OSmutex.hpp>
+#include <core/rvl/OS/OSMutex.hpp>
 #include <core/nw4r/snd/FrameHeap.hpp>
 #include <core/nw4r/snd/SoundMemoryAllocatable.hpp>
 namespace nw4r {

--- a/GameSource/core/nw4r/snd/SoundArchiveFile.hpp
+++ b/GameSource/core/nw4r/snd/SoundArchiveFile.hpp
@@ -3,7 +3,7 @@
 #include <types.hpp>
 #include <core/nw4r/snd/SoundArchive.hpp>
 #include <core/nw4r/snd/Util.hpp>
-#include <core/rvl/nand.hpp>
+#include <core/rvl/NAND.hpp>
 
 
 

--- a/GameSource/core/nw4r/snd/SoundArchiveLoader.hpp
+++ b/GameSource/core/nw4r/snd/SoundArchiveLoader.hpp
@@ -1,7 +1,7 @@
 #ifndef _NW4R_SNDSOUNDARCHIVELOADER_
 #define _NW4R_SNDSOUNDARCHIVELOADER_
 #include <types.hpp>
-#include <core/rvl/os/OSmutex.hpp>
+#include <core/rvl/OS/OSMutex.hpp>
 #include <core/nw4r/snd/SoundArchive.hpp>
 #include <core/nw4r/ut.hpp>
 #include <core/nw4r/snd/SoundHeap.hpp>

--- a/GameSource/core/nw4r/snd/SoundHeap.hpp
+++ b/GameSource/core/nw4r/snd/SoundHeap.hpp
@@ -1,7 +1,7 @@
 #ifndef _NW4R_SNDHEAP_
 #define _NW4R_SNDHEAP_
 #include <types.hpp>
-#include <core/rvl/os/OSmutex.hpp>
+#include <core/rvl/OS/OSMutex.hpp>
 #include <core/nw4r/snd/FrameHeap.hpp>
 #include <core/nw4r/snd/SoundMemoryAllocatable.hpp>
 namespace  nw4r {

--- a/GameSource/core/nw4r/snd/SoundInstanceManager.hpp
+++ b/GameSource/core/nw4r/snd/SoundInstanceManager.hpp
@@ -2,7 +2,7 @@
 #define _NW4R_SNDSOUNDINSTANCEMANAGER_
 #include <types.hpp>
 #include <core/nw4r/ut/LinkList.hpp>
-#include <core/rvl/os/OSmutex.hpp>
+#include <core/rvl/OS/OSMutex.hpp>
 #include <core/nw4r/snd/BasicSound.hpp>
 #include <core/nw4r/snd/InstancePool.hpp>
 

--- a/GameSource/core/nw4r/snd/SoundSystem.hpp
+++ b/GameSource/core/nw4r/snd/SoundSystem.hpp
@@ -1,7 +1,7 @@
 #ifndef _NW4R_SND_SOUNDSYSTEM_
 #define _NW4R_SND_SOUNDSYSTEM_
 #include <types.hpp>
-#include <core/rvl/os/OSthread.hpp>
+#include <core/rvl/OS/OSthread.hpp>
 
 namespace nw4r {
 namespace snd {

--- a/GameSource/core/nw4r/snd/SoundThread.hpp
+++ b/GameSource/core/nw4r/snd/SoundThread.hpp
@@ -3,9 +3,9 @@
 #include <types.hpp>
 #include <core/nw4r/ut/LinkList.hpp>
 #include <core/nw4r/snd/AxManager.hpp>
-#include <core/rvl/os/OSthread.hpp>
-#include <core/rvl/os/OSMessage.hpp>
-#include <core/rvl/os/OSMutex.hpp>
+#include <core/rvl/OS/OSthread.hpp>
+#include <core/rvl/OS/OSMessage.hpp>
+#include <core/rvl/OS/OSMutex.hpp>
 
 namespace nw4r {
 namespace snd {

--- a/GameSource/core/nw4r/ut/Misc.hpp
+++ b/GameSource/core/nw4r/ut/Misc.hpp
@@ -1,8 +1,8 @@
 #ifndef _NW4R_UT_MISC_
 #define _NW4R_UT_MISC_
 #include <types.hpp>
-#include <core/rvl/os/OS.hpp>
-#include <core/rvl/os/OSMutex.hpp>
+#include <core/rvl/OS/OS.hpp>
+#include <core/rvl/OS/OSMutex.hpp>
 
 namespace nw4r {
 namespace ut {

--- a/GameSource/core/nw4r/ut/RomFont.hpp
+++ b/GameSource/core/nw4r/ut/RomFont.hpp
@@ -2,7 +2,7 @@
 #define _NW4R_UT_ROMFONT_
 #include <types.hpp>
 #include <core/nw4r/ut/Font.hpp>
-#include <core/rvl/os/OSfont.hpp>
+#include <core/rvl/OS/OSFont.hpp>
 
 namespace nw4r {
 namespace ut {

--- a/GameSource/core/nw4r/ut/RuntimeTypeInfo.hpp
+++ b/GameSource/core/nw4r/ut/RuntimeTypeInfo.hpp
@@ -2,7 +2,7 @@
 #define _NW4R_UT_RUNTIMETYPEINFO_
 #include <types.hpp>
 #include <core/nw4r/ut/Font.hpp>
-#include <core/rvl/os/OSfont.hpp>
+#include <core/rvl/OS/OSFont.hpp>
 
 namespace nw4r {
 namespace ut {

--- a/GameSource/core/rvl/DWC/DWCFriend.hpp
+++ b/GameSource/core/rvl/DWC/DWCFriend.hpp
@@ -4,7 +4,7 @@
 #include <types.hpp>
 #include <core/rvl/DWC/DWCAccount.hpp>
 #include <core/rvl/DWC/DWCError.hpp>
-#include <core/rvl/os/OS.hpp>
+#include <core/rvl/OS/OS.hpp>
 
 //Credit Seeky
 

--- a/GameSource/core/rvl/DWC/DWCLogin.hpp
+++ b/GameSource/core/rvl/DWC/DWCLogin.hpp
@@ -4,7 +4,7 @@
 #include <types.hpp>
 #include <core/rvl/DWC/DWCAccount.hpp>
 #include <core/rvl/DWC/DWCError.hpp>
-#include <core/rvl/os/OS.hpp>
+#include <core/rvl/OS/OS.hpp>
 
 //Credit Seeky
 

--- a/GameSource/core/rvl/DWC/DWCMatch.hpp
+++ b/GameSource/core/rvl/DWC/DWCMatch.hpp
@@ -5,7 +5,7 @@
 #include <core/GS/GP/GP.hpp>
 #include <core/rvl/DWC/DWCAccount.hpp>
 #include <core/rvl/DWC/DWCError.hpp>
-#include <core/rvl/os/OS.hpp>
+#include <core/rvl/OS/OS.hpp>
 
 //Credit Seeky
 

--- a/GameSource/core/rvl/DWC/DWCTransport.hpp
+++ b/GameSource/core/rvl/DWC/DWCTransport.hpp
@@ -1,7 +1,7 @@
 #ifndef _DWC_TRANSPORT_ 
 #define _DWC_TRANSPORT_
 #include <types.hpp>
-#include <core/rvl/os/OS.hpp>
+#include <core/rvl/OS/OS.hpp>
 #include <core/GS/GT2/GT2.hpp>
 
 

--- a/GameSource/core/rvl/KPAD.hpp
+++ b/GameSource/core/rvl/KPAD.hpp
@@ -1,7 +1,7 @@
 #ifndef _KPAD_
 #define _KPAD_
 #include <types.hpp>
-#include <core/rvl/wpad.hpp>
+#include <core/rvl/WPAD.hpp>
 #include <core/rvl/mtx/mtx.hpp>
 
 namespace KPAD { //KPAD, high-level wii remote library

--- a/GameSource/core/rvl/MEM/MEMheap.hpp
+++ b/GameSource/core/rvl/MEM/MEMheap.hpp
@@ -2,7 +2,7 @@
 #define _MEMHEAP_
 #include <types.hpp>
 #include <core/rvl/MEM/MEMlist.hpp>
-#include <core/rvl/os/OSmutex.hpp>
+#include <core/rvl/OS/OSMutex.hpp>
 namespace MEM {
 enum HeapType {
     HEAPTYPE_EXP,    //Expanded

--- a/GameSource/core/rvl/OS/OSAlarm.hpp
+++ b/GameSource/core/rvl/OS/OSAlarm.hpp
@@ -1,7 +1,7 @@
 #ifndef _OSALARM_
 #define _OSALARM_
 #include <types.hpp>
-#include <core/rvl/os/OSContext.hpp>
+#include <core/rvl/OS/OSContext.hpp>
 
 namespace OS {
 

--- a/GameSource/core/rvl/OS/OSBootInfo.hpp
+++ b/GameSource/core/rvl/OS/OSBootInfo.hpp
@@ -1,7 +1,7 @@
 #ifndef _OSBOOTINFO_
 #define _OSBOOTINFO_
 #include <types.hpp>
-#include <core/rvl/dvd/DVD.hpp>
+#include <core/rvl/dvd/dvd.hpp>
 
 
 namespace OS {

--- a/GameSource/core/rvl/OS/OSMessage.hpp
+++ b/GameSource/core/rvl/OS/OSMessage.hpp
@@ -1,7 +1,7 @@
 #ifndef _OSMESSAGE_
 #define _OSMESSAGE_
 #include <types.hpp>
-#include <core/rvl/os/OSthread.hpp>
+#include <core/rvl/OS/OSthread.hpp>
 
 namespace OS {
 typedef void* Message;

--- a/GameSource/core/rvl/OS/OSMutex.hpp
+++ b/GameSource/core/rvl/OS/OSMutex.hpp
@@ -1,7 +1,7 @@
 #ifndef _MUTEX_
 #define _MUTEX_
 #include <types.hpp>
-#include <core/rvl/os/OSthread.hpp>
+#include <core/rvl/OS/OSthread.hpp>
 
 namespace OS {
 struct Mutex { //RVL mutexes are recursive

--- a/GameSource/core/rvl/OS/OSthread.hpp
+++ b/GameSource/core/rvl/OS/OSthread.hpp
@@ -1,7 +1,7 @@
 #ifndef _OSTHREAD_
 #define _OSTHREAD_
 #include <types.hpp>
-#include <core/rvl/os/OScontext.hpp>
+#include <core/rvl/OS/OSContext.hpp>
 
 namespace OS {
 class Thread;

--- a/GameSource/core/rvl/gx/GX.hpp
+++ b/GameSource/core/rvl/gx/GX.hpp
@@ -2,9 +2,9 @@
 #define _GX_
 
 #include <types.hpp>
-#include <core/rvl/GX/GXEnum.hpp>
-#include <core/rvl/GX/GXStruct.hpp>
-#include <core/rvl/os/OSthread.hpp>
+#include <core/rvl/gx/GXEnum.hpp>
+#include <core/rvl/gx/GXStruct.hpp>
+#include <core/rvl/OS/OSthread.hpp>
 
 namespace GX {
 

--- a/GameSource/core/rvl/nwc24/NWC24Msg.hpp
+++ b/GameSource/core/rvl/nwc24/NWC24Msg.hpp
@@ -2,7 +2,7 @@
 #define _NWC24MSG_
 #include <types.hpp>
 #include <core/rvl/nwc24/NWC24Types.hpp>
-#include <core/rvl/os/OS.hpp>
+#include <core/rvl/OS/OS.hpp>
 
 namespace NWC24 { //this is C, but don't care
 

--- a/PulsarEngine/AutoTrackSelect/ChooseNextTrack.cpp
+++ b/PulsarEngine/AutoTrackSelect/ChooseNextTrack.cpp
@@ -1,4 +1,4 @@
-#include <MarioKartWii/Race/Racedata.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
 #include <MarioKartWii/Audio/RSARPlayer.hpp>
 #include <PulsarSystem.hpp>
 #include <Network/PacketExpansion.hpp>

--- a/PulsarEngine/Debug/Debug.hpp
+++ b/PulsarEngine/Debug/Debug.hpp
@@ -1,7 +1,7 @@
 #ifndef _PUL_Debug_
 #define _PUL_Debug_
 
-#include <core/rvl/os/OSError.hpp>
+#include <core/rvl/OS/OSError.hpp>
 
 namespace Pulsar {
 namespace Debug {

--- a/PulsarEngine/Debug/ExceptionHandler.cpp
+++ b/PulsarEngine/Debug/ExceptionHandler.cpp
@@ -1,11 +1,11 @@
 #include <kamek.hpp>
 #include <core/System/SystemManager.hpp>
 #include <core/rvl/base/ppc.hpp>
-#include <core/rvl/os/OSthread.hpp>
-#include <core/rvl/os/OSTitle.hpp>
-#include <core/rvl/os/OSBootInfo.hpp>
-#include <core/rvl/pad.hpp>
-#include <core/rvl/kpad.hpp>
+#include <core/rvl/OS/OSthread.hpp>
+#include <core/rvl/OS/OSTitle.hpp>
+#include <core/rvl/OS/OSBootInfo.hpp>
+#include <core/rvl/PAD.hpp>
+#include <core/rvl/KPAD.hpp>
 #include <core/egg/Exception.hpp>
 #include <Debug/Debug.hpp>
 #include <PulsarSystem.hpp>

--- a/PulsarEngine/Extensions/LECODE/Lex.cpp
+++ b/PulsarEngine/Extensions/LECODE/Lex.cpp
@@ -2,7 +2,7 @@
 #include <Extensions/LECODE/Lex.hpp>
 #include <MarioKartWii/Archive/ArchiveMgr.hpp>
 #include <MarioKartWii/UI/Ctrl/CtrlRace/CtrlRaceRankNum.hpp>
-#include <MarioKartWii/Race/Raceinfo/Raceinfo.hpp>
+#include <MarioKartWii/Race/RaceInfo/RaceInfo.hpp>
 #include <MarioKartWii/Item/Obj/ItemObj.hpp>
 #include <PulsarSystem.hpp>
 #include <Extensions/LECODE/LECODEMgr.hpp>

--- a/PulsarEngine/Gamemodes/KO/KOHost.cpp
+++ b/PulsarEngine/Gamemodes/KO/KOHost.cpp
@@ -9,7 +9,7 @@
 #include <MarioKartWii/UI/Page/Other/WifiVSResults.hpp>
 #include <MarioKartWii/UI/Ctrl/CtrlRace/CtrlRaceRankNum.hpp>
 #include <MarioKartWii/UI/Ctrl/CtrlRace/CtrlRaceItemWindow.hpp>
-#include <MarioKartWii/Race/Raceinfo/Raceinfo.hpp>
+#include <MarioKartWii/Race/RaceInfo/RaceInfo.hpp>
 #include <MarioKartWii/Kart/KartManager.hpp>
 #include <Network/PacketExpansion.hpp>
 #include <Gamemodes/KO/KOMgr.hpp>

--- a/PulsarEngine/Gamemodes/KO/KOMgr.cpp
+++ b/PulsarEngine/Gamemodes/KO/KOMgr.cpp
@@ -1,4 +1,4 @@
-#include <MarioKartWii/Race/Raceinfo/Raceinfo.hpp>
+#include <MarioKartWii/Race/RaceInfo/RaceInfo.hpp>
 #include <MarioKartWii/UI/Page/Page.hpp>
 #include <MarioKartWii/Input/InputManager.hpp>
 #include <GameModes/KO/KOMgr.hpp>

--- a/PulsarEngine/Gamemodes/KO/KOMisc.cpp
+++ b/PulsarEngine/Gamemodes/KO/KOMisc.cpp
@@ -9,7 +9,7 @@
 #include <MarioKartWii/UI/Page/Other/WifiVSResults.hpp>
 #include <MarioKartWii/UI/Ctrl/CtrlRace/CtrlRaceRankNum.hpp>
 #include <MarioKartWii/UI/Ctrl/CtrlRace/CtrlRaceItemWindow.hpp>
-#include <MarioKartWii/Race/Raceinfo/Raceinfo.hpp>
+#include <MarioKartWii/Race/RaceInfo/RaceInfo.hpp>
 #include <MarioKartWii/Kart/KartManager.hpp>
 #include <Network/PacketExpansion.hpp>
 #include <Gamemodes/KO/KOMgr.hpp>

--- a/PulsarEngine/Gamemodes/OnlineTT/OnlineTT.cpp
+++ b/PulsarEngine/Gamemodes/OnlineTT/OnlineTT.cpp
@@ -1,6 +1,6 @@
 #include <kamek.hpp>
-#include <MarioKartWii/Race/Racedata.hpp>
-#include <MarioKartWii/Race/Raceinfo/Raceinfo.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
+#include <MarioKartWii/Race/RaceInfo/RaceInfo.hpp>
 #include <MarioKartWii/Kart/KartManager.hpp>
 #include <MarioKartWii/Objects/ObjectsMgr.hpp>
 #include <MarioKartWii/KMP/KMPManager.hpp>

--- a/PulsarEngine/Ghost/UI/EnhancedReplay.cpp
+++ b/PulsarEngine/Ghost/UI/EnhancedReplay.cpp
@@ -2,7 +2,7 @@
 #include <MarioKartWii/UI/Page/RaceHUD/RaceHUD.hpp>
 #include <MarioKartWii/UI/Page/RaceMenu/GhostReplayPause.hpp>
 #include <MarioKartWii/Kart/KartManager.hpp>
-#include <MarioKartWii/Race/Raceinfo/Raceinfo.hpp>
+#include <MarioKartWii/Race/RaceInfo/RaceInfo.hpp>
 #include <UI/UI.hpp>
 
 

--- a/PulsarEngine/Ghost/UI/ExpGhostSelect.cpp
+++ b/PulsarEngine/Ghost/UI/ExpGhostSelect.cpp
@@ -1,5 +1,5 @@
-#include <MarioKartWii/Race/Racedata.hpp>
-#include <MarioKartWii/Race/Raceinfo/Raceinfo.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
+#include <MarioKartWii/Race/RaceInfo/RaceInfo.hpp>
 #include <MarioKartWii/Input/InputManager.hpp>
 #include <MarioKartWii/UI/Page/Menu/CourseSelect.hpp>
 #include <Ghost/UI/ExpGhostSelect.hpp>

--- a/PulsarEngine/Network/MiscNetwork.cpp
+++ b/PulsarEngine/Network/MiscNetwork.cpp
@@ -2,7 +2,7 @@
 #include <MarioKartWii/RKNet/RKNetController.hpp>
 #include <MarioKartWii/RKNet/Select.hpp>
 #include <MarioKartWii/System/random.hpp>
-#include <MarioKartWii/Race/Racedata.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
 #include <MarioKartWii/UI/Section/SectionMgr.hpp>
 #include <Settings/Settings.hpp>
 #include <Network/PulSELECT.hpp>

--- a/PulsarEngine/Race/BinLoader.cpp
+++ b/PulsarEngine/Race/BinLoader.cpp
@@ -1,7 +1,7 @@
 #include <RetroRewind.hpp>
 #include <MarioKartWii/Archive/ArchiveMgr.hpp>
 #include <MarioKartWii/RKNet/RKNetController.hpp>
-#include <core/rvl/os/OS.hpp>
+#include <core/rvl/OS/OS.hpp>
 #ifdef PROD
 #include <Security/BinVerifier.hpp>
 #endif

--- a/PulsarEngine/Race/BinLoader.hpp
+++ b/PulsarEngine/Race/BinLoader.hpp
@@ -4,7 +4,7 @@
 #include <kamek.hpp>
 #include <MarioKartWii/Archive/ArchiveMgr.hpp>
 #include <Network/SHA256.hpp>
-#include <core/rvl/os/OS.hpp>
+#include <core/rvl/OS/OS.hpp>
 
 namespace RetroRewind {
 

--- a/PulsarEngine/Race/COOB.cpp
+++ b/PulsarEngine/Race/COOB.cpp
@@ -1,6 +1,6 @@
 #include <kamek.hpp>
 #include <MarioKartWii/KMP/KMPManager.hpp>
-#include <MarioKartWii/Race/Raceinfo/Raceinfo.hpp>
+#include <MarioKartWii/Race/RaceInfo/RaceInfo.hpp>
 #include <MarioKartWii/Kart/KartPointers.hpp>
 
 namespace Pulsar {

--- a/PulsarEngine/Race/LapSpeedModifier.cpp
+++ b/PulsarEngine/Race/LapSpeedModifier.cpp
@@ -1,5 +1,5 @@
 #include <kamek.hpp>
-#include <MarioKartWii/Race/Raceinfo/Raceinfo.hpp>
+#include <MarioKartWii/Race/RaceInfo/RaceInfo.hpp>
 #include <MarioKartWii/3D/Model/ModelDirector.hpp>
 #include <MarioKartWii/Kart/KartValues.hpp>
 #include <MarioKartWii/Kart/KartMovement.hpp>

--- a/PulsarEngine/Race/Spectating.cpp
+++ b/PulsarEngine/Race/Spectating.cpp
@@ -2,7 +2,7 @@
 #include <MarioKartWii/3D/Camera/CameraMgr.hpp>
 #include <MarioKartWii/3D/Camera/RaceCamera.hpp>
 #include <MarioKartWii/UI/Section/SectionMgr.hpp>
-#include <MarioKartWii/Race/Raceinfo/Raceinfo.hpp>
+#include <MarioKartWii/Race/RaceInfo/RaceInfo.hpp>
 #include <Gamemodes/KO/KOMgr.hpp>
 
 namespace Pulsar {

--- a/PulsarEngine/RetroRewind.cpp
+++ b/PulsarEngine/RetroRewind.cpp
@@ -1,4 +1,4 @@
-#include <MarioKartWii/Race/Racedata.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
 #include <SlotExpansion/CupsConfig.hpp>
 #include <Settings/UI/SettingsPanel.hpp>
 #include <Settings/Settings.hpp>

--- a/PulsarEngine/SlotExpansion/CupsConfig.hpp
+++ b/PulsarEngine/SlotExpansion/CupsConfig.hpp
@@ -1,7 +1,7 @@
 #ifndef _CUPSDEF_
 #define _CUPSDEF_
 #include <kamek.hpp>
-#include <MarioKartWii/Race/Racedata.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
 #include <MarioKartWii/System/Identifiers.hpp>
 #include <MarioKartWii/System/Random.hpp>
 #include <Config.hpp>

--- a/PulsarEngine/SlotExpansion/SlotProperties.cpp
+++ b/PulsarEngine/SlotExpansion/SlotProperties.cpp
@@ -2,7 +2,7 @@
 #include <kamek.hpp>
 #include <MarioKartWii/Archive/ArchiveMgr.hpp>
 #include <MarioKartWii/Effect/EffectMgr.hpp>
-#include <MarioKartWii/Race/Racedata.hpp>
+#include <MarioKartWii/Race/RaceData.hpp>
 #include <MarioKartWii/3D/Model/MatModelDirector.hpp>
 
 namespace Pulsar {

--- a/PulsarEngine/Sound/BRSTMSpeedUp.cpp
+++ b/PulsarEngine/Sound/BRSTMSpeedUp.cpp
@@ -1,5 +1,5 @@
 #include <kamek.hpp>
-#include <MarioKartWii/Race/Raceinfo/Raceinfo.hpp>
+#include <MarioKartWii/Race/RaceInfo/RaceInfo.hpp>
 #include <MarioKartWii/Audio/RSARPlayer.hpp>
 #include <MarioKartWii/Audio/RaceMgr.hpp>
 #include <MarioKartWii/Audio/Actors/KartActor.hpp>

--- a/PulsarEngine/UI/BootIntoSection.cpp
+++ b/PulsarEngine/UI/BootIntoSection.cpp
@@ -1,6 +1,6 @@
 #include <kamek.hpp>
-#include <core/rvl/pad.hpp>
-#include <core/rvl/kpad.hpp>
+#include <core/rvl/PAD.hpp>
+#include <core/rvl/KPAD.hpp>
 #include <core/System/SystemManager.hpp>
 #include <MarioKartWii/Input/InputManager.hpp>
 #include <MarioKartWii/UI/Section/SectionMgr.hpp>

--- a/PulsarEngine/UI/ExtendedTeamSelect/ExtendedTeamManager.hpp
+++ b/PulsarEngine/UI/ExtendedTeamSelect/ExtendedTeamManager.hpp
@@ -3,7 +3,7 @@
 
 #include <UI/UI.hpp>
 #include <PulsarSystem.hpp>
-#include <MarioKartwii/UI/Ctrl/CountDown.hpp>
+#include <MarioKartWii/UI/Ctrl/CountDown.hpp>
 #include <MarioKartWii/RKNet/RKNetController.hpp>
 #include <MarioKartWii/RKNet/ROOM.hpp>
 


### PR DESCRIPTION
Linux enforces case-sensitivity of path-names whereas Windows typically does not. Some IDEs on Linux will complain about `#include` directives having incorrect casing, so this fixes a load of them. This is likely non-exhaustive but this was a lot of what I found.