### PR TITLE
Add `SDIO` class for the new channel

### DIFF
--- a/KamekInclude/types.hpp
+++ b/KamekInclude/types.hpp
@@ -60,6 +60,12 @@ struct RGBA16 {
     u16 red, green, blue, alpha;
 };
 
+// Helper struct used by `offset_assert` because the `offsetof` macro can't be used in a `static_assert(...)`
+template<typename T, T lhs, T rhs>
+struct _AssertEq {
+    static_assert(lhs == rhs, "Assertion failed");
+};
+
 #define offsetof(st, m) \
     ((const u32)&(((const st *)0)->m))
 #endif
@@ -74,6 +80,7 @@ struct RGBA16 {
 #define __isync(...)
 #define size_assert(type, num) static_assert(sizeof(type)==(num),"type")
 #define static_assert(...)
+#define offset_assert(type, member, off)
 #else
 #define asmFunc asm void
 #define asmVolatile asm volatile
@@ -82,6 +89,7 @@ struct RGBA16 {
 #define ASM(...) __VA_ARGS__
 #define override
 #define size_assert(type, num) static_assert(sizeof(type) ==num,#type)
+#define offset_assert(type, member, off) _AssertEq<int, offsetof(type, member), off>()
 #endif
 
 

--- a/PulsarEngine/IO/IO.cpp
+++ b/PulsarEngine/IO/IO.cpp
@@ -1,8 +1,10 @@
 #include <kamek.hpp>
 #include <PulsarSystem.hpp>
 #include <IO/IO.hpp>
-#include <IO/NANDIO.hpp>
 #include <IO/RiivoIO.hpp>
+#include <IO/NANDIO.hpp>
+#include <IO/SDIO.hpp>
+#include <core/rvl/OS/OS.hpp>
 
 namespace Pulsar {
 
@@ -10,84 +12,28 @@ IO* IO::sInstance = nullptr;
 
 IO* IO::CreateInstance(IOType type, EGG::Heap* heap, EGG::TaskThread* const taskThread) {
     IO* io;
-    if(type != IOType_RIIVO) io = new (heap) NANDIO(type, heap, taskThread);
-    else io = new (heap) RiivoIO(type, heap, taskThread);
+
+    switch (type) {
+        case IOType_RIIVO:
+            io = new (heap) RiivoIO(type, heap, taskThread);
+        break;
+        case IOType_ISO:
+        case IOType_DOLPHIN:
+            io = new (heap) NANDIO(type, heap, taskThread);
+            break;
+        case IOType_SD:
+            io = new (heap) SDIO(type, heap, taskThread);
+            break;
+    }
+    
     IO::sInstance = io;
     return io;
 }
-
-//FILE
-#pragma suppress_warnings on
-bool IO::OpenFileDirectly(const char* path, u32 mode) {
-    if(type == IOType_ISO) return -1;
-    this->fd = IO::OpenFix(path, static_cast<IOS::Mode>(mode));
-    return this->fd >= 0;
-}
-
-#pragma suppress_warnings reset
-
-s32 IO::Read(u32 size, void* bufferIn) {
-    if(this->fd < 0) return 0;
-    return IOS::Read(this->fd, bufferIn, size);
-}
-
-s32 IO::Write(u32 length, const void* buffer) {
-    if(this->fd < 0) return -1;
-    return IOS::Write(this->fd, buffer, length);
-}
-
-s32 IO::Overwrite(u32 length, const void* buffer) {
-    if(this->fd < 0) return -1;
-    IOS::Seek(this->fd, 0, IOS::SEEK_START);
-    return IOS::Write(this->fd, buffer, length);
-}
-
-void IO::Close() {
-    if(this->fd >= 0) IOS::Close(this->fd);
-    this->fd = -1;
-    this->fileSize = -1;
-}
-
-s32 IO::GetFileSize() {
-    if(this->fileSize < 0 && this->fd >= 0) {
-        s32 size = IOS::Seek(this->fd, 0, IOS::SEEK_END);
-        if(size >= 0) {
-            this->fileSize = size;
-            IOS::Seek(this->fd, 0, IOS::SEEK_START);
-        }
-    }
-    return this->fileSize;
-}
-
-
-//FOLDER
-/*
-void IO::RequestCreateFolder(const char* path) {
-    if(!this->FolderExists(path)) {
-        CreateRequest* request = &this->requests[0];
-        if(!request->isFree) request = &this->requests[1];
-        if(request->isFree) {
-            request->isFree = false;
-            strncpy(request->path, path, IOS::ipcMaxPath);
-            System::sInstance->taskThread->Request(&IO::CreateFolderAsync, request, 0);
-        }
-    }
-}
-*/
 
 void IO::CreateFolderAsync(CreateRequest* request) {
     IO* io = IO::sInstance;
     io->CreateFolder(request->path);
     request->isFree = true;
-}
-
-void IO::CloseFolder() {
-    isBusy = false;
-    this->Close();
-    if(this->fileNames != nullptr) delete[](this->fileNames);
-    this->fileNames = nullptr;
-    this->folderName[0] = '\0';
-    this->fileCount = 0;
 }
 
 s32 IO::ReadFolderFileFromPath(void* bufferIn, const char* path, u32 maxLength) {

--- a/PulsarEngine/IO/IO.hpp
+++ b/PulsarEngine/IO/IO.hpp
@@ -14,7 +14,8 @@ typedef char FileName[255];
 enum IOType {
     IOType_RIIVO = 0,
     IOType_ISO = 1,
-    IOType_DOLPHIN = 2
+    IOType_DOLPHIN = 2,
+    IOType_SD = 3
 };
 
 enum FileMode {
@@ -40,7 +41,6 @@ public:
 
     virtual bool OpenFile(const char* path, u32 mode) = 0;
     virtual bool CreateAndOpen(const char* path, u32 mode) = 0;
-    virtual void GetCorrectPath(char* realPath, const char* path) const = 0;
     virtual bool RenameFile(const char* oldPath, const char* newPath) const = 0;
 
     virtual bool FolderExists(const char* path) const = 0;
@@ -51,19 +51,18 @@ public:
     static IO* CreateInstance(IOType type, EGG::Heap* heap, EGG::TaskThread* const taskThread);
     template<typename T>
     T* Alloc(u32 size) const { return EGG::Heap::alloc<T>(nw4r::ut::RoundUp(size, 0x20), 0x20, this->heap); }
-    s32 GetFileSize();
+    virtual s32 GetFileSize() = 0;
 
-    bool OpenFileDirectly(const char* path, u32 mode);
-    s32 Read(u32 size, void* bufferIn);
-    void Seek(u32 offset) { IOS::Seek(this->fd, offset, IOS::SEEK_START); }
-    s32 Write(u32 length, const void* buffer);
-    s32 Overwrite(u32 length, const void* buffer);
-    void Close();
+    virtual s32 Read(u32 size, void* bufferIn) = 0;
+    virtual void Seek(u32 offset) = 0;
+    virtual s32 Write(u32 length, const void* buffer) = 0;
+    virtual s32 Overwrite(u32 length, const void* buffer) = 0;
+    virtual void Close() = 0;
 
     const int GetFileCount() const { return this->fileCount; }
     const char* GetFolderName() const { return this->folderName; };
     //void RequestCreateFolder(const char* path); //up to 2 simultaneous
-    void CloseFolder();
+    virtual void CloseFolder() = 0;
     void PrintFullFilePath(char* path, const char* fileName) const {
         snprintf(path, IOS::ipcMaxPath, "%s/%s", &this->folderName, fileName);
     }
@@ -90,8 +89,7 @@ public:
     const IOType type;
 
 protected:
-    IO(IOType type, EGG::Heap* heap, EGG::TaskThread* taskThread) : type(type), fd(-1), heap(heap), taskThread(taskThread) {
-        filePath[0] = '\0';
+    IO(IOType type, EGG::Heap* heap, EGG::TaskThread* taskThread) : type(type), heap(heap), taskThread(taskThread) {
         folderName[0] = '\0';
     }
     void Bind(const char* path) { strncpy(this->folderName, path, IOS::ipcMaxPath); }
@@ -99,10 +97,6 @@ protected:
 
     EGG::Heap* heap;
     EGG::TaskThread* const taskThread;
-    bool isBusy;
-    s32 fd;
-    s32 fileSize;
-    char filePath[IOS::ipcMaxPath];
     char folderName[IOS::ipcMaxPath];
     u32 fileCount;
     IOS::IPCPath* fileNames;

--- a/PulsarEngine/IO/IOSIO.cpp
+++ b/PulsarEngine/IO/IOSIO.cpp
@@ -1,0 +1,63 @@
+#include <IO/IOSIO.hpp>
+
+namespace Pulsar {
+
+//FILE
+#pragma suppress_warnings on
+
+bool IOSIO::OpenFileDirectly(const char* path, u32 mode) {
+    if(type == IOType_ISO) return -1;
+    this->fd = IO::OpenFix(path, static_cast<IOS::Mode>(mode));
+    return this->fd >= 0;
+}
+
+#pragma suppress_warnings reset
+
+s32 IOSIO::Read(u32 size, void* bufferIn) {
+    if(this->fd < 0) return 0;
+    return IOS::Read(this->fd, bufferIn, size);
+}
+
+s32 IOSIO::Write(u32 length, const void* buffer) {
+    if(this->fd < 0) return -1;
+    return IOS::Write(this->fd, buffer, length);
+}
+
+s32 IOSIO::Overwrite(u32 length, const void* buffer) {
+    if(this->fd < 0) return -1;
+    IOS::Seek(this->fd, 0, IOS::SEEK_START);
+    return IOS::Write(this->fd, buffer, length);
+}
+
+void IOSIO::Close() {
+    if(this->fd >= 0) IOS::Close(this->fd);
+    this->fd = -1;
+    this->fileSize = -1;
+}
+
+s32 IOSIO::GetFileSize() {
+    if(this->fileSize < 0 && this->fd >= 0) {
+        s32 size = IOS::Seek(this->fd, 0, IOS::SEEK_END);
+        if(size >= 0) {
+            this->fileSize = size;
+            IOS::Seek(this->fd, 0, IOS::SEEK_START);
+        }
+    }
+    return this->fileSize;
+}
+
+void IOSIO::Seek(u32 offset) {
+    IOS::Seek(this->fd, offset, IOS::SEEK_START);
+}
+
+//FOLDER
+void IOSIO::CloseFolder() {
+    isBusy = false;
+    this->Close();
+    if(this->fileNames != nullptr) delete[](this->fileNames);
+    this->fileNames = nullptr;
+    this->folderName[0] = '\0';
+    this->fileCount = 0;
+}
+
+}//namespace Pulsar

--- a/PulsarEngine/IO/IOSIO.hpp
+++ b/PulsarEngine/IO/IOSIO.hpp
@@ -1,0 +1,35 @@
+#ifndef _IOSIO_
+#define _IOSIO_
+
+#include <IO/IO.hpp>
+#include <kamek.hpp>
+
+namespace Pulsar {
+
+class IOSIO : public IO {
+    public:
+        IOSIO(IOType type, EGG::Heap* heap, EGG::TaskThread* taskThread) : fd(-1), IO(type, heap, taskThread) {
+            filePath[0] = '\0';
+        }
+
+        s32 GetFileSize();
+
+        void CloseFolder() override;
+        
+        bool OpenFileDirectly(const char* path, u32 mode);
+        s32 Read(u32 size, void* bufferIn) override;
+        void Seek(u32 offset) override;
+        s32 Write(u32 length, const void* buffer) override;
+        s32 Overwrite(u32 length, const void* buffer) override;
+        void Close() override;
+
+    protected:
+        bool isBusy;
+        s32 fd;
+        s32 fileSize;
+        char filePath[IOS::ipcMaxPath];
+};
+
+}//namespace Pulsar
+
+#endif

--- a/PulsarEngine/IO/NANDIO.hpp
+++ b/PulsarEngine/IO/NANDIO.hpp
@@ -2,20 +2,20 @@
 #define _NANDIO_
 
 #include <kamek.hpp>
-#include <IO/IO.hpp>
+#include <IO/IOSIO.hpp>
 
 namespace Pulsar {
 
 typedef char FileName[255];
 
 
-class NANDIO : public IO {
+class NANDIO : public IOSIO {
 
-    NANDIO(IOType type, EGG::Heap* heap, EGG::TaskThread* taskThread) : IO(type, heap, taskThread) {}
+    NANDIO(IOType type, EGG::Heap* heap, EGG::TaskThread* taskThread) : IOSIO(type, heap, taskThread) {}
 
     bool OpenFile(const char* path, u32 mode) override;
     bool CreateAndOpen(const char* path, u32 mode) override;
-    void GetCorrectPath(char* realPath, const char* path) const override;
+    void GetCorrectPath(char* realPath, const char* path) const;
     bool RenameFile(const char* oldPath, const char* newPath) const override;
 
     bool FolderExists(const char* path) const override;

--- a/PulsarEngine/IO/RiivoIO.cpp
+++ b/PulsarEngine/IO/RiivoIO.cpp
@@ -7,7 +7,7 @@ namespace Pulsar {
 bool RiivoIO::OpenFile(const char* path, u32 mode) {
     RiivoMode riivoMode = this->GetRiivoMode(mode);
     this->GetCorrectPath(this->filePath, path);
-    return IO::OpenFileDirectly(this->filePath, riivoMode);
+    return IOSIO::OpenFileDirectly(this->filePath, riivoMode);
 }
 
 bool RiivoIO::CreateAndOpen(const char* path, u32 mode) {

--- a/PulsarEngine/IO/RiivoIO.hpp
+++ b/PulsarEngine/IO/RiivoIO.hpp
@@ -2,7 +2,7 @@
 #define _RIIVOIO_
 
 #include <kamek.hpp>
-#include <IO/IO.hpp>
+#include <IO/IOSIO.hpp>
 namespace Pulsar {
 
 const int riivoMaxPath = 1024;
@@ -99,13 +99,13 @@ enum RiivoError {
 };
 
 
-class RiivoIO : public IO {
+class RiivoIO : public IOSIO {
 
-    RiivoIO(IOType type, EGG::Heap* heap, EGG::TaskThread* taskThread) : IO(type, heap, taskThread) {}
+    RiivoIO(IOType type, EGG::Heap* heap, EGG::TaskThread* taskThread) : IOSIO(type, heap, taskThread) {}
 
     bool OpenFile(const char* path, u32 mode) override;
     bool CreateAndOpen(const char* path, u32 mode) override;
-    void GetCorrectPath(char* realPath, const char* path) const override;
+    void GetCorrectPath(char* realPath, const char* path) const;
     bool RenameFile(const char* oldPath, const char* newPath) const override { return false; }
 
     bool FolderExists(const char* path) const override;

--- a/PulsarEngine/IO/SDIO.cpp
+++ b/PulsarEngine/IO/SDIO.cpp
@@ -1,0 +1,129 @@
+#include <IO/SDIO.hpp>
+#include <core/rvl/ipc/ipc.hpp>
+
+namespace Pulsar {
+
+#define O_RDONLY                0
+#define O_WRONLY                1
+#define O_RDWR                  2
+#define O_APPEND                0x0008
+#define O_CREAT                 0x0200
+#define S_IFDIR                 0040000 /* st_mode is directory */
+#define S_IFMT                  0170000 /* st_mode filetype mask */
+#define SD_MAX_FILENAME_LENGTH  768     /* filename length limit imposed by sd driver */
+#define EEXIST                  17      /* errno code for 'File already exists' */
+
+struct sd_vtable {
+    int (*open)(void* file_struct, const char* path, int flags);
+    int (*close)(int fd);
+    int (*read)(int fd, void* ptr, size_t len);
+    int (*write)(int fd, const void* ptr, size_t len);
+    int (*rename)(const char* oldName, const char* newName);
+    int (*stat)(const char* path, void* statbuf);
+    int (*mkdir)(const char* path);
+    int (*diropen)(dir_struct* dir, const char* path);
+    int (*dirnext)(dir_struct* dir, char* outFilename, void* filestatbuf);
+    int (*dirclose)(dir_struct* dir);
+    int (*seek)(int fd, int pos, int direction);
+    int (*errno)();
+};
+
+const sd_vtable* __sd_vtable = reinterpret_cast<sd_vtable*>(0x81782e00);
+
+u32 ios_mode_to_sd_mode(u32 mode) {
+    switch (mode) {
+        case IOS::MODE_WRITE: return O_WRONLY;
+        case IOS::MODE_READ_WRITE: return O_RDWR;
+        case IOS::MODE_NONE:
+        case IOS::MODE_READ:
+        default: return O_RDONLY;
+    }
+}
+
+bool SDIO::OpenFile(const char* path, u32 mode) {
+    return __sd_vtable->open(&fileData, path, ios_mode_to_sd_mode(mode)) != -1;
+}
+
+bool SDIO::CreateAndOpen(const char* path, u32 mode) {
+    return __sd_vtable->open(&fileData, path, ios_mode_to_sd_mode(mode) | O_CREAT) != -1;
+}
+
+bool SDIO::RenameFile(const char* oldPath, const char* newPath) const {
+    return __sd_vtable->rename(oldPath, newPath) == 0;
+}
+
+bool SDIO::FolderExists(const char* path) const {
+    stat stat;
+    if (__sd_vtable->stat(path, &stat) != 0) {
+        return false;
+    }
+    return (stat.st_mode & S_IFMT) == S_IFDIR;
+}
+
+bool SDIO::CreateFolder(const char* path) {
+    this->Bind(path);
+    int res = __sd_vtable->mkdir(path);
+    return res == 0 || __sd_vtable->errno() == EEXIST;
+}
+
+void SDIO::ReadFolder(const char* path) {
+    __sd_vtable->diropen(&dirData, path);
+    strncpy(folderName, path, IOS::ipcMaxPath);
+    char filename[SD_MAX_FILENAME_LENGTH];
+    
+    fileNames = new (heap) IOS::IPCPath[maxFileCount];
+    stat stat;
+    while (__sd_vtable->dirnext(&dirData, filename, &stat) == 0) {
+        if (fileCount >= maxFileCount) {
+            break;
+        }
+        if ((stat.st_mode & S_IFMT) == S_IFDIR) {
+            // Skip directories
+            continue;
+        }
+        strncpy(fileNames[fileCount], filename, IOS::ipcMaxFileName);
+        fileCount++;
+    }
+}
+
+void SDIO::CloseFolder() {
+    if (fileNames) {
+        delete[](fileNames);
+        __sd_vtable->dirclose(&dirData);
+    }
+    fileNames = nullptr;
+    folderName[0] = '\0';
+    fileCount = 0;
+}
+
+s32 SDIO::GetFileSize() {
+    return fileData.filesize;
+}
+
+int SDIO::fd() const {
+    // The fd is always simply the address of the FILE_STRUCT.
+    return reinterpret_cast<int>(&fileData);
+}
+
+s32 SDIO::Read(u32 size, void* bufferIn) {
+    return __sd_vtable->read(fd(), bufferIn, size);
+}
+
+void SDIO::Seek(u32 offset) {
+    __sd_vtable->seek(fd(), offset, 0);
+}
+
+s32 SDIO::Write(u32 length, const void* buffer) {
+    return __sd_vtable->write(fd(), buffer, length);
+}
+
+s32 SDIO::Overwrite(u32 length, const void* buffer) {
+    Seek(0);
+    return __sd_vtable->write(fd(), buffer, length);
+}
+
+void SDIO::Close() {
+    __sd_vtable->close(fd());
+}
+
+}//namespace Pulsar

--- a/PulsarEngine/IO/SDIO.hpp
+++ b/PulsarEngine/IO/SDIO.hpp
@@ -1,0 +1,62 @@
+#ifndef _SDIO_
+#define _SDIO_
+
+#include <IO/IO.hpp>
+
+namespace Pulsar {
+    
+    struct file_struct {
+        u32 filesize;
+        u8 _unused[76];
+    };
+
+    struct dir_struct {
+        u8 _unused[836];
+    };
+
+    struct stat
+    {
+        u8 _unused[8];
+        u32 st_mode;
+        u8 _unused2[76];
+    };
+    
+    // Should be in sync with the assertions in runtime-ext
+    size_assert(file_struct, 80);
+    size_assert(dir_struct, 836);
+    size_assert(stat, 88);
+
+    class SDIO : public IO {
+        public:
+            SDIO(IOType type, EGG::Heap* heap, EGG::TaskThread* taskThread) : IO(type, heap, taskThread) {
+                offset_assert(stat, st_mode, 8);
+                offset_assert(file_struct, filesize, 0);
+                fileNames = nullptr;
+            }
+
+            bool OpenFile(const char* path, u32 mode) override;
+            bool CreateAndOpen(const char* path, u32 mode) override;
+            bool RenameFile(const char* oldPath, const char* newPath) const override;
+        
+            bool FolderExists(const char* path) const override;
+            bool CreateFolder(const char* path) override;
+            void ReadFolder(const char* path) override;
+            void CloseFolder() override;
+
+            s32 GetFileSize() override;
+
+            s32 Read(u32 size, void* bufferIn) override;
+            void Seek(u32 offset) override;
+            s32 Write(u32 length, const void* buffer) override;
+            s32 Overwrite(u32 length, const void* buffer) override;
+            void Close() override;
+
+        private:
+            file_struct fileData;
+            dir_struct dirData;
+
+            int fd() const;
+    };
+}//namespace Pulsar
+
+#endif

--- a/PulsarEngine/PulsarSystem.cpp
+++ b/PulsarEngine/PulsarSystem.cpp
@@ -45,6 +45,11 @@ System::System() :
     koMgr(nullptr) {
 }
 
+bool IsNewChannel() {
+    // Signature written by the new launcher.
+    return *reinterpret_cast<u32*>(0x93400100) == 0xDEADBEEF;
+}
+
 void System::Init(const ConfigFile& conf) {
     IOType type = IOType_ISO;
     s32 ret = IO::OpenFix("file", IOS::MODE_NONE);
@@ -52,6 +57,9 @@ void System::Init(const ConfigFile& conf) {
     if(ret >= 0) {
         type = IOType_RIIVO;
         IOS::Close(ret);
+    }
+    else if (IsNewChannel()) {
+        type = IOType_SD;
     }
     else {
         ret = IO::OpenFix("/dev/dolphin", IOS::MODE_NONE);


### PR DESCRIPTION
The main change here is a new `IO` class (`SDIO`) that's used for reading/writing SD card files (for TT ghosts), used only if Pulsar was launched through the new channel (detected by a special "signature" at a known address that's set only by the new channel, so the old channel/setup is unaffected by this and continues to use the existing classes).

`SDIO` uses the same SD functions that the channel's hooked DVD functions also use, and it's needed because the current `RiivoIO` class works by doing Riivo specific ioctls, which is not compatible with the new channel as we don't use Riivolution.

(Another option would be patching the `IOS_*` function in a similar vein as the DVD functions and detect the Riivo-specific ioctls and reroute the calls to the SD functions on the loader's side, but since we have to write some code either way, this seems like the less hacky solution)

----

This did need some refactoring of the other `IO` classes:

- A bunch of methods like `Read()`, `Seek()`, `Write()` etc. are now `virtual` methods so that `SDIO` can have its own implementations. (Previously this wasn't needed because they were just implemented in the base class doing IOS calls for both `NANDIO` and `RiivoIO`)

- A lot of class members that were in the base `IO` class made some sense when there was just `RiivoIO` and `NANDIO` because it all happened through `IOS`, but don't really make much sense anymore for `SDIO`. So this adds a middle `IOSIO` class that contains IOS-specific members that were previously shared between `RiivoIO` and `NANDIO`, but not `SDIO`.

<details>
<summary>So here's the new `IO` class hierarchy:</summary>

```mermaid
graph TD;
    RiivoIO-->IOSIO;
    NANDIO-->IOSIO;
    IOSIO-->IO;
    SDIO-->IO;
```
</details>